### PR TITLE
[castai-cluster-controller] add support for clusterIDSecretRef

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.74.4
+version: 0.75.0
 appVersion: "v0.54.6"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/README.md
+++ b/charts/castai-cluster-controller/README.md
@@ -21,6 +21,7 @@ Cluster controller is responsible for handling certain Kubernetes actions such a
 | castai.apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing agent access to the API apiKey and apiKeySecretRef are mutually exclusive The referenced secret must provide the token in .data["API_KEY"]. |
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
 | castai.clusterID | string | `""` | CASTAI Cluster unique identifier. |
+| clusterIDSecretRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | createNamespace | bool | `false` | By default namespace is expected to be created by castai-agent. |

--- a/charts/castai-cluster-controller/README.md
+++ b/charts/castai-cluster-controller/README.md
@@ -16,12 +16,11 @@ Cluster controller is responsible for handling certain Kubernetes actions such a
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"NotIn","values":["windows"]}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["castai-cluster-controller"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Pod affinity rules. Don't schedule application on windows node Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | autoscaling | object | `{"enabled":true}` | Settings for managing autoscaling features. |
 | autoscaling.enabled | bool | `true` | Adds permissions to manage autoscaling. |
-| castai | object | `{"apiKey":"","apiKeySecretRef":"","apiURL":"https://api.cast.ai","clusterID":""}` | CAST AI API configuration. |
+| castai | object | `{"apiKey":"","apiKeySecretRef":"","apiURL":"https://api.cast.ai","clusterID":"","clusterIdSecretKeyRef":{"key":"CLUSTER_ID","name":""}}` | CAST AI API configuration. |
 | castai.apiKey | string | `""` | Token to be used for authorizing agent access to the CASTAI API. |
 | castai.apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing agent access to the API apiKey and apiKeySecretRef are mutually exclusive The referenced secret must provide the token in .data["API_KEY"]. |
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
-| castai.clusterID | string | `""` | CASTAI Cluster unique identifier. |
-| castai.clusterIdSecretKeyRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
+| castai.clusterID | string | `""` | CASTAI Cluster unique identifier. clusterID and clusterIdSecretKeyRef are mutually exclusive |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | createNamespace | bool | `false` | By default namespace is expected to be created by castai-agent. |

--- a/charts/castai-cluster-controller/README.md
+++ b/charts/castai-cluster-controller/README.md
@@ -21,7 +21,7 @@ Cluster controller is responsible for handling certain Kubernetes actions such a
 | castai.apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing agent access to the API apiKey and apiKeySecretRef are mutually exclusive The referenced secret must provide the token in .data["API_KEY"]. |
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
 | castai.clusterID | string | `""` | CASTAI Cluster unique identifier. |
-| clusterIDSecretRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
+| clusterIdSecretKeyRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | createNamespace | bool | `false` | By default namespace is expected to be created by castai-agent. |

--- a/charts/castai-cluster-controller/README.md
+++ b/charts/castai-cluster-controller/README.md
@@ -21,7 +21,7 @@ Cluster controller is responsible for handling certain Kubernetes actions such a
 | castai.apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing agent access to the API apiKey and apiKeySecretRef are mutually exclusive The referenced secret must provide the token in .data["API_KEY"]. |
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
 | castai.clusterID | string | `""` | CASTAI Cluster unique identifier. |
-| clusterIdSecretKeyRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
+| castai.clusterIdSecretKeyRef | string | `""` | Name of secret with Cluster ID to be used as CASTAI Cluster unique identifier 
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | createNamespace | bool | `false` | By default namespace is expected to be created by castai-agent. |

--- a/charts/castai-cluster-controller/templates/config.yaml
+++ b/charts/castai-cluster-controller/templates/config.yaml
@@ -18,6 +18,6 @@ data:
 
   {{- if .Values.clusterID }}
   CLUSTER_ID: {{ required "clusterID must be provided" .Values.clusterID | quote }}
-  {{- else }}
+  {{- else if .Values.castai.clusterID }}
   CLUSTER_ID: {{ required "castai.clusterID must be provided" .Values.castai.clusterID | quote }}
   {{- end }}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -124,6 +124,17 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
+          {{- if .Values.castai.clusterIDSecretRef }}
+            - secretRef:             
+                {{- if and (ne .Values.castai.clusterID "") (ne .Values.clusterID "") }}
+                {{- fail "clusterID and clusterIDSecretRef are mutually exclusive" }}
+                {{- end }}
+                name: {{ required "clusterID or clusterIDSecretRef must be provided" .Values.castai.clusterIDSecretRef }}
+          {{- else }}
+            {{- if not .Values.castai.clusterID }}
+            {{- fail "either clusterID or clusterIDSecretRef must be provided" }}
+            {{- end }}
+          {{- end }}
             - secretRef:
                 {{- if or .Values.apiKey .Values.castai.apiKey }}
                   {{- if ne .Values.castai.apiKeySecretRef "" }}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -116,6 +116,20 @@ spec:
             - name: {{ $k }}
               value: "{{ $v }}"
           {{- end }}
+          {{- if .Values.castai.clusterIdSecretKeyRef.name }}          
+            {{- if and (ne .Values.castai.clusterID "") (ne .Values.clusterID "") }}
+            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
+            {{- end }}
+            - name: CLUSTER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "clusterID or clusterIdSecretKeyRef must be provided" .Values.castai.clusterIdSecretKeyRef.name }}
+                  key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
+          {{- else }}
+            {{- if not .Values.castai.clusterID }}
+            {{- fail "either clusterID or clusterIdSecretKeyRef must be provided" }}
+            {{- end }}
+          {{- end }}
           envFrom:
           {{- if .Values.trustedCACert }}
             - secretRef:
