### PR TITLE
[castai-cluster-controller] Add metrics port to spec and bump CC

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.81.5
-appVersion: "v0.57.1"
+version: 0.81.6
+appVersion: "v0.57.2"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -180,6 +180,9 @@ spec:
             - containerPort: 6060
               name: http
               protocol: TCP
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
           livenessProbe:
             httpGet:
               port: http


### PR DESCRIPTION
Bumps CC to this release that fixes concurrency bug in logexporter - https://github.com/castai/cluster-controller/releases/tag/v0.57.2 

Also adds the metrics port to the deployment spec (not required but makes it easier to discover). 