### PR TITLE
[gpu-metrics-exporter] add support for apiKeySecretRef

### DIFF
--- a/charts/gpu-metrics-exporter/Chart.yaml
+++ b/charts/gpu-metrics-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gpu-metrics-exporter
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.18
+version: 0.1.19
 appVersion: "0.1.17"

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -86,7 +86,11 @@ spec:
             - name: "API_KEY"
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.castai.apiKeySecretRef }}
+                  name: {{ .Values.castai.apiKeySecretRef }}
+                  {{- else }}
                   name: {{ include "gpu-metrics-exporter.fullname" . }}
+                  {{- end }}
                   key: API_KEY
           {{- if .Values.castai.clusterIdSecretKeyRef.name }}
             {{- if ne .Values.castai.clusterId "" }}

--- a/charts/gpu-metrics-exporter/templates/secret.yaml
+++ b/charts/gpu-metrics-exporter/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.castai.apiKeySecretRef "" }}
 ---
 apiVersion: v1
 kind: Secret
@@ -11,4 +12,5 @@ data:
   API_KEY: {{ .Values.castai.apiKey | b64enc | quote }}
 {{- else }}
   API_KEY: ""
+{{- end }}
 {{- end }}

--- a/charts/gpu-metrics-exporter/values.yaml
+++ b/charts/gpu-metrics-exporter/values.yaml
@@ -9,6 +9,7 @@ serviceAccount:
 
 castai:
   apiKey: ""
+  apiKeySecretRef: ""
   clusterId: ""
   clusterIdSecretKeyRef:
     name: ""


### PR DESCRIPTION
The change allows users to use a pre-made secret to store the api key.  This matches the ability of several other castai helm charts.