### PR TITLE
[castai-pod-pinner] Use image v1.0.3

### DIFF
--- a/charts/castai-pod-pinner/Chart.yaml
+++ b/charts/castai-pod-pinner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-pod-pinner
 description: CAST AI Pod Pinning deployment chart.
 type: application
-version: 1.0.4
-appVersion: "v1.0.2"
+version: 1.0.5
+appVersion: "v1.0.3"
 dependencies:
   - name: castai-pod-pinner-ext
     version: 1.0.1

--- a/charts/castai-pod-pinner/README.md
+++ b/charts/castai-pod-pinner/README.md
@@ -1,6 +1,6 @@
 # castai-pod-pinner
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.3](https://img.shields.io/badge/AppVersion-v1.0.3-informational?style=flat-square)
 
 CAST AI Pod Pinning deployment chart.
 


### PR DESCRIPTION
Regular version upgrade to [pod pinner v1.0.3](https://github.com/castai/pod-pinner/releases/tag/v1.0.3).