### PR TITLE
[castai-agent] Microsoft CNAB API version 2022-12-01

### DIFF
--- a/cnab-config/castai-agent/mainTemplate.json
+++ b/cnab-config/castai-agent/mainTemplate.json
@@ -128,7 +128,7 @@
     {
       "type": "Microsoft.ContainerService/managedClusters",
       "condition" : "[parameters('createNewCluster')]",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2022-12-01",
       "name": "[parameters('clusterResourceName')]",
       "location": "[parameters('location')]",
       "dependsOn": [],
@@ -184,7 +184,7 @@
     },
     {
       "type": "Microsoft.KubernetesConfiguration/extensions",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2022-12-01",
       "name": "[variables('extensionResourceName')]",
       "properties": {
         "extensionType": "[variables('clusterExtensionTypeName')]",


### PR DESCRIPTION
I was getting following error in unrelated PR:
```
apiVersions Should Be Recent - Api versions must be the latest or under 2 years old (730 days) - API version 2022-11-01 of Microsoft.ContainerService/managedClusters is 734 days old
apiVersions Should Be Recent - Api versions must be the latest or under 2 years old (730 days) - API version 2022-11-01 of Microsoft.KubernetesConfiguration/extensions is 734 days old
```

So I want to bump this API version a little, hoping not much changed. Just to unblock changes in this repository. Afterwards, I'll move on to figure out whether this can be pushed further than that.