### PR TITLE
[castai-hibernate] - Adding in the option to reference an existing secret for the API Key

### DIFF
--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -3,4 +3,4 @@ name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
 version: 0.2.3
-appVersion: "v0.7"
+appVersion: "v0.8"

--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -3,4 +3,4 @@ name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
 version: 0.2.3
-appVersion: "v0.8"
+appVersion: "v0.7"

--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "v0.7"

--- a/charts/castai-hibernate/README.md
+++ b/charts/castai-hibernate/README.md
@@ -8,6 +8,7 @@ CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defi
 |-----|------|---------|-------------|
 | agentNamespace | string | `"castai-agent"` |  |
 | apiKey | string | `""` | API token with Full Access permissions and encode base64 |
+| apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing evictor access to the API apiKey and apiKeySecretRef are mutually exclusive The referenced secret must provide the token in .data["API_KEY"]. |
 | backoffLimit | int | `0` |  |
 | cloud | string | `""` | Set CronJobs "Cloud" env variable to [EKS|GKE|AKS] |
 | clusterRoleBindingAdminName | string | `"hibernate-admin"` |  |

--- a/charts/castai-hibernate/templates/pause-cronjob.yaml
+++ b/charts/castai-hibernate/templates/pause-cronjob.yaml
@@ -27,7 +27,12 @@ spec:
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             envFrom:
               - secretRef:
+                  {{- if .Values.apiKeySecretRef }}
+                  name: {{ .Values.apiKeySecretRef }}
+                  {{- else }}
                   name: {{ .Values.secretName }}
+                  {{- end }}
+                  optional: false
             securityContext:
               readOnlyRootFilesystem: true       
             env:

--- a/charts/castai-hibernate/templates/resume-cronjob.yaml
+++ b/charts/castai-hibernate/templates/resume-cronjob.yaml
@@ -28,7 +28,12 @@ spec:
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             envFrom:
               - secretRef:
+                  {{- if .Values.apiKeySecretRef }}
+                  name: {{ .Values.apiKeySecretRef }}
+                  {{- else }}
                   name: {{ .Values.secretName }}
+                  {{- end }}
+                  optional: false
             securityContext:
               readOnlyRootFilesystem: true   
             env:

--- a/charts/castai-hibernate/templates/secret.yaml
+++ b/charts/castai-hibernate/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.apiKey }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +8,4 @@ metadata:
 type: Opaque
 data:
   API_KEY: {{ .Values.apiKey }}
+{{- end }}

--- a/charts/castai-hibernate/values.yaml
+++ b/charts/castai-hibernate/values.yaml
@@ -6,6 +6,11 @@
 # -- API token with Full Access permissions and encode base64
 apiKey: ""
 
+# apiKeySecretRef -- Name of secret with Token to be used for authorizing evictor access to the API
+# apiKey and apiKeySecretRef are mutually exclusive
+# The referenced secret must provide the token in .data["API_KEY"].
+apiKeySecretRef: ""
+
 # -- Set CronJobs "Cloud" env variable to [EKS|GKE|AKS]
 cloud: ""
 


### PR DESCRIPTION
Adding the ability to use an existing secret for the APIKey rather than creating a new one and requiring the API_KEY to be passed into the helm chart.

This fixed #419 .

This is just to help - its not a big change and not worried if you would rather implement it your own way.