### PR TITLE
[castai-evictor][castai-agent][castai-controller] add hostNetwork and dnsPolicy 

### DIFF
--- a/charts/castai-agent/templates/deployment.yaml
+++ b/charts/castai-agent/templates/deployment.yaml
@@ -29,6 +29,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.hostNetwork.enabled }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       shareProcessNamespace: true
       volumes:
         - name: shared-metadata

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -72,6 +72,13 @@ priorityClass:
   enabled: true
   name: system-cluster-critical
 
+hostNetwork:
+  # Enable host networking
+  enabled: false
+
+# DNS Policy Override - Needed when using some custom CNI's.
+dnsPolicy: ""
+
 # Pod toleration rules.
 # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: {}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -36,6 +36,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.hostNetwork.enabled }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version) (.Values.priorityClass | default dict).enabled }}
       priorityClassName: {{ .Values.priorityClass.name }}
       {{- end }}

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -104,6 +104,13 @@ aks:
   nodeSelector:
     provisioner.cast.ai/aks-init-data: "true"
 
+hostNetwork:
+  # Enable host networking
+  enabled: false
+
+# DNS Policy Override - Needed when using some custom CNI's.
+dnsPolicy: ""
+
 priorityClass:
   enabled: true
   name: system-cluster-critical

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -30,6 +30,12 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hostNetwork.enabled }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -70,6 +70,13 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+hostNetwork:
+  # Enable host networking
+  enabled: false
+
+# DNS Policy Override - Needed when using some custom CNI's.
+dnsPolicy: ""
+
 podSecurityContext:
   readOnlyRootFilesystem: true
 


### PR DESCRIPTION
Add the ability for customers to set hostNetwork and dnsPolicy in the values file, this is useful if desirable to run on fargate nodes for the CAST AI components. 