### PR TITLE
Exclude gpu-metrics-exporter chart from linting

### DIFF
--- a/kube-linter-config.yaml
+++ b/kube-linter-config.yaml
@@ -7,3 +7,4 @@ checks:
     - ./charts/egressd/**
     - ./charts/kvisor/**
     - ./charts/kvisord/**
+    - ./charts/gpu-metrics-exporter/**


### PR DESCRIPTION
The chart contains Nvidia's DCGM expoter which
can not run in unpriviledged mode

We configured the linter in the gpu-metrics-exporter repo 
to check for the other issues, so the chart will not be 
completely unlinted