### PR TITLE
[castai-evictor] feat(evictor): expose LIVE migration settings

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.69
+version: 0.30.70
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -37,6 +37,7 @@ Cluster utilization defragmentation tool
 | imagePullSecrets | list | `[]` |  |
 | leaderElection | object | `{"enabled":true}` | Specifies leader election parameters. |
 | leaderElection.enabled | bool | `true` | Whether to enable leader election. |
+| liveMigration | object | `{"enabled":false}` | Specifies LIVE migration settings. This options assumes that the CAST AI LIVE components are already installed in the cluster. |
 | managedByCASTAI | bool | `true` | Specifies whether the Evictor was installed using mothership and is automatically updated by CAST AI. Alternative scenarios are, when CAST AI is not managing charts, and customers' are install them with Argo CD/Terraform or something else. |
 | maxNodesToEvictPerCycle | int | `20` | Specifies the max nodes evictor can evict in a single cycle. |
 | nameOverride | string | `""` |  |

--- a/charts/castai-evictor/templates/clusterrole.yaml
+++ b/charts/castai-evictor/templates/clusterrole.yaml
@@ -60,8 +60,8 @@ rules:
   # ------------------------------------------------
   - apiGroups:
       - ""
-    resources: ["pods/eviction"]
-    verbs: ["create"]
+    resources: [ "pods/eviction" ]
+    verbs: [ "create" ]
   # ------------------------------------------------
   # Leader election
   # ------------------------------------------------
@@ -75,3 +75,18 @@ rules:
       - list
       - watch
       - update
+  {{- if .Values.liveMigration.enabled }}
+  # ------------------------------------------------
+  # Live Migration
+  # ------------------------------------------------
+  - apiGroups:
+      - cast.ai
+    resources:
+      - livepodextensions
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  {{- end }}

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               value: {{ .Values.dryRun | quote }}
             - name: AGGRESSIVE_MODE
               value: {{ .Values.aggressiveMode | quote }}
-            - name: TRY_LIVE_MIGRATION
+            - name: LIVE_MIGRATION_ENABLED
               value: {{ .Values.liveMigration.enabled | quote }}
             - name: SCOPED_MODE
               value: {{ .Values.scopedMode | quote }}

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
               value: {{ .Values.dryRun | quote }}
             - name: AGGRESSIVE_MODE
               value: {{ .Values.aggressiveMode | quote }}
+            - name: TRY_LIVE_MIGRATION
+              value: {{ .Values.liveMigration.enabled | quote }}
             - name: SCOPED_MODE
               value: {{ .Values.scopedMode | quote }}
             - name: NODE_GRACE_PERIOD_MINUTES

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -40,6 +40,15 @@ maxNodesToEvictPerCycle: 20
 # frequency of the evictor's find-and-drain operations.
 cycleInterval: 1m
 
+# liveMigration -- Specifies LIVE migration settings.
+# This options assumes that the CAST AI LIVE components are already installed in the cluster.
+liveMigration:
+  # If true, Evictor will consider using LIVE migrations to move workloads that prevent a node from being evicted
+  # to another node without interrupting these workloads.
+  # Evictor will only consider LIVE migrations for workloads that explicitly request it.
+  # as long as they can be scheduled somewhere else.
+  enabled: false
+
 # leaderElection -- Specifies leader election parameters.
 leaderElection:
   # leaderElection.enabled -- Whether to enable leader election.


### PR DESCRIPTION
This commit exposes settings that control LIVE migration in the Evictor Helm chart.

The settings let the user instruct Evictor to try or not try using LIVE migrations when evicting nodes.