### PR TITLE
[castai-agent] Add automountServiceAccountToken=true.

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.23.0
+version: 0.23.1
 appVersion: "v0.27.0"

--- a/charts/castai-agent/templates/deployment.yaml
+++ b/charts/castai-agent/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       priorityClassName: {{ .Values.priorityClass.name }}
       {{- end }}
       serviceAccountName: castai-agent
+      automountServiceAccountToken: true
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Set automountServiceAccountToken=true for autoscaler POD. Default is expected to be true, but there were cases on some clusters that service account token was not mounted.