### PR TITLE
[castai-agent] version collision due to concurrent PRs

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.33.2
+version: 0.33.3
 appVersion: "v0.31.0"


### PR DESCRIPTION
pipelines didn't catch concurrent update to 33.2 version