### PR TITLE
[castai-cluster-controller] Update helm chart 

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.53.3
-appVersion: "v0.37.4"
+version: 0.53.4
+appVersion: "v0.37.5"


### PR DESCRIPTION
- `Log real reason of shutdown of the controller.`  https://github.com/castai/cluster-controller/releases/tag/v0.37.5