### PR TITLE
[castai-cluster-controller] feat(cluster-controller): node rbac

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.81.4
+version: 0.81.5
 appVersion: "v0.57.1"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/templates/rbac.yaml
+++ b/charts/castai-cluster-controller/templates/rbac.yaml
@@ -44,7 +44,7 @@ rules:
     resources: [ "deployments" ]
     verbs: [ "patch" ]
   {{- end}}
-  {{- if .Values.autoscaling.enabled }}
+  {{- if .Values.nodeManagement.enabled }}
   # For advertising extended resources
   - apiGroups: [ "" ]
     resources: [ "nodes/status" ]
@@ -74,6 +74,8 @@ rules:
     resources: [ "signers" ]
     resourceNames: [ "kubernetes.io/kubelet-serving", "kubernetes.io/kube-apiserver-client-kubelet" ]
     verbs: [ "approve" ]
+  {{- end}}
+  {{- if .Values.autoscaling.enabled }}
   # For creating events.
   - apiGroups: [ "" ]
     resources: [ "events" ]

--- a/charts/castai-cluster-controller/templates/rbac.yaml
+++ b/charts/castai-cluster-controller/templates/rbac.yaml
@@ -44,7 +44,7 @@ rules:
     resources: [ "deployments" ]
     verbs: [ "patch" ]
   {{- end}}
-  {{- if .Values.nodeManagement.enabled }}
+  {{- if .Values.autoscaling.enabled }}
   # For advertising extended resources
   - apiGroups: [ "" ]
     resources: [ "nodes/status" ]
@@ -74,17 +74,15 @@ rules:
     resources: [ "signers" ]
     resourceNames: [ "kubernetes.io/kubelet-serving", "kubernetes.io/kube-apiserver-client-kubelet" ]
     verbs: [ "approve" ]
-  {{- end}}
-  {{- if .Values.autoscaling.enabled }}
   # For creating events.
   - apiGroups: [ "" ]
     resources: [ "events" ]
     verbs: [ "create", "patch" ]
+  {{- end}}
   # For CAST autoscaling CRDs management.
   - apiGroups: [ "autoscaling.cast.ai" ]
     resources: [ "*" ]
     verbs: [ "get", "list", "watch", "patch", "create", "delete", "update" ]
-  {{- end}}
   # For installing/updating CAST AI components.
   - apiGroups: [ "rbac.authorization.k8s.io" ]
     resources: [ "roles" ]

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -170,11 +170,6 @@ workloadManagement:
   # workloadManagement.enabled -- Adds permissions to patch deployments.
   enabled: false
 
-# nodeManagement -- Settings for managing nodes.
-nodeManagement:
-  # nodeManagement.enabled -- Adds permissions to manage nodes.
-  enabled: false
-
 # autoscaling -- Settings for managing autoscaling features.
 autoscaling:
   # autoscaling.enabled -- Adds permissions to manage autoscaling.

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -170,6 +170,11 @@ workloadManagement:
   # workloadManagement.enabled -- Adds permissions to patch deployments.
   enabled: false
 
+# nodeManagement -- Settings for managing nodes.
+nodeManagement:
+  # nodeManagement.enabled -- Adds permissions to manage nodes.
+  enabled: false
+
 # autoscaling -- Settings for managing autoscaling features.
 autoscaling:
   # autoscaling.enabled -- Adds permissions to manage autoscaling.


### PR DESCRIPTION
The goal is to be able to not grant the cluster-controller write access on nodes when only the workload autoscaler is enabled and the node autoscaler is disabled.