### PR TITLE
[castai-cluster-controller] fix in old versions of k8s system-critica…

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-cluster-controller
 description: CAST AI cluster controller deployment chart.
 type: application
-version: 0.42.0
+version: 0.42.1
 appVersion: "v0.28.1"

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") (semverCompare ">= 1.14-0" .Capabilities.KubeVersion.Version) (.Values.priorityClass | default dict).enabled }}
+      {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version) (.Values.priorityClass | default dict).enabled }}
       priorityClassName: {{ .Values.priorityClass.name }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}


### PR DESCRIPTION
…l can be only in kube-system ns

https://github.com/kubernetes/kubernetes/issues/60596#issuecomment-559537077