### PR TITLE
[castai-pod-node-lifecycle] Bump version to v0.19.0

### DIFF
--- a/charts/castai-pod-node-lifecycle/Chart.yaml
+++ b/charts/castai-pod-node-lifecycle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-pod-node-lifecycle
 description: CAST AI spot-only K8s webhook to control workload placement during cluster migration and spot-only.
 type: application
-version: 0.23.0
-appVersion: "v0.18.0"
+version: 0.24.0
+appVersion: "v0.19.0"


### PR DESCRIPTION
[Releases](https://github.com/castai/k8s-webhooks/releases)