### PR TITLE
rename helper names

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.81.8
+version: 0.81.9
 appVersion: "v0.57.3"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/templates/_helpers.tpl
+++ b/charts/castai-cluster-controller/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "castai-agent.name" -}}
+{{- define "cluster-controller.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "castai-agent.fullname" -}}
+{{- define "cluster-controller.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,21 +26,21 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "castai-agent.chart" -}}
+{{- define "cluster-controller.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "castai-agent.labels" -}}
+{{- define "cluster-controller.labels" -}}
 {{ if gt (len .Values.commonLabels) 0 -}}
 {{- with .Values.commonLabels }}
 {{- toYaml . }}
 {{- end }}
 {{- end }}
-helm.sh/chart: {{ include "castai-agent.chart" . }}
-{{ include "castai-agent.selectorLabels" . }}
+helm.sh/chart: {{ include "cluster-controller.chart" . }}
+{{ include "cluster-controller.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -50,7 +50,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Common Annotations
 */}}
-{{- define "castai-agent.annotations" -}}
+{{- define "cluster-controller.annotations" -}}
 {{ if gt (len .Values.commonAnnotations) 0 -}}
 {{- with .Values.commonAnnotations }}
 {{- toYaml . }}
@@ -61,17 +61,17 @@ Common Annotations
 {{/*
 Selector labels
 */}}
-{{- define "castai-agent.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "castai-agent.name" . }}
+{{- define "cluster-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cluster-controller.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "castai-agent.serviceAccountName" -}}
+{{- define "cluster-controller.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "castai-agent.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "cluster-controller.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/castai-cluster-controller/templates/secret.yaml
+++ b/charts/castai-cluster-controller/templates/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: castai-cluster-controller
   namespace: {{ .Values.namespace }}
   labels:
-    {{- include "castai-agent.labels" . | nindent 4 }}
+    {{- include "castai-cluster-controller.labels" . | nindent 4 }}
   {{ if gt (len .Values.commonAnnotations) 0 -}}
   annotations:
-    {{- include "castai-agent.annotations" . | nindent 4 }}
+    {{- include "castai-cluster-controller.annotations" . | nindent 4 }}
   {{- end }}
 data:
   {{- if .Values.apiKey }}

--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.26.2
+version: 0.26.3
 appVersion: "v0.17.1"

--- a/charts/castai-spot-handler/templates/_helpers.tpl
+++ b/charts/castai-spot-handler/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "castai-agent.name" -}}
+{{- define "spot-handler.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "castai-agent.fullname" -}}
+{{- define "spot-handler.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,21 +26,21 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "castai-agent.chart" -}}
+{{- define "spot-handler.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "castai-agent.labels" -}}
+{{- define "spot-handler.labels" -}}
 {{ if gt (len .Values.commonLabels) 0 -}}
 {{- with .Values.commonLabels }}
 {{- toYaml . }}
 {{- end }}
 {{- end }}
-helm.sh/chart: {{ include "castai-agent.chart" . }}
-{{ include "castai-agent.selectorLabels" . }}
+helm.sh/chart: {{ include "spot-handler.chart" . }}
+{{ include "spot-handler.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -50,7 +50,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Common Annotations
 */}}
-{{- define "castai-agent.annotations" -}}
+{{- define "spot-handler.annotations" -}}
 {{ if gt (len .Values.commonAnnotations) 0 -}}
 {{- with .Values.commonAnnotations }}
 {{- toYaml . }}
@@ -61,17 +61,17 @@ Common Annotations
 {{/*
 Selector labels
 */}}
-{{- define "castai-agent.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "castai-agent.name" . }}
+{{- define "spot-handler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spot-handler.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "castai-agent.serviceAccountName" -}}
+{{- define "spot-handler.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "castai-agent.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "spot-handler.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}


### PR DESCRIPTION
Adds support for common labels and annotations in CAST AI spot handler and cluster-controller _helpers.tpl

Changes:
- Added helper functions for labels and annotations in _helpers.tpl

This change allows users to have proper helm labels in deployments when using CASTAI component control management feature. 