### PR TITLE
[castai-hibernate] adjust k8s support for timezone

### DIFF
--- a/charts/castai-hibernate/templates/pause-cronjob.yaml
+++ b/charts/castai-hibernate/templates/pause-cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   schedule: "{{ .Values.pauseCronSchedule }}"
   concurrencyPolicy: {{ .Values.concurrencyPolicy }}
-  {{- if and .Values.timeZone (semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if and .Values.timeZone (semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion) }}
   timeZone: {{ .Values.timeZone }}
   {{- end }}
   jobTemplate:

--- a/charts/castai-hibernate/templates/resume-cronjob.yaml
+++ b/charts/castai-hibernate/templates/resume-cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   schedule: "{{ .Values.resumeCronSchedule }}"
   concurrencyPolicy: {{ .Values.concurrencyPolicy }}
-  {{- if and .Values.timeZone (semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if and .Values.timeZone (semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion) }}
   timeZone: {{ .Values.timeZone }}
   {{- end }}
   jobTemplate:


### PR DESCRIPTION
Adjusting the timezone k8s versions to the hibernate cronjobs from 1.27 to 1.25.
Ref: https://github.com/castai/hibernate/pull/21/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45