### PR TITLE
Feature: Add commonLabels and commonAnnotations

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.35.0
+version: 0.36.0
 appVersion: "v0.33.0"

--- a/charts/castai-agent/templates/_helpers.tpl
+++ b/charts/castai-agent/templates/_helpers.tpl
@@ -34,11 +34,23 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "castai-agent.labels" -}}
+{{- with .Values.commonLabels }}
+{{- toYaml . }}
+{{- end }}
 {{ include "castai-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: castai
+{{- end }}
+
+{{/*
+Common Annotations
+*/}}
+{{- define "castai-agent.annotations" -}}
+{{- with .Values.commonAnnotations }}
+{{- toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/castai-agent/templates/_helpers.tpl
+++ b/charts/castai-agent/templates/_helpers.tpl
@@ -34,8 +34,10 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "castai-agent.labels" -}}
+{{ if gt (len .Values.commonLabels) 0 -}}
 {{- with .Values.commonLabels }}
 {{- toYaml . }}
+{{- end }}
 {{- end }}
 {{ include "castai-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -48,8 +50,10 @@ app.kubernetes.io/managed-by: castai
 Common Annotations
 */}}
 {{- define "castai-agent.annotations" -}}
+{{ if gt (len .Values.commonAnnotations) 0 -}}
 {{- with .Values.commonAnnotations }}
 {{- toYaml . }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/castai-agent/templates/clustervpa-configmap.yaml
+++ b/charts/castai-agent/templates/clustervpa-configmap.yaml
@@ -5,6 +5,12 @@ kind: ConfigMap
 metadata:
   name: {{ include "castai-agent.fullname" . }}-autoscaler
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 data:
   # Increase memory requests/limits by 256Mi for every 20 nodes. round_up(nodes/nodes_per_step)*step
   # For example, for 150 nodes: round_up(150/20)*256Mi=2048Mi

--- a/charts/castai-agent/templates/clustervpa-deployment.yaml
+++ b/charts/castai-agent/templates/clustervpa-deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "castai-agent.fullname" . }}-cpvpa
     app.kubernetes.io/instance: {{ include "castai-agent.fullname" . }}-cpvpa
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/castai-agent/templates/deployment.yaml
+++ b/charts/castai-agent/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/castai-agent/templates/namespace.yaml
+++ b/charts/castai-agent/templates/namespace.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ .Release.Namespace }}
   labels:
   {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+  {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end -}}
 {{- end }}

