### PR TITLE
[castai-pod-mutator] Update chart and app versions to 0.0.9 and v0.0.5

### DIFF
--- a/charts/castai-pod-mutator/Chart.yaml
+++ b/charts/castai-pod-mutator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-pod-mutator
 description: CAST AI Pod Mutator.
 type: application
-version: 0.0.8
-appVersion: "v0.0.4"
+version: 0.0.9
+appVersion: "v0.0.5"

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -1,6 +1,6 @@
 # castai-pod-mutator
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.4](https://img.shields.io/badge/AppVersion-v0.0.4-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.5](https://img.shields.io/badge/AppVersion-v0.0.5-informational?style=flat-square)
 
 CAST AI Pod Mutator.
 


### PR DESCRIPTION
Bump the chart version to 0.0.9 and the app version to v0.0.5 in both the Chart.yaml file and the README.md badge. This ensures consistency and reflects the latest updates.