### PR TITLE
[castai-cluster-controller] v0.78.5 (app v0.54.9)

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.78.4
-appVersion: "v0.54.8"
+version: 0.78.5
+appVersion: "v0.54.9"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:


### PR DESCRIPTION
Corresponds to app release [v0.54.9](https://github.com/castai/cluster-controller/releases/tag/v0.54.9).