### PR TITLE
[castai-agent] remove cluster level configmap access

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.68.1
+version: 0.68.2
 appVersion: "v0.53.5"

--- a/charts/castai-agent/README.md
+++ b/charts/castai-agent/README.md
@@ -46,7 +46,8 @@ CAST AI agent deployment chart.
 | priorityClass.enabled | bool | `true` |  |
 | priorityClass.name | string | `"system-cluster-critical"` |  |
 | provider | string | `""` | Name of the Kubernetes service provider one of: "eks", "gks", "aks", "kops". |
-| rbac | object | `{"enabled":true}` | Specifies whether RBAC Clusterrole should be created. |
+| rbac.configmapsReadAccessNamespaces | list | `["kube-system"]` | Namespaces to be granted access to the castai-agent for configmaps read access. |
+| rbac.enabled | bool | `true` | Specifies whether a Clusterrole should be created. |
 | replicaCount | int | `2` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |

--- a/charts/castai-agent/templates/rbac.yaml
+++ b/charts/castai-agent/templates/rbac.yaml
@@ -289,4 +289,44 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end}}
 
+{{- range .Values.rbac.configmapsReadAccessNamespaces }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "castai-agent.serviceAccountName" $ }}
+  namespace: {{ . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "castai-agent.serviceAccountName" $ }}
+  labels:
+    {{- include "castai-agent.labels" $ | nindent 4 }}
+  namespace: {{ . }}
+  {{ if gt (len $.Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" $ | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "castai-agent.serviceAccountName" $ }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "castai-agent.serviceAccountName" $ }}
+    namespace: {{ . }}
+
+{{- end }}
+
 {{- end }}

--- a/charts/castai-agent/templates/rbac.yaml
+++ b/charts/castai-agent/templates/rbac.yaml
@@ -43,7 +43,6 @@ rules:
       - services
       - namespaces
       - events
-      - configmaps
     verbs:
       - get
       - list
@@ -186,7 +185,6 @@ subjects:
     name: {{ include "castai-agent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 
-{{- if .Values.clusterVPA.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -201,6 +199,18 @@ metadata:
   {{- end }}
 rules:
   # ---
+  # Required for cost savings estimation features.
+  # ---
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  {{- if .Values.clusterVPA.enabled }}
+  # ---
   # Required for proportional vertical cluster autoscaler to adjust castai-agent requests/limits.
   # ---
   - apiGroups:
@@ -211,6 +221,7 @@ rules:
       - {{ include "castai-agent.fullname" . }}
     verbs:
       - patch
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -231,7 +242,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "castai-agent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
 
 {{- if eq .Values.provider "openshift" }}
 ---

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -23,10 +23,11 @@ fullnameOverride: castai-agent
 
 # createNamespace -- Specifies whether a namespace should be created.
 createNamespace: true
-# rbac -- Specifies whether RBAC Clusterrole should be created.
+
 rbac:
+  # rbac.enabled -- Specifies whether a Clusterrole should be created.
   enabled: true
-  # Namespaces to be granted access to the castai-agent for configmaps read access.
+  # rbac.configmapsReadAccessNamespaces -- Namespaces to be granted access to the castai-agent for configmaps read access.
   configmapsReadAccessNamespaces:
     - "kube-system"
 

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -26,6 +26,9 @@ createNamespace: true
 # rbac -- Specifies whether RBAC Clusterrole should be created.
 rbac:
   enabled: true
+  # Namespaces to be granted access to the castai-agent for configmaps read access.
+  configmapsReadAccessNamespaces:
+    - "kube-system"
 
 serviceAccount:
   # serviceAccount.create -- Specifies whether a service account should be created.


### PR DESCRIPTION
This PR removes access to `configmaps` from `ClusterRole` and replaces it with configurable namespace-level RBAC.