### PR TITLE
[castai-evictor] fix clusterrole, add watch for replicasets and statefulsets

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.31.74
+version: 0.31.75
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/templates/clusterrole.yaml
+++ b/charts/castai-evictor/templates/clusterrole.yaml
@@ -48,6 +48,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - "policy"
     resources:
@@ -75,7 +76,7 @@ rules:
       - list
       - watch
       - update
-  {{- if .Values.liveMigration.enabled }}
+{{- if .Values.liveMigration.enabled }}
   # ------------------------------------------------
   # Live Migration
   # ------------------------------------------------
@@ -89,4 +90,4 @@ rules:
       - watch
       - patch
       - update
-  {{- end }}
+{{- end }}


### PR DESCRIPTION
this fixes following error:

```
tai-evictor-6f8467cb47-ctzpj castai-evictor E0326 22:17:37.796231       1 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: Failed to watch *v1.StatefulSet: statefulsets.apps is forbidden: User \"system:serviceaccount:castai-agent:castai-evictor\" cannot watch resource \"statefulsets\" in API group \"apps\" at the cluster scope" logger="UnhandledError"
castai-evictor-6f8467cb47-ctzpj castai-evictor E0326 22:18:05.382889       1 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: Failed to watch *v1.ReplicaSet: replicasets.apps is forbidden: User \"system:serviceaccount:castai-agent:castai-evictor\" cannot watch resource \"replicasets\" in API group \"apps\" at the cluster scope" logger="UnhandledError"
castai-evictor-6f8467cb47-ctzpj castai-evictor E0326 22:18:23.593671       1 reflector.go:166] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.32.3/tools/cache/reflector.go:251: Failed to watch *v1.StatefulSet: statefulsets.apps is forbidden: User \"system:serviceaccount:castai-agent:castai-evictor\" cannot watch resource \"statefulsets\" in API group \"apps\" at the cluster scope" logger="UnhandledError"
```

Add also livepodextensions even if live migration is disabled

```
time="2025-04-08T11:22:47Z" level=warning msg="evictor cannot access live pod extensions, some functionality will be limited: livepodextensions.cast.ai is forbidden: User \"system:serviceaccount:castai-agent:castai-evictor\" cannot list resource \"livepodextensions\" in API group \"cast.ai\" at the cluster scope" commit=754d8cc7 level_int=3
```