### PR TITLE
[castai-audit-logs-receiver] add an option for clusterIdSecretKeyRef

### DIFF
--- a/charts/castai-audit-logs-receiver/Chart.yaml
+++ b/charts/castai-audit-logs-receiver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-audit-logs-receiver
 description: A Helm chart for CAST AI OpenTelemetry Collector.
 type: application
-version: 0.5.1
+version: 0.6.0
 appVersion: "v0.5.1"

--- a/charts/castai-audit-logs-receiver/README.md
+++ b/charts/castai-audit-logs-receiver/README.md
@@ -9,6 +9,9 @@ A Helm chart for CAST AI OpenTelemetry Collector.
 | affinity | object | `{}` |  |
 | castai.apiKey | string | `""` | Token to be used for authorizing access to the CASTAI API. |
 | castai.apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing access to the API. apiKey and apiKeySecretRef are mutually exclusive. The referenced secret must provide the token in .data["CASTAI_API_KEY"]. |
+| castai.clusterID | string | `""` | Optional clusterid to filter the logs to scrape. |
+| castai.clusterIdSecretKeyRef.name | string | `""` | Name of the reference secret that contains the cluster id. |
+| castai.clusterIdSecretKeyRef.key | string | `"CASTAI_CLUSTER_ID"` | Key of the secret with a base64 encoded cluster id.
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
@@ -18,7 +21,7 @@ A Helm chart for CAST AI OpenTelemetry Collector.
 | config.extensions.health_check.endpoint | string | `"0.0.0.0:13133"` |  |
 | config.receivers.castai_audit_logs.api.key | string | `"${env:CASTAI_API_KEY}"` |  |
 | config.receivers.castai_audit_logs.api.url | string | `"${env:CASTAI_API_URL}"` |  |
-| config.receivers.castai_audit_logs.filters.cluster_id | string | `""` |  |
+| config.receivers.castai_audit_logs.filters.cluster_id | string | `"${env:CASTAI_CLUSTER_ID}"` |  |
 | config.receivers.castai_audit_logs.page_limit | int | `100` |  |
 | config.receivers.castai_audit_logs.poll_interval_sec | int | `10` |  |
 | config.receivers.castai_audit_logs.storage.filename | string | `"/var/lib/otelcol/file_storage/audit_logs_poll_data.json"` |  |

--- a/charts/castai-audit-logs-receiver/README.md
+++ b/charts/castai-audit-logs-receiver/README.md
@@ -9,9 +9,6 @@ A Helm chart for CAST AI OpenTelemetry Collector.
 | affinity | object | `{}` |  |
 | castai.apiKey | string | `""` | Token to be used for authorizing access to the CASTAI API. |
 | castai.apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing access to the API. apiKey and apiKeySecretRef are mutually exclusive. The referenced secret must provide the token in .data["CASTAI_API_KEY"]. |
-| castai.clusterID | string | `""` | Optional clusterid to filter the logs to scrape. |
-| castai.clusterIdSecretKeyRef.name | string | `""` | Name of the reference secret that contains the cluster id. |
-| castai.clusterIdSecretKeyRef.key | string | `"CASTAI_CLUSTER_ID"` | Key of the secret with a base64 encoded cluster id.
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
@@ -21,7 +18,7 @@ A Helm chart for CAST AI OpenTelemetry Collector.
 | config.extensions.health_check.endpoint | string | `"0.0.0.0:13133"` |  |
 | config.receivers.castai_audit_logs.api.key | string | `"${env:CASTAI_API_KEY}"` |  |
 | config.receivers.castai_audit_logs.api.url | string | `"${env:CASTAI_API_URL}"` |  |
-| config.receivers.castai_audit_logs.filters.cluster_id | string | `"${env:CASTAI_CLUSTER_ID}"` |  |
+| config.receivers.castai_audit_logs.filters.cluster_id | string | `""` |  |
 | config.receivers.castai_audit_logs.page_limit | int | `100` |  |
 | config.receivers.castai_audit_logs.poll_interval_sec | int | `10` |  |
 | config.receivers.castai_audit_logs.storage.filename | string | `"/var/lib/otelcol/file_storage/audit_logs_poll_data.json"` |  |

