### PR TITLE
[castai-agent] apiKey backward compatible (can be passed as string)

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.31.0
+version: 0.31.1
 appVersion: "v0.30.0"

--- a/charts/castai-agent/ci/test-values-old.yaml
+++ b/charts/castai-agent/ci/test-values-old.yaml
@@ -1,0 +1,20 @@
+apiKey: "test"
+apiURL: "test"
+provider: "castai"
+namespace: "default"
+createNamespace: false
+additionalEnv:
+  CASTAI_CLUSTER_ID: "c1"
+  CASTAI_ORGANIZATION_ID: "org1"
+additionalSecretEnv:
+  AWS_ACCESS_KEY_ID: "key"
+  AWS_SECRET_ACCESS_KEY: "secret"
+clusterVPA:
+  enabled: true
+resources:
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi

--- a/charts/castai-agent/templates/deployment.yaml
+++ b/charts/castai-agent/templates/deployment.yaml
@@ -55,7 +55,9 @@ spec:
           {{- end }}
           envFrom:
             - secretRef:
-          {{- if .Values.apiKey.value }}
+          {{-  if and  (kindIs "string" .Values.apiKey) .Values.apiKey}}
+                name: {{ include "castai-agent.fullname" . -}}
+          {{- else if .Values.apiKey.value }}
                 name: {{ include "castai-agent.fullname" . -}}
           {{- else }}
                 name: {{ required "apiKey.value or apiKey.secretKeyRef.name must be provided" .Values.apiKey.secretKeyRef.name -}}

--- a/charts/castai-agent/templates/secret.yaml
+++ b/charts/castai-agent/templates/secret.yaml
@@ -22,7 +22,7 @@ metadata:
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
 data:
-  API_KEY: {{ .Values.apiKey | b64enc | quote }}
+  API_KEY: {{ .Values.apiKey.value | b64enc | quote }}
   {{- range $k, $v := .Values.additionalSecretEnv }}
   {{ $k }}: {{ $v | b64enc | quote }}
   {{- end }}

--- a/charts/castai-agent/templates/secret.yaml
+++ b/charts/castai-agent/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.apiKey.value }}
+{{-  if kindIs "string" .Values.apiKey }}
 ---
 apiVersion: v1
 kind: Secret
@@ -8,8 +8,23 @@ metadata:
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
 data:
-  API_KEY: {{ .Values.apiKey.value | b64enc | quote }}
+  API_KEY: {{ .Values.apiKey | b64enc | quote }}
   {{- range $k, $v := .Values.additionalSecretEnv }}
   {{ $k }}: {{ $v | b64enc | quote }}
   {{- end }}
+{{ else if .Values.apiKey.value }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "castai-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "castai-agent.labels" . | nindent 4 }}
+data:
+  API_KEY: {{ .Values.apiKey | b64enc | quote }}
+  {{- range $k, $v := .Values.additionalSecretEnv }}
+  {{ $k }}: {{ $v | b64enc | quote }}
+  {{- end }}
+
 {{- end }}


### PR DESCRIPTION
In terraform we are using `apiKey` as string  https://github.com/castai/terraform-castai-gke-cluster/blob/main/main.tf#L43