### PR TITLE
[castai-agent] fix: Azure CNAB pipeline

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -46,7 +46,7 @@ jobs:
         run: ct lint --debug --config ct.yaml
 
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3.12.0
+        uses: docker://github/super-linter:v7.2.1
         env:
           FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt|lint-test\.yaml).*
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: docker://github/super-linter:v3.12.0
         env:
           # Do not lint cnab-config/castai-agent/mainTemplate.json until super-linter is upgraded to recent version.
-          # v3.12.0 does not support Azure ARM API of newer than 2022-05-01.
+          # v3.12.0 does not support Azure ARM API newer than 2022-05-01.
           FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt|lint-test\.yaml|mainTemplate\.json).*
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_KUBERNETES_KUBEVAL: false

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -46,7 +46,7 @@ jobs:
         run: ct lint --debug --config ct.yaml
 
       - name: Lint Code Base
-        uses: docker://github/super-linter:v5.1.0
+        uses: docker://ghcr.io/super-linter/super-linter:v7.2.1
         env:
           FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt|lint-test\.yaml).*
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -46,7 +46,7 @@ jobs:
         run: ct lint --debug --config ct.yaml
 
       - name: Lint Code Base
-        uses: docker://ghcr.io/super-linter/super-linter:v7.2.1
+        uses: docker://github/super-linter:v3.12.0
         env:
           FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt|lint-test\.yaml).*
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -48,7 +48,9 @@ jobs:
       - name: Lint Code Base
         uses: docker://github/super-linter:v3.12.0
         env:
-          FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt|lint-test\.yaml).*
+          # Do not lint cnab-config/castai-agent/mainTemplate.json until super-linter is upgraded to recent version.
+          # v3.12.0 does not support Azure ARM API of newer than 2022-05-01.
+          FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt|lint-test\.yaml|mainTemplate\.json).*
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_KUBERNETES_KUBEVAL: false
           VALIDATE_YAML: false

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -46,7 +46,7 @@ jobs:
         run: ct lint --debug --config ct.yaml
 
       - name: Lint Code Base
-        uses: docker://github/super-linter:v7.2.0
+        uses: docker://github/super-linter:v5.1.0
         env:
           FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt|lint-test\.yaml).*
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -46,7 +46,7 @@ jobs:
         run: ct lint --debug --config ct.yaml
 
       - name: Lint Code Base
-        uses: docker://github/super-linter:v7.2.1
+        uses: docker://github/super-linter:v7.2.0
         env:
           FILTER_REGEX_EXCLUDE: .*(README\.md|Chart\.yaml|NOTES.txt|lint-test\.yaml).*
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -33,3 +33,8 @@ jobs:
         run: scripts/validate-pr.sh
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+
+      - name: Verify CNAB package
+        run: scripts/verify-cnab-package.sh
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -3,4 +3,4 @@ name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
 version: 0.91.0
-appVersion: "v0.75.0"
+appVersion: "v0.76.1"

--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -3,4 +3,4 @@ name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
 version: 0.91.0
-appVersion: "v0.76.0"
+appVersion: "v0.75.0"

--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.91.0
-appVersion: "v0.76.1"
+version: 0.91.1
+appVersion: "v0.76.0"

--- a/cnab-config/castai-agent/mainTemplate.json
+++ b/cnab-config/castai-agent/mainTemplate.json
@@ -128,7 +128,7 @@
     {
       "type": "Microsoft.ContainerService/managedClusters",
       "condition" : "[parameters('createNewCluster')]",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2023-05-01",
       "name": "[parameters('clusterResourceName')]",
       "location": "[parameters('location')]",
       "dependsOn": [],
@@ -184,7 +184,7 @@
     },
     {
       "type": "Microsoft.KubernetesConfiguration/extensions",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2023-05-01",
       "name": "[variables('extensionResourceName')]",
       "properties": {
         "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/scripts/verify-cnab-package.sh
+++ b/scripts/verify-cnab-package.sh
@@ -75,6 +75,7 @@ main() {
 
     echo "Verifying CNAB package.."
     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD/.cpa-stage/$chartName":/data  "$PACKAGING_IMAGE" /bin/bash -c 'cd /data ; cpa verify --telemetryOptOut'
+
 }
 
 main

--- a/scripts/verify-cnab-package.sh
+++ b/scripts/verify-cnab-package.sh
@@ -75,7 +75,6 @@ main() {
 
     echo "Verifying CNAB package.."
     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD/.cpa-stage/$chartName":/data  "$PACKAGING_IMAGE" /bin/bash -c 'cd /data ; cpa verify --telemetryOptOut'
-
 }
 
 main


### PR DESCRIPTION
Azure Resource Manager (ARM) templates were using a deprecated API version. 
Hence, the Cloud Native Application Bundle (CNAB) could not be built and released to Azure marketplace.