### PR TITLE
[castai-pod-node-lifecycle]  CSU-1569: Disable TLS 1.2 and below in spot-lifecycle webhook

### DIFF
--- a/charts/castai-pod-node-lifecycle/Chart.yaml
+++ b/charts/castai-pod-node-lifecycle/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-pod-node-lifecycle
 description: CAST AI spot-only K8s webhook to control workload placement during cluster migration and spot-only.
 type: application
-version: 0.32.2
-appVersion: "v0.27.1"
+version: 0.33.0
+appVersion: "v0.28.0"


### PR DESCRIPTION
See https://github.com/castai/k8s-webhooks/pull/47 for what changed