### PR TITLE
[castai-agent] update image for clusterVPA - arm64 support

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -3,4 +3,4 @@ name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
 version: 0.37.0
-appVersion: "v0.33.0"
+appVersion: "v0.34.0"

--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.36.0
+version: 0.37.0
 appVersion: "v0.33.0"

--- a/charts/castai-agent/templates/clustervpa-deployment.yaml
+++ b/charts/castai-agent/templates/clustervpa-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: autoscaler
-          image: k8s.gcr.io/cpvpa-amd64:{{ .Values.clusterVPA.version }}
+          image: k8s.gcr.io/cpa/cpvpa:{{ .Values.clusterVPA.version }}
           command:
             - /cpvpa
             - --target=deployment/{{ include "castai-agent.fullname" . }}

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -42,7 +42,7 @@ podLabels: {}
 # https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler
 clusterVPA:
   enabled: true
-  version: v0.8.3
+  version: v0.8.4
   pollPeriodSeconds: 300
 
 resources: {}


### PR DESCRIPTION
The only change between v0.8.3 vs 0.8.4 is a multi-arch build https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/releases/tag/v0.8.4