### PR TITLE
[gpu-metrics-exporter] add support for clusterIDSecretRef #622

### DIFF
--- a/charts/gpu-metrics-exporter/Chart.yaml
+++ b/charts/gpu-metrics-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gpu-metrics-exporter
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "0.1.17"

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -88,6 +88,16 @@ spec:
                 secretKeyRef:
                   name: {{ include "gpu-metrics-exporter.fullname" . }}
                   key: API_KEY
+          {{- if .Values.castai.clusterIdSecretKeyRef.name }}
+            {{- if ne .Values.castai.clusterId "" }}
+            {{- fail "clusterId and clusterIdSecretKeyRef are mutually exclusive" }}
+            {{- end }}
+            - name: "CLUSTER_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
+                  key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
+          {{- end }}
           {{- if .Values.dcgmExporter.enabled }}
             - name: "DCGM_HOST"
               value: "localhost"

--- a/charts/gpu-metrics-exporter/values-eks.yaml
+++ b/charts/gpu-metrics-exporter/values-eks.yaml
@@ -1,0 +1,1 @@
+provider: eks

--- a/charts/gpu-metrics-exporter/values.yaml
+++ b/charts/gpu-metrics-exporter/values.yaml
@@ -9,6 +9,9 @@ serviceAccount:
 castai:
   apiKey: ""
   clusterId: ""
+  clusterIdSecretKeyRef:
+    name: ""
+    key: "CLUSTER_ID"
 
 gpuMetricsExporter:
   image:


### PR DESCRIPTION
Following the best practices of GitOps should allow minimum/no manual intervention required from the developers. When using crossplane to deploy the castai cluster resources, a secret containing the value of clusterID is stored in the cluster. These changes allow reading the value of the field "clusterID" from the secret instead of someone having to manually add it in the values files.