### PR TITLE
[castai-evictor] moving leader election to role

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.31.21
+version: 0.31.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/templates/clusterrole.yaml
+++ b/charts/castai-evictor/templates/clusterrole.yaml
@@ -62,19 +62,6 @@ rules:
       - ""
     resources: [ "pods/eviction" ]
     verbs: [ "create" ]
-  # ------------------------------------------------
-  # Leader election
-  # ------------------------------------------------
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
   {{- if .Values.liveMigration.enabled }}
   # ------------------------------------------------
   # Live Migration

--- a/charts/castai-evictor/templates/rbac.yaml
+++ b/charts/castai-evictor/templates/rbac.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.clusterVPA.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -12,6 +11,20 @@ metadata:
     {{- include "evictor.annotations" . | nindent 4 }}
   {{- end }}
 rules:
+  # ------------------------------------------------
+  # Leader election
+  # ------------------------------------------------
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  {{- if .Values.clusterVPA.enabled }}
   # ---
   # Required for proportional vertical cluster autoscaler to adjust evictor requests/limits.
   # ---
@@ -23,6 +36,7 @@ rules:
       - {{ include "evictor.fullname" . }}
     verbs:
       - patch
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -43,4 +57,3 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "evictor.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}


### PR DESCRIPTION
As evictor and the VPA has the same service account role. I moved the the if statement down so it just adds the rbac if VPA is enabled and moved the leaderElection