### PR TITLE
[castai-cluster-controller] Apply {{ .Release.Namespace }} consistently in cluster-controller resources

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.81.7
+version: 0.81.8
 appVersion: "v0.57.3"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/templates/rbac.yaml
+++ b/charts/castai-cluster-controller/templates/rbac.yaml
@@ -119,6 +119,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: castai-cluster-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
   {{ if gt (len .Values.commonAnnotations) 0 -}}
@@ -135,6 +136,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: castai-cluster-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "castai-agent.labels" . | nindent 4 }}
   {{ if gt (len .Values.commonAnnotations) 0 -}}


### PR DESCRIPTION
Customers using `helm template` to deploy helm charts have rbac resources for the cluster controller output with metadata.namespace: default since in the template `metadata.namespace: {{ .Release.Namespace }}` is not present. This is due to a nuance with helm template vs install/upgrade. 