### PR TITLE
[castai-audit-logs-receiver] Fix tolerations location

### DIFF
--- a/charts/castai-audit-logs-receiver/Chart.yaml
+++ b/charts/castai-audit-logs-receiver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-audit-logs-receiver
 description: A Helm chart for CAST AI OpenTelemetry Collector.
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: "v0.4.1"

--- a/charts/castai-audit-logs-receiver/Chart.yaml
+++ b/charts/castai-audit-logs-receiver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-audit-logs-receiver
 description: A Helm chart for CAST AI OpenTelemetry Collector.
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "v0.4.0"

--- a/charts/castai-audit-logs-receiver/templates/statefulset.yaml
+++ b/charts/castai-audit-logs-receiver/templates/statefulset.yaml
@@ -35,24 +35,16 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.affinity }}
-          affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
           env:
             - name: MY_POD_IP
               valueFrom:
@@ -91,6 +83,14 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if .Values.configMap.create }}
         - name: {{ include "castai-audit-logs-receiver.lowercase_chartname" . }}-configmap


### PR DESCRIPTION
affinity, nodeSelector, and tolerations are part of the pod spec, not the container.