### PR TITLE
[castai-cluster-controller] KUBE-996: bump controller

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.80.4
-appVersion: "v0.56.4"
+version: 0.81.0
+appVersion: "v0.57.0"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:


### PR DESCRIPTION
https://github.com/castai/cluster-controller/releases/tag/v0.57.0