### PR TITLE
[castai-cluster-controller] Bump CC version with one that has metrics. 

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.80.2
-appVersion: "v0.56.3"
+version: 0.80.1
+appVersion: "v0.56.4"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:

--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.80.1
+version: 0.80.3
 appVersion: "v0.56.4"
 annotations:
   release-date: "2024-06-04T07:10:07"


### PR DESCRIPTION
See https://github.com/castai/cluster-controller/releases/tag/v0.56.4 