### PR TITLE
[castai-agent] chore: bump agent version: send deltas with a non-sliding interval

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.75.0
-appVersion: "v0.60.0"
+version: 0.76.0
+appVersion: "v0.61.0"


### PR DESCRIPTION
Relevant Agent release here: castai/k8s-agent#174