### PR TITLE
[castai-agent] Chart v0.102.0 (app image v0.89.0)

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.101.0
-appVersion: "v0.88.0"
+version: 0.102.0
+appVersion: "v0.89.0"


### PR DESCRIPTION
We ran this agent version for over 24 hours. It contains some changes in the code that's collecting and uploading deltas (in order to retry on error).