### PR TITLE
[castai-evictor] chore: bump rate limiter values

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.32.18
+version: 0.32.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -40,9 +40,9 @@ Cluster utilization defragmentation tool
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/evictor"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
-| kubernetesClient | object | `{"rateLimiter":{"burst":100,"qps":50}}` | Specifies Kubernetes client settings. |
-| kubernetesClient.rateLimiter.burst | int | `100` | Burst controls the maximum queries per second that the client is allowed to issue in a short burst. |
-| kubernetesClient.rateLimiter.qps | int | `50` | QPS or queries per second. Controls how many queries per second the client should be allowed to issue, not accounting for bursts. |
+| kubernetesClient | object | `{"rateLimiter":{"burst":200,"qps":100}}` | Specifies Kubernetes client settings. |
+| kubernetesClient.rateLimiter.burst | int | `200` | Burst controls the maximum queries per second that the client is allowed to issue in a short burst. |
+| kubernetesClient.rateLimiter.qps | int | `100` | QPS or queries per second. Controls how many queries per second the client should be allowed to issue, not accounting for bursts. |
 | leaderElection | object | `{"enabled":true}` | Specifies leader election parameters. |
 | leaderElection.enabled | bool | `true` | Whether to enable leader election. |
 | liveMigration | object | `{"enabled":false}` | Specifies LIVE migration settings. This options assumes that the CAST AI LIVE components are already installed in the cluster. |

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -71,9 +71,9 @@ kubernetesClient:
   rateLimiter:
     # kubernetesClient.rateLimiter.qps -- QPS or queries per second.
     # Controls how many queries per second the client should be allowed to issue, not accounting for bursts.
-    qps: 50
+    qps: 100
     # kubernetesClient.rateLimiter.burst -- Burst controls the maximum queries per second that the client is allowed to issue in a short burst.
-    burst: 100
+    burst: 200
 
 # updateStrategy -- Controls `deployment.spec.strategy` field.
 updateStrategy:


### PR DESCRIPTION
This commit bumps Evictor client rate limiter values to match those in Cluster Controller.