### PR TITLE
[castai-cluster-controller] NOJIRA: add podantiaffinity to cluster-controller template

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
+        with: 
+          config: kind.yaml
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-cluster-controller
 description: CAST AI cluster controller deployment chart.
 type: application
-version: 0.23.0
+version: 0.24.0
 appVersion: "v0.17.0"

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -42,6 +42,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       affinity:
+        podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                      - castai-cluster-controller
+                topologyKey: kubernetes.io/hostname
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
                     - key: app.kubernetes.io/name
                       operator: In
                       values:
-                      - castai-cluster-controller
+                      - {{ include "castai-agent.name" . }} 
                 topologyKey: kubernetes.io/hostname
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/kind.yaml
+++ b/kind.yaml
@@ -1,0 +1,16 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# One control plane node and three "workers".
+#
+# While these will not add more real compute capacity and
+# have limited isolation, this can be useful for testing
+# rolling updates etc.
+#
+# The API-server and other control plane components will be
+# on the control-plane node.
+#
+# You probably don't need this unless you are testing Kubernetes itself.
+nodes:
+- role: control-plane
+- role: worker
+- role: worker


### PR DESCRIPTION
Currently the cluster-controller pods can get scheduled on the same node which can cause FAILED mode if the node goes offline and the pods can't land somewhere else. In order to reduce the fragility of cluster-controller I have added a podAntiAffinity rule to force them onto separate nodes. 