@@ -123,18 +137,6 @@ spec:
           {{- else if .Values.trustedCACertSecretRef }}
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
-          {{- end }}
-          {{- if .Values.castai.clusterIdSecretKeyRef.name }}
-            - secretRef:             
-                {{- if and (ne .Values.castai.clusterID "") (ne .Values.clusterID "") }}
-                {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
-                {{- end }}
-                name: {{ required "clusterID or clusterIdSecretKeyRef must be provided" .Values.castai.clusterIdSecretKeyRef.name }}
-                key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
-          {{- else }}
-            {{- if not .Values.castai.clusterID }}
-            {{- fail "either clusterID or clusterIdSecretKeyRef must be provided" }}
-            {{- end }}
           {{- end }}
             - secretRef:
                 {{- if or .Values.apiKey .Values.castai.apiKey }}
@@ -211,6 +213,20 @@ spec:
           {{- range $k, $v := .Values.additionalEnv }}
             - name: {{ $k }}
               value: "{{ $v }}"
+          {{- end }}
+          {{- if .Values.castai.clusterIdSecretKeyRef.name }}          
+            {{- if and (ne .Values.castai.clusterID "") (ne .Values.clusterID "") }}
+            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
+            {{- end }}
+            - name: CLUSTER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "clusterID or clusterIdSecretKeyRef must be provided" .Values.castai.clusterIdSecretKeyRef.name }}
+                  key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
+          {{- else }}
+            {{- if not .Values.castai.clusterID }}
+            {{- fail "either clusterID or clusterIdSecretKeyRef must be provided" }}
+            {{- end }}
           {{- end }}
           envFrom:
           {{- if .Values.trustedCACert }}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -124,15 +124,16 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- if .Values.castai.clusterIDSecretRef }}
+          {{- if .Values.castai.clusterIdSecretKeyRef.name }}
             - secretRef:             
                 {{- if and (ne .Values.castai.clusterID "") (ne .Values.clusterID "") }}
-                {{- fail "clusterID and clusterIDSecretRef are mutually exclusive" }}
+                {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
                 {{- end }}
-                name: {{ required "clusterID or clusterIDSecretRef must be provided" .Values.castai.clusterIDSecretRef }}
+                name: {{ required "clusterID or clusterIdSecretKeyRef must be provided" .Values.castai.clusterIdSecretKeyRef.name }}
+                key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
           {{- else }}
             {{- if not .Values.castai.clusterID }}
-            {{- fail "either clusterID or clusterIDSecretRef must be provided" }}
+            {{- fail "either clusterID or clusterIdSecretKeyRef must be provided" }}
             {{- end }}
           {{- end }}
             - secretRef:

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -56,11 +56,13 @@ castai:
   apiURL: "https://api.cast.ai"
 
   # castai.clusterID -- CASTAI Cluster unique identifier.
-  # clusterID and clusterIDSecretRef are mutually exclusive
+  # clusterID and clusterIdSecretKeyRef are mutually exclusive
   clusterID: ""
-  # clusterIDSecretRef -- Name of secret with ClusterID
-  # The referenced secret must provide the token in .data["CLUSTER_ID"]
-  clusterIDSecretRef: ""
+  # clusterIdSecretKeyRef -- Name and Key of secret with ClusterID
+  # The referenced secret must provide the ClusterID in .data[<<.Values.castai.clusterIdSecretKeyRef.key>>]
+  clusterIdSecretKeyRef:
+    name: "test"
+    key: "CLUSTER_ID"
 
 # podAnnotations -- Annotations added to each pod.
 podAnnotations: {}

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -56,7 +56,11 @@ castai:
   apiURL: "https://api.cast.ai"
 
   # castai.clusterID -- CASTAI Cluster unique identifier.
+  # clusterID and clusterIDSecretRef are mutually exclusive
   clusterID: ""
+  # clusterIDSecretRef -- Name of secret with ClusterID
+  # The referenced secret must provide the token in .data["CLUSTER_ID"]
+  clusterIDSecretRef: ""
 
 # podAnnotations -- Annotations added to each pod.
 podAnnotations: {}

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -61,7 +61,7 @@ castai:
   # clusterIdSecretKeyRef -- Name and Key of secret with ClusterID
   # The referenced secret must provide the ClusterID in .data[<<.Values.castai.clusterIdSecretKeyRef.key>>]
   clusterIdSecretKeyRef:
-    name: "test"
+    name: ""
     key: "CLUSTER_ID"
 
 # podAnnotations -- Annotations added to each pod.


### PR DESCRIPTION
Following the best practices of GitOps should allow minimum/no manual intervention required from the developers. When using crossplane to deploy the castai cluster resources, a secret containing the value of clusterID is stored in the cluster. These changes allow reading the value of the field "clusterID" from the secret instead of someone having to manually add it in the values files.