### PR TITLE
[castai-db-optimizer] allow full api url

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.1.3
+version: 0.1.4

--- a/charts/castai-db-optimizer/templates/_helpers.tpl
+++ b/charts/castai-db-optimizer/templates/_helpers.tpl
@@ -21,3 +21,33 @@ app.kubernetes.io/managed-by: Helm
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: {{ include "chart" . }}
 {{- end }}
+
+
+{{- define "extractUrlComponents" -}}
+  {{- $url := . -}}
+  {{- $protocol := "unknown" -}}
+  {{- $host := "" -}}
+  {{- $port := "" -}}
+  {{- $tls := false -}}
+
+  {{- if hasPrefix "https://" $url -}}
+    {{- $protocol = "https" -}}
+    {{- $url = trimPrefix "https://" $url -}}
+    {{- $port = 443 -}}
+    {{- $tls = true -}}
+  {{- else if hasPrefix "http://" $url -}}
+    {{- $protocol = "http" -}}
+    {{- $url = trimPrefix "http://" $url -}}
+    {{- $port = 80 -}}
+  {{- end -}}
+
+  {{- $urlParts := split ":" $url -}}
+  {{- $host = index $urlParts "_0" -}}
+
+  {{- if gt (len $urlParts) 1 -}}
+    {{- $port = index $urlParts "_1" -}}
+  {{- end -}}
+
+  {{- $result := dict "url" . "protocol" $protocol "host" $host "port" $port "tls" $tls -}}
+  {{ $result | toYaml}}
+{{- end -}}

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: LOG_LEVEL
               value: {{ required "log level must be provided" .Values.queryProcessor.logLevel }}
             - name: API_URL
-              value: {{ required "apiURL must be provided" .Values.apiURL | printf "https://%s" }}
+              value: {{ required "apiURL must be provided" .Values.apiURL }}
             - name: API_KEY
               value: {{ .Values.apiKey | quote }}
             - name: PROXY_METRICS_PORT

--- a/charts/castai-db-optimizer/templates/envoy_config.yaml
+++ b/charts/castai-db-optimizer/templates/envoy_config.yaml
@@ -1,3 +1,5 @@
+{{ $apiURL := (include "extractUrlComponents" .Values.apiURL | fromYaml)  }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,6 +8,7 @@ metadata:
     {{- include "labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ include "name" . }}
 data:
+
   envoy-config.yaml: |-
     node:
       cluster: castai
@@ -35,7 +38,7 @@ data:
         typed_config:
           "@type": type.googleapis.com/castai.cluster_control.v1.ClusterControlConfig
           path: /v1/dbo/cache-groups/{{ .Values.cacheGroupID | required ".Values.cacheGroupID is required." }}/cache-configurations
-          hostname: {{ .Values.apiURL }}
+          hostname: {{ $apiURL.host }}
           api_key: {{ .Values.apiKey | quote }}
       - name: "castai.grpc.services"
         typed_config:
@@ -117,18 +120,19 @@ data:
                           address: 127.0.0.1
                           port_value: 1234
 
-        - name: {{ .Values.apiURL }}
+        - name: {{ $apiURL.host }}
           type: LOGICAL_DNS
           connect_timeout: 2s
           load_assignment:
-            cluster_name: {{ .Values.apiURL }}
+            cluster_name: {{ $apiURL.host }}
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: {{ .Values.apiURL }}
-                          port_value: 443
+                          address: {{ $apiURL.host }}
+                          port_value: {{ $apiURL.port }}
+          {{ if $apiURL.tls }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -141,7 +145,8 @@ data:
                       filename: cert.pem
                     private_key:
                       filename: key.pem
-              sni: {{ .Values.apiURL }}
+              sni: {{ $apiURL.host }}
+          {{ end }}
 
         - name: query_processor_service
           type: LOGICAL_DNS

--- a/charts/castai-db-optimizer/values.yaml
+++ b/charts/castai-db-optimizer/values.yaml
@@ -1,7 +1,7 @@
 replicas: 2
 
 # apiURL -- URL to the CAST AI API server.
-apiURL: "api.cast.ai"
+apiURL: "https://api.cast.ai"
 
 # apiKey -- Token to be used for authorizing access to the CAST AI API.
 #


### PR DESCRIPTION
This enables chart users to use local proxies to reach CAST.AI mothership. Also, unifies API_URL usage with the rest of the charts.