--- a/charts/castai-audit-logs-receiver/README.md
+++ b/charts/castai-audit-logs-receiver/README.md
@@ -10,6 +10,9 @@ A Helm chart for CAST AI OpenTelemetry Collector.
 | castai.apiKey | string | `""` | Token to be used for authorizing access to the CASTAI API. |
 | castai.apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing access to the API. apiKey and apiKeySecretRef are mutually exclusive. The referenced secret must provide the token in .data["CASTAI_API_KEY"]. |
 | castai.apiURL | string | `"https://api.cast.ai"` | CASTAI public api url. |
+| castai.clusterID | string | `""` | Cluster id to be used for filtering audit logs. |
+| castai.clusterIdSecretKeyRef.key | string | `"CASTAI_CLUSTER_ID"` |  |
+| castai.clusterIdSecretKeyRef.name | string | `""` |  |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | config.exporters.debug.sampling_initial | int | `5` |  |
@@ -18,9 +21,9 @@ A Helm chart for CAST AI OpenTelemetry Collector.
 | config.extensions.health_check.endpoint | string | `"0.0.0.0:13133"` |  |
 | config.receivers.castai_audit_logs.api.key | string | `"${env:CASTAI_API_KEY}"` |  |
 | config.receivers.castai_audit_logs.api.url | string | `"${env:CASTAI_API_URL}"` |  |
-| config.receivers.castai_audit_logs.filters.cluster_id | string | `""` |  |
+| config.receivers.castai_audit_logs.filters.cluster_id | string | `"${env:CASTAI_CLUSTER_ID}"` |  |
 | config.receivers.castai_audit_logs.page_limit | int | `100` |  |
-| config.receivers.castai_audit_logs.poll_interval_sec | int | `10` |  |
+| config.receivers.castai_audit_logs.poll_interval_sec | int | `30` |  |
 | config.receivers.castai_audit_logs.storage.filename | string | `"/var/lib/otelcol/file_storage/audit_logs_poll_data.json"` |  |
 | config.receivers.castai_audit_logs.storage.type | string | `"persistent"` |  |
 | config.service.extensions[0] | string | `"health_check"` |  |

--- a/charts/castai-audit-logs-receiver/templates/statefulset.yaml
+++ b/charts/castai-audit-logs-receiver/templates/statefulset.yaml
@@ -53,6 +53,19 @@ spec:
                   fieldPath: status.podIP
             - name: CASTAI_API_URL
               value: {{ required "apiURL must be provided" .Values.castai.apiURL | quote }}
+            {{- if .Values.castai.clusterIdSecretKeyRef.name }}
+            {{- if ne .Values.castai.clusterID "" }}
+            {{- fail "choose clusterID OR clusterIdSecretKeyRef only" }}
+            {{- end }}
+            - name: CASTAI_CLUSTER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
+                  key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
+            {{- else }}
+            - name: CASTAI_CLUSTER_ID
+              value: {{ .Values.castai.clusterID | quote }}
+            {{- end }}
           volumeMounts:
             {{- if .Values.configMap.create }}
             - mountPath: /etc/otel
@@ -76,11 +89,14 @@ spec:
               port: 13133
           envFrom:
             - secretRef:
-          {{- if .Values.castai.apiKey  }}
+                {{- if .Values.castai.apiKey }}
+                  {{- if ne .Values.castai.apiKeySecretRef "" }}
+                  {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
+                  {{- end }}
                 name: {{ include "castai-audit-logs-receiver.fullname" . -}}
-          {{- else }}
-                name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.castai.apiKeySecretRef -}}
-          {{- end }}
+                {{- else }}
+                name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.castai.apiKeySecretRef }}
+                {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.tolerations }}

--- a/charts/castai-audit-logs-receiver/values.yaml
+++ b/charts/castai-audit-logs-receiver/values.yaml
@@ -19,7 +19,16 @@ castai:
   # castai.apiKeySecretRef -- Name of secret with Token to be used for authorizing access to the API.
   # apiKey and apiKeySecretRef are mutually exclusive.
   # The referenced secret must provide the token in .data["CASTAI_API_KEY"].
-  apiKeySecretRef: ""
+  apiKeySecretRef: "audit-logs-receiver-apikey-secret"
+
+  # Optional filter of logs using the Cluster ID.
+  # castai.clusterID -- Cluster ID to be used for filtering audit logs.
+  clusterID: ""
+  # castai.clusterIdConfigMapKeyRef -- Name of the Secret with the Cluster ID.
+  # clusterID needs to be in base64 format in the secret.
+  clusterIdSecretKeyRef:
+    name: ""
+    key: "CASTAI_CLUSTER_ID"
 
   # castai.apiURL -- CASTAI public api url.
   apiURL: "https://api.cast.ai"
