### PR TITLE
[castai-spot-handler] Chore: Bump spot-handler to go 1.22 version

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.19.7
-appVersion: "v0.11.5"
+version: 0.19.8
+appVersion: "v0.12.0"

--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.19.8
+version: 0.20.0
 appVersion: "v0.12.0"


### PR DESCRIPTION
Release for spot-handler app - https://github.com/castai/spot-handler/releases/tag/v0.12.0