### PR TITLE
[castai-spot-handler] add support for clusterIDSecretRef

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.22.1
+version: 0.23.0
 appVersion: "v0.14.0"

--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.23.0
-appVersion: "v0.16.0"
+version: 0.24.0
+appVersion: "v0.15.0"

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -14,6 +14,7 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 | apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing access to the API The referenced secret must provide the token in .data["API_KEY"] |
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
 | castai.clusterID | string | `""` | CASTAI Cluster unique identifier. |
+| clusterIDSecretRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
 | castai.provider | string | `""` | Cloud provider (azure, gcp, aws). |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -14,7 +14,7 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 | apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing access to the API The referenced secret must provide the token in .data["API_KEY"] |
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
 | castai.clusterID | string | `""` | CASTAI Cluster unique identifier. |
-| clusterIDSecretRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
+| clusterIdSecretKeyRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
 | castai.provider | string | `""` | Cloud provider (azure, gcp, aws). |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -13,8 +13,9 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 | affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0] | string | `"windows"` |  |
 | apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing access to the API The referenced secret must provide the token in .data["API_KEY"] |
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
-| castai.clusterID | string | `""` | CASTAI Cluster unique identifier. |
-| clusterIdSecretKeyRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
+| castai.clusterID | string | `""` | CASTAI Cluster unique identifier. castai.clusterID and castai.clusterIdSecretKeyRef are mutually exclusive |
+| castai.clusterIdSecretKeyRef.key | string | `"CLUSTER_ID"` |  |
+| castai.clusterIdSecretKeyRef.name | string | `""` |  |
 | castai.provider | string | `""` | Cloud provider (azure, gcp, aws). |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -60,8 +60,8 @@ spec:
             - name: CLUSTER_ID
               value: {{ required "castai.clusterID must be provided" .Values.castai.clusterID | quote }}
           {{- else }}
-            {{- if not .Values.castai.clusterIDSecretRef }}
-              {{- fail "Either clusterID or clusterIDSecretRef must be provided." -}}
+            {{- if not .Values.castai.clusterIdSecretKeyRef.name }}
+              {{- fail "Either clusterID or clusterIdSecretKeyRef must be provided." -}}
             {{- end }}
           {{- end }}
             - name: PROVIDER
@@ -78,12 +78,13 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- if .Values.castai.clusterIDSecretRef }}
+          {{- if .Values.castai.clusterIdSecretKeyRef.name }}
             {{- if ne .Values.castai.clusterID "" }}
-            {{- fail "clusterID and clusterIDSecretRef are mutually exclusive" }}
+            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
             {{- end }}
             - secretRef:
-                name: {{ .Values.castai.clusterIDSecretRef }}
+                name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
+                key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
           {{- end }}
             - secretRef:
                 {{- if .Values.apiKeySecretRef }}

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -57,11 +57,20 @@ spec:
             - name: API_URL
               value: {{ required "castai.apiURL must be provided" .Values.castai.apiURL | quote }}
           {{- if .Values.castai.clusterID }}
+            {{- if ne .Values.castai.clusterIdSecretKeyRef.name "" }}
+            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
+            {{- end }}
             - name: CLUSTER_ID
               value: {{ required "castai.clusterID must be provided" .Values.castai.clusterID | quote }}
           {{- else }}
-            {{- if not .Values.castai.clusterIdSecretKeyRef.name }}
-              {{- fail "Either clusterID or clusterIdSecretKeyRef must be provided." -}}
+            {{- if .Values.castai.clusterIdSecretKeyRef.name }}
+            - name: CLUSTER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
+                  key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
+            {{- else}}
+            {{- fail "either clusterID or clusterIdSecretKeyRef must be provided" }}
             {{- end }}
           {{- end }}
             - name: PROVIDER
@@ -77,14 +86,6 @@ spec:
           {{- else if .Values.trustedCACertSecretRef }}
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
-          {{- end }}
-          {{- if .Values.castai.clusterIdSecretKeyRef.name }}
-            {{- if ne .Values.castai.clusterID "" }}
-            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
-            {{- end }}
-            - secretRef:
-                name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
-                key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
           {{- end }}
             - secretRef:
                 {{- if .Values.apiKeySecretRef }}

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -56,8 +56,14 @@ spec:
                   fieldPath: spec.nodeName
             - name: API_URL
               value: {{ required "castai.apiURL must be provided" .Values.castai.apiURL | quote }}
+          {{- if .Values.castai.clusterID }}
             - name: CLUSTER_ID
               value: {{ required "castai.clusterID must be provided" .Values.castai.clusterID | quote }}
+          {{- else }}
+            {{- if not .Values.castai.clusterIDSecretRef }}
+              {{- fail "Either clusterID or clusterIDSecretRef must be provided." -}}
+            {{- end }}
+          {{- end }}
             - name: PROVIDER
               value: {{ required "castai.provider must be provided" .Values.castai.provider | quote }}
             {{- range $k, $v := .Values.additionalEnv }}
@@ -71,6 +77,13 @@ spec:
           {{- else if .Values.trustedCACertSecretRef }}
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
+          {{- end }}
+          {{- if .Values.castai.clusterIDSecretRef }}
+            {{- if ne .Values.castai.clusterID "" }}
+            {{- fail "clusterID and clusterIDSecretRef are mutually exclusive" }}
+            {{- end }}
+            - secretRef:
+                name: {{ .Values.castai.clusterIDSecretRef }}
           {{- end }}
             - secretRef:
                 {{- if .Values.apiKeySecretRef }}

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -31,7 +31,11 @@ castai:
   apiURL: "https://api.cast.ai"
 
   # castai.clusterID -- CASTAI Cluster unique identifier.
+  # castai.clusterID and castai.clusterIDSecretRef are mutually exclusive
   clusterID: ""
+  # clusterIDSecretRef -- Name of secret with ClusterID
+  # The referenced secret must provide the token in .data["CLUSTER_ID"]
+  clusterIDSecretRef: ""
 
   # castai.provider -- Cloud provider (azure, gcp, aws).
   provider: ""

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -31,11 +31,13 @@ castai:
   apiURL: "https://api.cast.ai"
 
   # castai.clusterID -- CASTAI Cluster unique identifier.
-  # castai.clusterID and castai.clusterIDSecretRef are mutually exclusive
+  # castai.clusterID and castai.clusterIdSecretKeyRef are mutually exclusive
   clusterID: ""
-  # clusterIDSecretRef -- Name of secret with ClusterID
-  # The referenced secret must provide the token in .data["CLUSTER_ID"]
-  clusterIDSecretRef: ""
+  # clusterIdSecretKeyRef -- Name of secret with ClusterID
+  # The referenced secret must provide the ClusterID in .data[<<.Values.castai.clusterIdSecretKeyRef.key>>]
+  clusterIdSecretKeyRef:
+    name: ""
+    key: "CLUSTER_ID"
 
   # castai.provider -- Cloud provider (azure, gcp, aws).
   provider: ""


### PR DESCRIPTION
Following the best practices of GitOps should allow minimum/no manual intervention required from the developers. When using crossplane to deploy the castai cluster resources, a secret containing the value of clusterID is stored in the cluster. These changes allow reading the value of the field "clusterID" from the secret instead of someone having to manually add it in the values files.