### PR TITLE
[castai-audit-logs-receiver] bump to latest version

### DIFF
--- a/charts/castai-audit-logs-receiver/Chart.yaml
+++ b/charts/castai-audit-logs-receiver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-audit-logs-receiver
 description: A Helm chart for CAST AI OpenTelemetry Collector.
 type: application
-version: 0.5.0
-appVersion: "v0.5.0"
+version: 0.5.1
+appVersion: "v0.5.1"


### PR DESCRIPTION
* New version includes updated go-resty library