@@ -110,7 +119,7 @@ config:
       # config.receivers.castai-audit-logs.filters -- Optional configuration for filtering scraped audit logs
       filters:
         # config.receivers.castai-audit-logs.filters.cluster_id -- This optional parameters defines cluster id for which logs should be scraped.
-        cluster_id: ""
+        cluster_id: ${env:CASTAI_CLUSTER_ID}
 
   exporters:
     debug:

--- a/charts/castai-audit-logs-receiver/values.yaml
+++ b/charts/castai-audit-logs-receiver/values.yaml
@@ -19,9 +19,9 @@ castai:
   # castai.apiKeySecretRef -- Name of secret with Token to be used for authorizing access to the API.
   # apiKey and apiKeySecretRef are mutually exclusive.
   # The referenced secret must provide the token in .data["CASTAI_API_KEY"].
-  apiKeySecretRef: "audit-logs-receiver-apikey-secret"
+  apiKeySecretRef: ""
 
-  # Optional filter of logs using the Cluster ID.
+  # Optional filter of logs using the cluster id.
   # castai.clusterID -- Cluster ID to be used for filtering audit logs.
   clusterID: ""
   # castai.clusterIdConfigMapKeyRef -- Name of the Secret with the Cluster ID.
@@ -110,7 +110,7 @@ config:
         # config.receivers.castai-audit-logs.api.key -- Use CASTAI_API_KEY env variable to provide API Access Key.
         key: ${env:CASTAI_API_KEY}
       # config.receivers.castai-audit-logs.poll_interval_sec -- This parameter defines poll cycle in seconds.
-      poll_interval_sec: 10
+      poll_interval_sec: 30
       # config.receivers.castai-audit-logs.page_limit -- This parameter defines the max number of records returned from the backend in one page.
       page_limit: 100
       storage:
@@ -119,6 +119,7 @@ config:
       # config.receivers.castai-audit-logs.filters -- Optional configuration for filtering scraped audit logs
       filters:
         # config.receivers.castai-audit-logs.filters.cluster_id -- This optional parameters defines cluster id for which logs should be scraped.
+        # Use castai.clusterID or castai.clusterIdSecretKeyRef to provide cluster id.
         cluster_id: ${env:CASTAI_CLUSTER_ID}
 
   exporters:

--- a/charts/castai-audit-logs-receiver/values.yaml
+++ b/charts/castai-audit-logs-receiver/values.yaml
@@ -21,11 +21,10 @@ castai:
   # The referenced secret must provide the token in .data["CASTAI_API_KEY"].
   apiKeySecretRef: ""
 
-  # Optional filter of logs using the cluster id.
-  # castai.clusterID -- Cluster ID to be used for filtering audit logs.
+  # Optional filter of logs using the cluster id. Choose one of the following options:
+  # castai.clusterID -- Cluster id to be used for filtering audit logs.
   clusterID: ""
-  # castai.clusterIdConfigMapKeyRef -- Name of the Secret with the Cluster ID.
-  # clusterID needs to be in base64 format in the secret.
+  # castai.clusterIdConfigMapKeyRef -- Name of the Secret and that contains the base64 encoded cluster id.
   clusterIdSecretKeyRef:
     name: ""
     key: "CASTAI_CLUSTER_ID"
@@ -118,8 +117,7 @@ config:
         filename: "/var/lib/otelcol/file_storage/audit_logs_poll_data.json"
       # config.receivers.castai-audit-logs.filters -- Optional configuration for filtering scraped audit logs
       filters:
-        # config.receivers.castai-audit-logs.filters.cluster_id -- This optional parameters defines cluster id for which logs should be scraped.
-        # Use castai.clusterID or castai.clusterIdSecretKeyRef to provide cluster id.
+        # config.receivers.castai-audit-logs.filters.cluster_id -- Use castai.clusterID or castai.clusterIdSecretKeyRef to provide cluster id for optional filtering.
         cluster_id: ${env:CASTAI_CLUSTER_ID}
 
   exporters:


### PR DESCRIPTION
Currently the clusterid filter is included in the config block as an inline string, which is loaded into the configmap. This PR will now allow this to be set outside of the config block, allowing the users to have an option to either use
`castai.clusterID` or `castai.clusterIdSecretKeyRef` 
similar to the other components like cluster-controller, evictor.
