### PR TITLE
[castai-evictor] feat: add Kubernetes client rate limiting controls

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.17
+version: 0.32.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -40,6 +40,9 @@ Cluster utilization defragmentation tool
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/evictor"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
+| kubernetesClient | object | `{"rateLimiter":{"burst":100,"qps":50}}` | Specifies Kubernetes client settings. |
+| kubernetesClient.rateLimiter.burst | int | `100` | Burst controls the maximum queries per second that the client is allowed to issue in a short burst. |
+| kubernetesClient.rateLimiter.qps | int | `50` | QPS or queries per second. Controls how many queries per second the client should be allowed to issue, not accounting for bursts. |
 | leaderElection | object | `{"enabled":true}` | Specifies leader election parameters. |
 | leaderElection.enabled | bool | `true` | Whether to enable leader election. |
 | liveMigration | object | `{"enabled":false}` | Specifies LIVE migration settings. This options assumes that the CAST AI LIVE components are already installed in the cluster. |

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
               value: "/config/config.yaml"
             - name: CYCLE_INTERVAL
               value: {{ .Values.cycleInterval | quote }}
+            - name: K8S_CLIENT_RATE_LIMITER_QPS
+              value: {{ .Values.kubernetesClient.rateLimiter.qps | quote }}
+            - name: K8S_CLIENT_RATE_LIMITER_BURST
+              value: {{ .Values.kubernetesClient.rateLimiter.burst | quote }}
             {{- if .Values.clusterIdSecretKeyRef.name }}
             {{- if ne .Values.clusterIdConfigMapKeyRef.name "" }}
             {{- fail "clusterIdConfigMapKeyRef and clusterIdSecretKeyRef are mutually exclusive" }}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -66,6 +66,15 @@ leaderElection:
   # leaderElection.enabled -- Whether to enable leader election.
   enabled: true
 
+# kubernetesClient -- Specifies Kubernetes client settings.
+kubernetesClient:
+  rateLimiter:
+    # kubernetesClient.rateLimiter.qps -- QPS or queries per second.
+    # Controls how many queries per second the client should be allowed to issue, not accounting for bursts.
+    qps: 50
+    # kubernetesClient.rateLimiter.burst -- Burst controls the maximum queries per second that the client is allowed to issue in a short burst.
+    burst: 100
+
 # updateStrategy -- Controls `deployment.spec.strategy` field.
 updateStrategy:
   type: Recreate


### PR DESCRIPTION
Prior to this commit, Evictor used the default Kubernetes client rate limiting settings. These settings were insufficient to operate in large enough clusters.

This commit exposes the environment variables that the updated Evictor binary can use to control its rate limiting settings.