### PR TITLE
[castai-cluster-controller] Chore: Bump cluster controller to go 1.22 version

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.57.0
-appVersion: "v0.42.1"
+version: 0.57.1
+appVersion: "v0.43.0"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:

--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.57.1
+version: 0.58.0
 appVersion: "v0.43.0"
 annotations:
   release-date: "2024-06-04T07:10:07"


### PR DESCRIPTION
Release for app - https://github.com/castai/cluster-controller/releases/tag/v0.43.0 