### PR TITLE
Add repos that are required by the Temporal helm chart

### DIFF
--- a/.github/workflows/release-cnab.yaml
+++ b/.github/workflows/release-cnab.yaml
@@ -18,6 +18,10 @@ jobs:
       - name: Add dependencies
         run: |
           helm repo add vector https://helm.vector.dev
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add incubator https://charts.helm.sh/incubator
+          helm repo add elasticsearch https://helm.elastic.co  
+          helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Install Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,10 @@ jobs:
       - name: Add dependencies
         run: |
           helm repo add vector https://helm.vector.dev
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add incubator https://charts.helm.sh/incubator
+          helm repo add elasticsearch https://helm.elastic.co  
+          helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Install Helm
         uses: azure/setup-helm@v1


### PR DESCRIPTION
We want to publish a modified helm chart for Temporal
but it requires a few repos to be added to helm so the Release
step can succeed.

We need to manually add repos for deps due to bug in https://github.com/helm/chart-releaser/issues/135