### PR TITLE
[castai-hibernate] Hibernate Node Labels Support

### DIFF
--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
-version: 0.2.9
-appVersion: "v0.12"
+version: 0.2.10
+appVersion: "v0.13"

--- a/charts/castai-hibernate/README.md
+++ b/charts/castai-hibernate/README.md
@@ -18,7 +18,7 @@ CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defi
 | concurrencyPolicy | string | `"Forbid"` |  |
 | configMapName | string | `"castai-cluster-controller"` |  |
 | hibernateNode | string | `""` | Set the HIBERNATE_NODE environment variable to override the default node sizing selections. Make sure the size selected is appropriate for your cloud. |
-| hibernateNodeLabels | string | `""` | Set the HIBERNATE_NODE_LABELS comma separated list, do not use duplicate keys, "imaginary.devops/requirements=true, acme.io/infra=true" |
+| hibernateNodeLabels | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"castai/hibernate"` |  |
 | image.tag | string | `""` | Tag is set using Chart.yaml appVersion field. |

--- a/charts/castai-hibernate/README.md
+++ b/charts/castai-hibernate/README.md
@@ -18,6 +18,7 @@ CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defi
 | concurrencyPolicy | string | `"Forbid"` |  |
 | configMapName | string | `"castai-cluster-controller"` |  |
 | hibernateNode | string | `""` | Set the HIBERNATE_NODE environment variable to override the default node sizing selections. Make sure the size selected is appropriate for your cloud. |
+| hibernateNodeLabels | string | `""` | Set the HIBERNATE_NODE_LABELS comma separated list, do not use duplicate keys, "imaginary.devops/requirements=true, acme.io/infra=true" |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"castai/hibernate"` |  |
 | image.tag | string | `""` | Tag is set using Chart.yaml appVersion field. |

--- a/charts/castai-hibernate/templates/pause-cronjob.yaml
+++ b/charts/castai-hibernate/templates/pause-cronjob.yaml
@@ -44,6 +44,8 @@ spec:
                 value: "{{ .Values.cloud }}"
               - name: HIBERNATE_NODE
                 value: "{{ .Values.hibernateNode }}"
+              - name: HIBERNATE_NODE_LABELS
+                value: "{{ .Values.hibernateNodeLabels }}"
               - name: NAMESPACES_TO_KEEP
                 value: "{{ .Values.namespacesToKeep }}"
               - name: PROTECT_REMOVAL_DISABLED

--- a/charts/castai-hibernate/values.yaml
+++ b/charts/castai-hibernate/values.yaml
@@ -86,6 +86,6 @@ podSecurityContext:
 # -- Set the HIBERNATE_NODE environment variable to override the default node sizing selections. Make sure the size selected is appropriate for your cloud.
 hibernateNode: ""
 
-# Set kubernetes labels on hibernate-node, if CASTAI components and other kube-system workloads for wrong reasons have nodeSelector 
+# Set kubernetes labels on hibernate-node, if CASTAI components and other kube-system workloads for wrong reasons have nodeSelector
 # - HIBERNATE_NODE_LABELS, comma separated list, do not use duplicate keys, "imaginary.devops/requirements=true, acme.io/infra=true"
 hibernateNodeLabels: ""

--- a/charts/castai-hibernate/values.yaml
+++ b/charts/castai-hibernate/values.yaml
@@ -60,6 +60,7 @@ image:
   tag: ""
   pullPolicy: Always
 
+
 # Override default NAMESPACES_TO_KEEP
 # -- Set the NAMESPACES_TO_KEEP environment variable to override, "opa,istio""
 namespacesToKeep: ""
@@ -84,3 +85,7 @@ podSecurityContext:
 # Override default hibernate-node size
 # -- Set the HIBERNATE_NODE environment variable to override the default node sizing selections. Make sure the size selected is appropriate for your cloud.
 hibernateNode: ""
+
+# Set kubernetes labels on hibernate-node, if CASTAI components and other kube-system workloads for wrong reasons have nodeSelector 
+# - HIBERNATE_NODE_LABELS, comma separated list, do not use duplicate keys, "imaginary.devops/requirements=true, acme.io/infra=true"
+hibernateNodeLabels: ""


### PR DESCRIPTION
**Changes**
- Added `hibernateNodeLabels` parameter to set Kubernetes labels on hibernate nodes
- Updated Chart version to `0.2.10` and appVersion to `v0.13`
- Added new `HIBERNATE_NODE_LABELS` environment variable to pause-cronjob
**Purpose**
- Enables better integration with CAST AI components and kube-system workloads that use nodeSelectors by allowing custom labels on hibernate nodes.
**Testing**
Verify hibernate functionality works with the new label support and labels are correctly applied to nodes.