### PR TITLE
[castai-cluster-controller] add apiKeySecretRef option

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-cluster-controller
 description: CAST AI cluster controller deployment chart.
 type: application
-version: 0.29.0
+version: 0.30.0
 appVersion: "v0.19.0"

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
           {{- end }}
           envFrom:
             - secretRef:
-                {{- if or (.Values.apiKey ) (.Values.castai.apiKey) }}
+                {{- if or .Values.apiKey .Values.castai.apiKey }}
                   {{- if ne .Values.castai.apiKeySecretRef "" }}
                   {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
                   {{- end }}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -87,7 +87,14 @@ spec:
           {{- end }}
           envFrom:
             - secretRef:
+                {{- if or (.Values.apiKey ) (.Values.castai.apiKey) }}
+                  {{- if ne .Values.castai.apiKeySecretRef "" }}
+                  {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
+                  {{- end }}
                 name: castai-cluster-controller
+                {{- else }}
+                name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.castai.apiKeySecretRef }}
+                {{- end }}
             - configMapRef:
                 name: castai-cluster-controller
           {{- with .Values.resources }}

--- a/charts/castai-cluster-controller/templates/secret.yaml
+++ b/charts/castai-cluster-controller/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- if or .Values.apiKey .Values.castai.apiKey }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +13,4 @@ data:
   {{- else }}
   API_KEY: {{ required "castai.apiKey must be provided" .Values.castai.apiKey | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -29,6 +29,10 @@ castai:
   # Token to be used for authorizing agent access to the CASTAI API
   apiKey: ""
 
+  # Name of secret with Token to be used for authorizing agent access to the API
+  # apiKey and apiKeySecretRef are mutually exclusive
+  apiKeySecretRef: ""
+
   # CASTAI public api url.
   apiURL: "https://api.cast.ai"
 

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -31,6 +31,7 @@ castai:
 
   # Name of secret with Token to be used for authorizing agent access to the API
   # apiKey and apiKeySecretRef are mutually exclusive
+  # The referenced secret must provide the token in .data["API_KEY"]
   apiKeySecretRef: ""
 
   # CASTAI public api url.


### PR DESCRIPTION
Allow users to provide API key in their own secret via a reference.