### PR TITLE
Feature/add cluster id secret ref egressd

### DIFF
--- a/charts/egressd/templates/exporter/deployment.yaml
+++ b/charts/egressd/templates/exporter/deployment.yaml
@@ -61,6 +61,21 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.castai.clusterID }}
+          {{- if ne .Values.castai.clusterIDSecretRef "" }}
+          {{- fail "clusterID and clusterIDSecretRef are mutually exclusive" }}
+          {{- end }}
+        - name: CLUSTER_ID
+          value: {{ .Values.castai.clusterID | quote }}
+        {{- else }}
+          {- if not .Values.castai.clusterIDSecretRef }}
+          {{- fail "either clusterID or clusterIDSecretRef should be passed" }}
+          {{- end }}       
+        valueFrom:
+            secretKeyRef:
+              name: {{ .Values.castai.clusterIDSecretRef }}
+              key: CLUSTER_ID
+        {{- end }}
         {{- if or .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
         - name: API_KEY
           valueFrom:

--- a/charts/egressd/templates/exporter/deployment.yaml
+++ b/charts/egressd/templates/exporter/deployment.yaml
@@ -62,19 +62,20 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         {{- if .Values.castai.clusterID }}
-          {{- if ne .Values.castai.clusterIDSecretRef "" }}
-          {{- fail "clusterID and clusterIDSecretRef are mutually exclusive" }}
-          {{- end }}
+        {{- if ne .Values.castai.clusterIDSecretRef "" }}
+        {{- fail "clusterID and clusterIDSecretRef are mutually exclusive" }}
+        {{- end }}
         - name: CLUSTER_ID
           value: {{ .Values.castai.clusterID | quote }}
         {{- else }}
-          {- if not .Values.castai.clusterIDSecretRef }}
-          {{- fail "either clusterID or clusterIDSecretRef should be passed" }}
-          {{- end }}       
-        valueFrom:
+        {{- if not .Values.castai.clusterIDSecretRef }}
+        {{- fail "either clusterID or clusterIDSecretRef should be passed" }}
+        {{- end }}
+        - name: CLUSTER_ID     
+          valueFrom:
             secretKeyRef:
               name: {{ .Values.castai.clusterIDSecretRef }}
-              key: CLUSTER_ID
+              key: CLUSTER_ID       
         {{- end }}
         {{- if or .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
         - name: API_KEY
@@ -84,6 +85,9 @@ spec:
                 {{- fail "`collector.extraArgs.send-traffic-delta` should be set to `true` when CAST AI is used as sink" }}
               {{- else }}
                 {{- if .Values.castai.apiKey }}
+                {{- if ne .Values.castai.apiKeySecretRef "" }}
+                {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
+                {{- end }}
                 name: "{{- include "egressd.fullname" . }}"
                 key: API_KEY
                 {{- else if  .Values.castai.apiKeySecretRef }}

--- a/charts/egressd/values.yaml
+++ b/charts/egressd/values.yaml
@@ -15,7 +15,11 @@ castai:
   apiURL: "https://api.cast.ai"
 
   # CASTAI Cluster unique identifier.
+  # clusterID and clusterIDSecretRef are mutually exclusive
   clusterID: ""
+  # clusterIDSecretRef -- Name of secret with ClusterID
+  # The referenced secret must provide the token in .data["CLUSTER_ID"]
+  clusterIDSecretRef: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -126,7 +130,7 @@ exporter:
     {{- if or .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
       castai:
         http:
-          url: "{{.Values.castai.apiURL}}/v1/kubernetes/clusters/{{.Values.castai.clusterID}}/egressd-metrics"
+          url: "{{.Values.castai.apiURL}}/v1/kubernetes/clusters/${CLUSTER_ID}/egressd-metrics"
           compression: gzip
           encoding: protobuf
           method: POST


### PR DESCRIPTION
Following the best practices of GitOps should allow minimum/no manual intervention required from the developers. When using crossplane to deploy the castai cluster resources, a secret containing the value of clusterID is stored in the cluster. These changes allow reading the value of the field "clusterID" from the secret instead of someone having to manually add it in the values files.