### PR TITLE
[castai-agent] avoid confusion on gke as cloud provider in values

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.97.0
+version: 0.97.1
 appVersion: "v0.83.0"

--- a/charts/castai-agent/README.md
+++ b/charts/castai-agent/README.md
@@ -45,7 +45,7 @@ CAST AI agent deployment chart.
 | podLabels | object | `{}` | Labels to be added to agent pods. |
 | priorityClass.enabled | bool | `true` |  |
 | priorityClass.name | string | `"system-cluster-critical"` |  |
-| provider | string | `""` | Name of the Kubernetes service provider one of: "eks", "gks", "aks", "kops", "anywhere". |
+| provider | string | `""` | Name of the Kubernetes service provider one of: "eks", "gke", "aks", "kops", "anywhere". |
 | rbac.configmapsReadAccessNamespaces | list | `["kube-system"]` | Namespaces to be granted access to the castai-agent for configmaps read access. |
 | rbac.enabled | bool | `true` | Specifies whether a Clusterrole should be created. |
 | replicaCount | int | `2` |  |

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -91,7 +91,7 @@ trustedCACert: ""
 trustedCACertSecretRef: ""
 
 # provider -- Name of the Kubernetes service provider
-# one of: "eks", "gks", "aks", "kops", "anywhere".
+# one of: "eks", "gke", "aks", "kops", "anywhere".
 provider: ""
 
 # allowReadIngress -- Allow to read ingress resources. Needed for k8s security and compliance.


### PR DESCRIPTION
This PR will avoid the confusion of using GKS instead of GKE as the provider for castai-agent values.
