### PR TITLE
[castai-agent] moving leader election to role instead of clusterrole

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.89.0
+version: 0.90.0
 appVersion: "v0.75.0"

--- a/charts/castai-agent/templates/rbac.yaml
+++ b/charts/castai-agent/templates/rbac.yaml
@@ -90,16 +90,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "coordination.k8s.io"
-    resources:
-      - leases
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
       - "metrics.k8s.io"
     resources:
       - pods
@@ -236,6 +226,19 @@ metadata:
     {{- include "castai-agent.annotations" . | nindent 4 }}
   {{- end }}
 rules:
+  # ---
+  # Required for lease election
+  # ---
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
   # ---
   # Required for cost savings estimation features.
   # ---


### PR DESCRIPTION
I don't think that leases need to be scoped at the clusterrole level and instead it can be scoped at the role them in the castai-agent ns