### PR TITLE
[castai-cluster-controller] Downgrade CC version due to CSR instabilities

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.70.1
-appVersion: "v0.51.1"
+version: 0.71.0
+appVersion: "v0.50.2"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:


### PR DESCRIPTION
Seeing nodes where kube-proxy fails to start, seems to happen mostly on v0.52+ (although hard to reproduce consistently). Temporary downgrade until we resolve issue. 