### PR TITLE
[castai-agent] prefer castai nodes during scheduling

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.38.0
+version: 0.39.0
 appVersion: "v0.34.1"

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -90,6 +90,14 @@ affinity:
               operator: NotIn
               values:
                 - windows
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: provisioner.cast.ai/managed-by
+              operator: In
+              values:
+                - cast.ai
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100


### PR DESCRIPTION
Prefer CAST AI nodes during agent scheduling to be able to call CSP metadata API by inheriting node instance profiles.