### PR TITLE
[castai-agent] revert-agent-ram-requests

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -3,4 +3,4 @@ name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
 version: 0.58.0
-appVersion: "v0.45.0"
+appVersion: "v0.45.1"

--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.58.0
-appVersion: "v0.45.1"
+version: 0.58.1
+appVersion: "v0.45.0"

--- a/charts/castai-agent/templates/clustervpa-configmap.yaml
+++ b/charts/castai-agent/templates/clustervpa-configmap.yaml
@@ -21,7 +21,7 @@ data:
       "agent": {
         "requests": {
           "memory": {
-            "base": "2Gi",
+            "base": "512Mi",
             "max": "8Gi",
             "step": "256Mi",
             "nodesPerStep": 20,


### PR DESCRIPTION
There is actually no reason to make only memory requests = limits, so leaving limits high (as CPU needs to be request=limits as well to get Guaranteed QoS), but reducing requests.