### PR TITLE
[castai-cluster-controller] Bump version v0.30.0

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -3,4 +3,4 @@ name: castai-cluster-controller
 description: CAST AI cluster controller deployment chart.
 type: application
 version: 0.42.2
-appVersion: "v0.29.0"
+appVersion: "v0.30.0"


### PR DESCRIPTION
- Release to support aks arm64 https://github.com/castai/cluster-controller/releases/tag/v0.30.0