### PR TITLE
[castai-hibernate] hibernate app bump 

### DIFF
--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
-version: 0.2.7
-appVersion: "v0.10"
+version: 0.2.8
+appVersion: "v0.11"


### PR DESCRIPTION
Update Helm Chart for v0.11

This update bumps the Helm chart version to reflect the release of v0.11 of the application.

Key Changes in app :

	•	Removed Fallback Label: The fallback label has been removed from the application. As a result, the hibernation node will now appear as a Spot node but will function as a demand node with a pause label.
	•	Reason for Change: The autoscaler was frequently replacing the fallback node, causing instability. This update addresses that issue by removing the fallback label.
