### PR TITLE
[castai-db-optimizer] add proxy readiness probe

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.1.4
+version: 0.1.5

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 
@@ -13,6 +13,7 @@ CAST AI database cache deployment.
 | cacheGroupID | string | `""` | ID of the cache group for which cache configuration should be pulled.  |
 | hostAntiAffinityEnabled | bool | `true` |  |
 | proxy.logLevel | string | `"filter:info"` | Default proxy log level. |
+| proxy.readinessProbeEnabled | bool | `true` | Ensure proxy has retrieved initial cache configuration before accepting connections. |
 | proxyImage.pullPolicy | string | `"IfNotPresent"` |  |
 | proxyImage.repository | string | `"us-docker.pkg.dev/castai-hub/library/dbo-proxy"` |  |
 | proxyImage.tag | string | `""` |  |

--- a/charts/castai-db-optimizer/ci/test-values.yaml
+++ b/charts/castai-db-optimizer/ci/test-values.yaml
@@ -6,4 +6,4 @@ resources:
     ephemeralStorage: 5Mi
 
 proxy:
-  readinessProbeEnabled: true
+  readinessProbeEnabled: false

--- a/charts/castai-db-optimizer/ci/test-values.yaml
+++ b/charts/castai-db-optimizer/ci/test-values.yaml
@@ -4,3 +4,6 @@ apiKey: "456"
 resources:
   proxy:
     ephemeralStorage: 5Mi
+
+proxy:
+  readinessProbeEnabled: false

--- a/charts/castai-db-optimizer/ci/test-values.yaml
+++ b/charts/castai-db-optimizer/ci/test-values.yaml
@@ -6,4 +6,4 @@ resources:
     ephemeralStorage: 5Mi
 
 proxy:
-  readinessProbeEnabled: false
+  readinessProbeEnabled: true

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -115,6 +115,17 @@ spec:
         - name: proxy
           image: "{{.Values.proxyImage.repository}}:{{default (include "defaultProxyVersion" .) .Values.proxyImage.tag}}"
           imagePullPolicy: {{.Values.proxyImage.pullPolicy}}
+          {{- if .Values.proxy.readinessProbeEnabled }}
+          readinessProbe:
+            periodSeconds: 3
+            exec:
+              command:
+              - /bin/bash
+              - '-c'
+              - |-
+                 health=$(curl --silent localhost:9901/clusters | grep {{ .Values.apiURL }} | grep -c health_flags::healthy);
+                 if [[ $health -ne 1 ]]; then echo "Initial cache configuration wasn't pulled yet" && exit 1; fi
+          {{- end}}
           securityContext:
             capabilities:
               drop:

--- a/charts/castai-db-optimizer/templates/envoy_config.yaml
+++ b/charts/castai-db-optimizer/templates/envoy_config.yaml
@@ -129,6 +129,18 @@ data:
                         socket_address:
                           address: {{ .Values.apiURL }}
                           port_value: 443
+
+          health_checks:
+            - timeout: 1s
+              interval: 5s
+              no_traffic_interval: 5s
+              unhealthy_threshold: 3
+              healthy_threshold: 1
+              custom_health_check:
+                name: "castai.cluster_control.health_check"
+                typed_config:
+                  "@type": type.googleapis.com/castai.cluster_control.v1.ClusterControlHealthCheck
+
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:

--- a/charts/castai-db-optimizer/values.yaml
+++ b/charts/castai-db-optimizer/values.yaml
@@ -29,6 +29,9 @@ resources:
 proxy:
   # proxy.logLevel -- Default proxy log level.
   logLevel: "filter:info"
+  # proxy.readinessProbeEnabled -- Ensure proxy has retrieved initial cache configuration before accepting connections.
+  readinessProbeEnabled: true
+
 
 queryProcessor:
   # queryProcessor.logLevel -- Default query-processor log level.


### PR DESCRIPTION
Example output:
```
Events:
  Type     Reason     Age              From               Message
  ----     ------     ----             ----               -------
  Normal   Scheduled  9s               default-scheduler  Successfully assigned default/castai-db-optimizer-589fd9dfcf-8rtmg to tilt-control-plane
  Normal   Pulled     9s               kubelet            Container image "us-docker.pkg.dev/castai-hub/library/query-processor:v0.1.0-rc.19" already present on machine
  Normal   Created    9s               kubelet            Created container query-processor
  Normal   Started    9s               kubelet            Started container query-processor
  Normal   Pulled     9s               kubelet            Container image "us-docker.pkg.dev/castai-hub/library/dbo-proxy:4.48.1" already present on machine
  Normal   Created    9s               kubelet            Created container proxy
  Normal   Started    9s               kubelet            Started container proxy
  Warning  Unhealthy  3s (x3 over 7s)  kubelet            Readiness probe failed: Initial cache configuration wasn't pulled yet
  ```