### PR TITLE
[castai-pod-node-lifecycle] terminating pods and annotation fix

### DIFF
--- a/charts/castai-pod-node-lifecycle/Chart.yaml
+++ b/charts/castai-pod-node-lifecycle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-pod-node-lifecycle
 description: CAST AI spot-only K8s webhook to control workload placement during cluster migration and spot-only.
 type: application
-version: 0.28.0
-appVersion: "v0.21.0"
+version: 0.29.0
+appVersion: "v0.23.0"


### PR DESCRIPTION
Spot-webhook
* should look at Pod status for partial distribution
* CSU-453 fix annotation override bug when global DefaultToSpot is True