### PR TITLE
[castai-cluster-controller] KUBE-479: Bump app and chart version for cluster-controller

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.61.1
-appVersion: "v0.43.4"
+version: 0.62.0
+appVersion: "v0.44.0"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:


### PR DESCRIPTION
Bumps chart to use this release https://github.com/castai/cluster-controller/releases/tag/v0.44.0 