### PR TITLE
Add skip_existing to chart release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,5 +37,6 @@ jobs:
         with:
           charts_dir: charts
           config: cr.yaml
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.PAT_CICD }}"


### PR DESCRIPTION
Egressd is released in it's owed repo. Only chart content is synced.