### PR TITLE
[castai-pod-mutator] add additional env vars support to pod-mutator

### DIFF
--- a/charts/castai-pod-mutator/Chart.yaml
+++ b/charts/castai-pod-mutator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-pod-mutator
 description: CAST AI Pod Mutator.
 type: application
-version: 0.0.17
+version: 0.0.18
 appVersion: "v0.0.11"

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -1,6 +1,6 @@
 # castai-pod-mutator
 
-![Version: 0.0.17](https://img.shields.io/badge/Version-0.0.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.11](https://img.shields.io/badge/AppVersion-v0.0.11-informational?style=flat-square)
+![Version: 0.0.18](https://img.shields.io/badge/Version-0.0.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.11](https://img.shields.io/badge/AppVersion-v0.0.11-informational?style=flat-square)
 
 CAST AI Pod Mutator.
 

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -8,6 +8,7 @@ CAST AI Pod Mutator.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalEnv | object | `{}` | Used to set additional environment variables for the pod-mutator container. |
 | affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"kubernetes.io/os"` |  |
 | affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"NotIn"` |  |
 | affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0] | string | `"windows"` |  |

--- a/charts/castai-pod-mutator/templates/deployment.yaml
+++ b/charts/castai-pod-mutator/templates/deployment.yaml
@@ -59,6 +59,10 @@ spec:
               value: "true"
             - name: CERTS_SECRET
               value: {{ include "pod-mutator.certsSecretName" . }}
+            {{- range $name, $value := .Values.additionalEnv }}
+            - name: "{{ $name }}"
+              value: "{{ $value }}"
+            {{- end }}
           {{- if .Values.castai.organizationIdSecretKeyRef.name }}          
             {{- if ne .Values.castai.organizationID "" }}
             {{- fail "organizationID and organizationIdSecretKeyRef are mutually exclusive" }}

--- a/charts/castai-pod-mutator/values.yaml
+++ b/charts/castai-pod-mutator/values.yaml
@@ -28,6 +28,9 @@ podAnnotations: {}
 # podLabels - Labels added to each pod.
 podLabels: {}
 
+# -- Used to set additional environment variables for the pod-mutator container.
+additionalEnv: {}
+
 priorityClass:
   enabled: true
   name: system-cluster-critical


### PR DESCRIPTION
Env vars could be set by providing them in values.yaml or using args 
> --set additionalEnv.test=1 --set additionalEnv.test2=2