### PR TITLE
[castai-pod-pinner] bump pod pinner to v1.2.4

### DIFF
--- a/charts/castai-pod-pinner/Chart.yaml
+++ b/charts/castai-pod-pinner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-pod-pinner
 description: CAST AI Pod Pinning deployment chart.
 type: application
-version: 1.1.2
-appVersion: "v1.2.3"
+version: 1.1.3
+appVersion: "v1.2.4"
 dependencies:
   - name: castai-pod-pinner-ext
     version: 1.0.1

--- a/charts/castai-pod-pinner/README.md
+++ b/charts/castai-pod-pinner/README.md
@@ -1,6 +1,6 @@
 # castai-pod-pinner
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.3](https://img.shields.io/badge/AppVersion-v1.2.3-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.4](https://img.shields.io/badge/AppVersion-v1.2.4-informational?style=flat-square)
 
 CAST AI Pod Pinning deployment chart.
 


### PR DESCRIPTION
release: https://github.com/castai/pod-pinner/releases/tag/v1.2.4