### PR TITLE
[castai-cluster-controller] feat: Remove cluster-controller RBAC write permissions

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 1.0.0
+version: 0.55.0
 appVersion: "v0.39.1"

--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.54.1
+version: 1.0.0
 appVersion: "v0.39.1"

--- a/charts/castai-cluster-controller/templates/rbac.yaml
+++ b/charts/castai-cluster-controller/templates/rbac.yaml
@@ -73,7 +73,7 @@ rules:
   - apiGroups: [ "rbac.authorization.k8s.io" ]
     resources: [ "roles", "clusterroles", "clusterrolebindings" ]
     resourceNames: [ "castai-cluster-controller", "castai-evictor", "castai-agent", "castai-spot-handler", "castai-kvisor", "castai-egressd" ]
-    verbs: [ "get", "patch", "update", "delete", "escalate" ]
+    verbs: [ "get", "delete" ]
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
     resourceNames: [ "castai-agent" ]

--- a/charts/castai-cluster-controller/templates/rbac.yaml
+++ b/charts/castai-cluster-controller/templates/rbac.yaml
@@ -71,7 +71,11 @@ rules:
     verbs: [ "list", "create", "patch" ]
   # For installing/updating CAST AI components.
   - apiGroups: [ "rbac.authorization.k8s.io" ]
-    resources: [ "roles", "clusterroles", "clusterrolebindings" ]
+    resources: [ "roles" ]
+    resourceNames: [ "castai-cluster-controller", "castai-evictor", "castai-agent", "castai-spot-handler", "castai-kvisor", "castai-egressd" ]
+    verbs: [  "get", "patch", "update", "delete" ]
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources: [ "clusterroles", "clusterrolebindings" ]
     resourceNames: [ "castai-cluster-controller", "castai-evictor", "castai-agent", "castai-spot-handler", "castai-kvisor", "castai-egressd" ]
     verbs: [ "get", "delete" ]
   - apiGroups: [ "" ]


### PR DESCRIPTION
Breaking change: Remove cluster-controller RBAC write permissions.
In order for cluster-controller to support chartUpsert actions, cluster have to be running cluster-controller v0.38.0 version.