### PR TITLE
[castai-agent] Add standard labels and annotations for kube-system Role

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.81.0
+version: 0.82.0
 appVersion: "v0.66.0"

--- a/charts/castai-agent/templates/rbac.yaml
+++ b/charts/castai-agent/templates/rbac.yaml
@@ -335,6 +335,12 @@ kind: Role
 metadata:
   name: {{ include "castai-agent.serviceAccountName" $ }}
   namespace: {{ . }}
+  labels:
+    {{- include "castai-agent.labels" $ | nindent 4 }}
+  {{ if gt (len $.Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "castai-agent.annotations" $ | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""


### PR DESCRIPTION
Example new kube-system Role with labels:

```
kubectl get Role -n kube-system castai-agent -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  annotations:
    meta.helm.sh/release-name: mycastai-agent
    meta.helm.sh/release-namespace: castai-agent2
  creationTimestamp: "2024-10-14T10:39:18Z"
  labels:
    app.kubernetes.io/instance: mycastai-agent
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: castai-agent
    app.kubernetes.io/version: v0.64.0
    helm.sh/chart: castai-agent-0.79.0
  name: castai-agent
  namespace: kube-system
  resourceVersion: "91193"
  uid: 7452e15c-1110-4f66-a810-28b43d1cd8a3
rules:
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - get
  - list
  - watch

```