### PR TITLE
[castai-pod-pinner] P5791, add probe properties to values.yaml

### DIFF
--- a/charts/castai-pod-pinner/templates/deployment.yaml
+++ b/charts/castai-pod-pinner/templates/deployment.yaml
@@ -53,10 +53,14 @@ spec:
             httpGet:
               port: 9091
               path: /healthz
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 10 }}
           readinessProbe:
             httpGet:
               port: 9091
               path: /readyz
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/charts/castai-pod-pinner/values.yaml
+++ b/charts/castai-pod-pinner/values.yaml
@@ -14,6 +14,14 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+livenessProbe:
+  periodSeconds: 10
+  initialDelaySeconds: 5
+
+readinessProbe:
+  periodSeconds: 10
+  initialDelaySeconds: 5
+
 # -- Specifies whether the Pod Pinner should be managed by CAST AI automatically. Only the exact value "false" disables automatic management of the chart.
 # If set to "false", then the installation, upgrade or any changes have to be managed manually.
 managedByCASTAI: true


### PR DESCRIPTION
iSpot is seeing their pod-pinner pods restart cause they aren't starting fast enough. The helm chart doesn't currently allow setting these values