### PR TITLE
Move to a hard antiaffinity for cluster-controller

### DIFF
--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -73,16 +73,14 @@ affinity:
               values:
                 - windows
   podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - castai-cluster-controller
-          topologyKey: kubernetes.io/hostname
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - castai-cluster-controller
+        topologyKey: kubernetes.io/hostname
 
 # Pod security context.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
Ensure that cluster-controller gets scheduled on separate nodes by default. Setup the default to be a required antiAffinity rather than preferred. 