--- a/charts/castai-agent/templates/rbac.yaml
+++ b/charts/castai-agent/templates/rbac.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "castai-agent.annotations" . | nindent 4 }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -19,6 +20,10 @@ metadata:
   name: {{ include "castai-agent.serviceAccountName" . }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 rules:
   # ---
   # Required for cost savings estimation features.
@@ -101,6 +106,10 @@ metadata:
   name: {{ include "castai-agent.serviceAccountName" . }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -117,6 +126,12 @@ kind: Role
 metadata:
   name: {{ include "castai-agent.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 rules:
   # ---
   # Required for proportional vertical cluster autoscaler to adjust castai-agent requests/limits.
@@ -134,7 +149,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "castai-agent.serviceAccountName" . }}
+  labels:
+    {{- include "castai-agent.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/castai-agent/templates/resource-quota.yaml
+++ b/charts/castai-agent/templates/resource-quota.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 spec:
   scopeSelector:
     matchExpressions:

--- a/charts/castai-agent/templates/secret.yaml
+++ b/charts/castai-agent/templates/secret.yaml
@@ -7,6 +7,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 data:
   API_KEY: {{ .Values.apiKey | b64enc | quote }}
   {{- range $k, $v := .Values.additionalSecretEnv }}

--- a/charts/castai-agent/templates/test-secret.yaml
+++ b/charts/castai-agent/templates/test-secret.yaml
@@ -8,6 +8,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 data:
   API_KEY: {{ "test" | b64enc | quote }}
 {{- end }}

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -5,6 +5,12 @@
 replicaCount: 1
 namespace: "castai-agent"
 
+# labels to add to all resources
+commonLabels: {}
+
+# annotations to add to all resources
+commonAnnotations: {}
+
 image:
   repository: us-docker.pkg.dev/castai-hub/library/agent
   pullPolicy: IfNotPresent

--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-cluster-controller
 description: CAST AI cluster controller deployment chart.
 type: application
-version: 0.39.0
+version: 0.40.0
 appVersion: "v0.26.0"

--- a/charts/castai-cluster-controller/templates/_helpers.tpl
+++ b/charts/castai-cluster-controller/templates/_helpers.tpl
@@ -34,9 +34,25 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "castai-agent.labels" -}}
+{{ if gt (len .Values.commonLabels) 0 -}}
+{{- with .Values.commonLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
 {{ include "castai-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common Annotations
+*/}}
+{{- define "castai-agent.annotations" -}}
+{{ if gt (len .Values.commonAnnotations) 0 -}}
+{{- with .Values.commonAnnotations }}
+{{- toYaml . }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/castai-cluster-controller/templates/aks-ds.yaml
+++ b/charts/castai-cluster-controller/templates/aks-ds.yaml
@@ -5,6 +5,10 @@ metadata:
   name: castai-aks-init-data
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/castai-cluster-controller/templates/config.yaml
+++ b/charts/castai-cluster-controller/templates/config.yaml
@@ -4,6 +4,10 @@ metadata:
   name: castai-cluster-controller
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 data:
   {{- if .Values.apiURL }}
   API_URL: {{ required "apiURL must be provided" .Values.apiURL | quote }}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     ignore-check.kube-linter.io/no-read-only-root-fs: "This deployment writes to local fs during chart upsert actions."
     ignore-check.kube-linter.io/run-as-non-root: "This deployment writes to local fs during chart upsert actions."
+    {{- include "castai-agent.annotations" . | nindent 4 }}
 spec:
   strategy:
     {{- .Values.updateStrategy | toYaml | nindent 4 }}

--- a/charts/castai-cluster-controller/templates/namespace.yaml
+++ b/charts/castai-cluster-controller/templates/namespace.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ .Release.Namespace }}
   labels:
   {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/castai-cluster-controller/templates/pdb.yaml
+++ b/charts/castai-cluster-controller/templates/pdb.yaml
@@ -9,6 +9,10 @@ metadata:
   name: castai-cluster-controller
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 spec:
   minAvailable: {{ .Values.pdbMinAvailable }}
   selector:

--- a/charts/castai-cluster-controller/templates/rbac.yaml
+++ b/charts/castai-cluster-controller/templates/rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+    {{- include "castai-agent.annotations" . | nindent 4 }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,6 +18,10 @@ metadata:
   name: castai-cluster-controller
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 rules:
   # Readonly.
   - apiGroups: [ "" ]
@@ -70,6 +75,10 @@ metadata:
   name: castai-cluster-controller
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 rules:
   # Controller has full access in castai-agent namespace. This is required to fully manage castai components.
   - apiGroups: [ "*" ]
@@ -80,6 +89,12 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: castai-cluster-controller
+  labels:
+    {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -95,6 +110,10 @@ metadata:
   name: castai-cluster-controller
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/castai-cluster-controller/templates/resource-quota.yaml
+++ b/charts/castai-cluster-controller/templates/resource-quota.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 spec:
   scopeSelector:
     matchExpressions:

--- a/charts/castai-cluster-controller/templates/secret.yaml
+++ b/charts/castai-cluster-controller/templates/secret.yaml
@@ -7,6 +7,10 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 data:
   {{- if .Values.apiKey }}
   API_KEY: {{ required "apiKey must be provided" .Values.apiKey | b64enc | quote }}

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -6,6 +6,12 @@ replicas: 2
 pdbMinAvailable: 1
 leaderElectionEnabled: true
 
+# labels to add to all resources
+commonLabels: {}
+
+# annotations to add to all resources
+commonAnnotations: {}
+
 nameOverride: ""
 fullnameOverride: castai-cluster-controller
 

--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.21
+version: 0.20.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/templates/_helpers.tpl
+++ b/charts/castai-evictor/templates/_helpers.tpl
@@ -34,12 +34,24 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "evictor.labels" -}}
+{{- with .Values.commonLabels }}
+{{- toYaml . }}
+{{- end }}
 helm.sh/chart: {{ include "evictor.chart" . }}
 {{ include "evictor.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common Annotations
+*/}}
+{{- define "evictor.annotations" -}}
+{{- with .Values.commonAnnotations }}
+{{- toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/castai-evictor/templates/_helpers.tpl
+++ b/charts/castai-evictor/templates/_helpers.tpl
@@ -34,8 +34,10 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "evictor.labels" -}}
+{{ if gt (len .Values.commonLabels) 0 -}}
 {{- with .Values.commonLabels }}
 {{- toYaml . }}
+{{- end }}
 {{- end }}
 helm.sh/chart: {{ include "evictor.chart" . }}
 {{ include "evictor.selectorLabels" . }}
@@ -49,8 +51,10 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Common Annotations
 */}}
 {{- define "evictor.annotations" -}}
+{{ if gt (len .Values.commonAnnotations) 0 -}}
 {{- with .Values.commonAnnotations }}
 {{- toYaml . }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/castai-evictor/templates/clusterrole.yaml
+++ b/charts/castai-evictor/templates/clusterrole.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "evictor.fullname" . }}
   labels:
   {{- include "evictor.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+  {{- include "evictor.annotations" . | nindent 4 }}
+  {{- end -}}
 rules:
   # ------------------------------------------------
   # Finding a suitable node for eviction

--- a/charts/castai-evictor/templates/clusterrole.yaml
+++ b/charts/castai-evictor/templates/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
   {{- include "evictor.annotations" . | nindent 4 }}
-  {{- end -}}
+  {{- end }}
 rules:
   # ------------------------------------------------
   # Finding a suitable node for eviction

--- a/charts/castai-evictor/templates/clusterrolebinding.yaml
+++ b/charts/castai-evictor/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
   {{- include "evictor.annotations" . | nindent 4 }}
-  {{- end -}}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/castai-evictor/templates/clusterrolebinding.yaml
+++ b/charts/castai-evictor/templates/clusterrolebinding.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "evictor.fullname" . }}
   labels:
   {{- include "evictor.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+  {{- include "evictor.annotations" . | nindent 4 }}
+  {{- end -}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "evictor.fullname" . }}
   labels:
     {{- include "evictor.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "evictor.annotations" . | nindent 4 }}
+  {{- end -}}
 spec:
   strategy:
     {{- .Values.updateStrategy | toYaml | nindent 4 }}

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
     {{- include "evictor.annotations" . | nindent 4 }}
-  {{- end -}}
+  {{- end }}
 spec:
   strategy:
     {{- .Values.updateStrategy | toYaml | nindent 4 }}

--- a/charts/castai-evictor/templates/role.yaml
+++ b/charts/castai-evictor/templates/role.yaml
@@ -8,7 +8,7 @@ metadata:
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
     {{- include "evictor.annotations" . | nindent 4 }}
-  {{- end -}}
+  {{- end }}
 rules:
   # ------------------------------------------------
   # Leader election

--- a/charts/castai-evictor/templates/role.yaml
+++ b/charts/castai-evictor/templates/role.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "evictor.serviceAccountName" . }}
   labels:
     {{- include "evictor.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "evictor.annotations" . | nindent 4 }}
+  {{- end -}}
 rules:
   # ------------------------------------------------
   # Leader election

--- a/charts/castai-evictor/templates/rolebinding.yaml
+++ b/charts/castai-evictor/templates/rolebinding.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "evictor.serviceAccountName" . }}
   labels:
     {{- include "evictor.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "evictor.annotations" . | nindent 4 }}
+  {{- end -}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/castai-evictor/templates/rolebinding.yaml
+++ b/charts/castai-evictor/templates/rolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
     {{- include "evictor.annotations" . | nindent 4 }}
-  {{- end -}}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/castai-evictor/templates/service.yaml
+++ b/charts/castai-evictor/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "evictor.fullname" . }}
   labels:
     {{- include "evictor.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "evictor.annotations" . | nindent 4 }}
+  {{- end -}}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/castai-evictor/templates/service.yaml
+++ b/charts/castai-evictor/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
     {{- include "evictor.annotations" . | nindent 4 }}
-  {{- end -}}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/castai-evictor/templates/serviceaccount.yaml
+++ b/charts/castai-evictor/templates/serviceaccount.yaml
@@ -4,9 +4,10 @@ kind: ServiceAccount
 metadata:
   name: {{ include "evictor.serviceAccountName" . }}
   labels:
-    {{- include "evictor.labels" . | nindent 4 }}
+  {{- include "evictor.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "evictor.annotations" . | nindent 4 }}
 {{- end }}

--- a/charts/castai-evictor/templates/test-configmap.yaml
+++ b/charts/castai-evictor/templates/test-configmap.yaml
@@ -9,7 +9,7 @@ metadata:
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
     {{- include "evictor.annotations" . | nindent 4 }}
-  {{- end -}}
+  {{- end }}
 data:
   API_URL: {{ required "test.apiURL must be provided" .Values.test.apiURL | quote }}
   CLUSTER_ID: {{ required "test.clusterID must be provided" .Values.test.clusterID | quote }}

--- a/charts/castai-evictor/templates/test-configmap.yaml
+++ b/charts/castai-evictor/templates/test-configmap.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "evictor.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "evictor.annotations" . | nindent 4 }}
+  {{- end -}}
 data:
   API_URL: {{ required "test.apiURL must be provided" .Values.test.apiURL | quote }}
   CLUSTER_ID: {{ required "test.clusterID must be provided" .Values.test.clusterID | quote }}

--- a/charts/castai-evictor/templates/test-secret.yaml
+++ b/charts/castai-evictor/templates/test-secret.yaml
@@ -9,7 +9,7 @@ metadata:
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
     {{- include "evictor.annotations" . | nindent 4 }}
-  {{- end -}}
+  {{- end }}
 data:
   API_KEY: {{ required "test.apiKey must be provided" .Values.test.apiKey | b64enc | quote }}
 {{ end }}

--- a/charts/castai-evictor/templates/test-secret.yaml
+++ b/charts/castai-evictor/templates/test-secret.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "evictor.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "evictor.annotations" . | nindent 4 }}
+  {{- end -}}
 data:
   API_KEY: {{ required "test.apiKey must be provided" .Values.test.apiKey | b64enc | quote }}
 {{ end }}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -4,6 +4,14 @@
 
 replicaCount: 1
 
+# labels to add to all resources
+commonLabels:
+  mylabel: my-label-value
+
+# annotations to add to all resources
+commonAnnotations: {}
+  # my-annotation: my-annotation-value
+
 # Specifies whether the Evictor should run in dryRun mode (Read-Only).
 # if true, evictor will just log action(s) it would perform
 # instead of actually performing them.

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -5,12 +5,10 @@
 replicaCount: 1
 
 # labels to add to all resources
-commonLabels:
-  mylabel: my-label-value
+commonLabels: {}
 
 # annotations to add to all resources
 commonAnnotations: {}
-  # my-annotation: my-annotation-value
 
 # Specifies whether the Evictor should run in dryRun mode (Read-Only).
 # if true, evictor will just log action(s) it would perform

--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: CAST AI spot handler daemonset chart
 type: application
-version: 0.13.0
+version: 0.14.0
 appVersion: "v0.7.0"

--- a/charts/castai-spot-handler/templates/_helpers.tpl
+++ b/charts/castai-spot-handler/templates/_helpers.tpl
@@ -34,11 +34,27 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "castai-agent.labels" -}}
+{{ if gt (len .Values.commonLabels) 0 -}}
+{{- with .Values.commonLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
 {{ include "castai-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: castai
+{{- end }}
+
+{{/*
+Common Annotations
+*/}}
+{{- define "castai-agent.annotations" -}}
+{{ if gt (len .Values.commonAnnotations) 0 -}}
+{{- with .Values.commonAnnotations }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "castai-agent.labels" . | nindent 4 }}
   annotations:
     ignore-check.kube-linter.io/host-network: "Spot handler need host network to access instance metadata endpoints for spot interrupts checks."
+    {{- include "castai-agent.annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/castai-spot-handler/templates/namespace.yaml
+++ b/charts/castai-spot-handler/templates/namespace.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ .Release.Namespace }}
   labels:
   {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/castai-spot-handler/templates/rbac.yaml
+++ b/charts/castai-spot-handler/templates/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-
+    {{- include "castai-agent.annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -17,6 +17,10 @@ metadata:
   name: castai-spot-handler
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""
@@ -31,6 +35,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: castai-spot-handler
+  labels:
+    {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/castai-spot-handler/templates/test-secret.yaml
+++ b/charts/castai-spot-handler/templates/test-secret.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: castai-cluster-controller
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "castai-agent.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" . | nindent 4 }}
+  {{- end }}
 data:
   API_KEY: {{ required "test.apiKey must be provided" .Values.test.apiKey | b64enc | quote }}
 {{ end }}

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -2,6 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# labels to add to all resources
+commonLabels: {}
+
+# annotations to add to all resources
+commonAnnotations: {}
+
 image:
   repository: us-docker.pkg.dev/castai-hub/library/spot-handler
   # Tag is set using Chart.yaml appVersion field.


### PR DESCRIPTION
PR to add commonLabels and commonAnnotations options to the following charts:

- castai-agent
- castai-evictor
- castai-spot-handler
- castai-cluster-controller

**Why is this feature needed:**
Certain consumers of these charts will have a need to apply labels/annotations to the resources created by these charts globally. One such use case is when using a mixture of ArgoCD/Terraform/Helm to deploy Cast. In our case, we deploy Cast via Helm/Terraform during cluster creation, after which ArgoCD is connected to the cluster to assume management of the deployed platform-level applications, of which Cast is included. 

Because ArgoCD does not *actually* use helm to deploy the helm chart when using a Helm source for an application or applicationset we are left with mismatching labels/annotations on resources that were deployed via Helm/Terraform causing the need for a force-sync (basically a deletion/re-creation) of these resources in order to reconcile.

With an option to add labels/annotations, we could instead manually set labels/annotations normally generated by Helm and smooth this process. 
