### PR TITLE
[castai-cluster-controller] Disabling if workloadManagement is disabled

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.81.9
+version: 0.81.10
 appVersion: "v0.57.3"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/templates/rbac.yaml
+++ b/charts/castai-cluster-controller/templates/rbac.yaml
@@ -43,6 +43,10 @@ rules:
   - apiGroups: [ "apps" ]
     resources: [ "deployments" ]
     verbs: [ "patch" ]
+  # For CAST autoscaling CRDs management.
+  - apiGroups: [ "autoscaling.cast.ai" ]
+    resources: [ "*" ]
+    verbs: [ "get", "list", "watch", "patch", "create", "delete", "update" ]
   {{- end}}
   {{- if .Values.autoscaling.enabled }}
   # For advertising extended resources
@@ -79,10 +83,6 @@ rules:
     resources: [ "events" ]
     verbs: [ "create", "patch" ]
   {{- end}}
-  # For CAST autoscaling CRDs management.
-  - apiGroups: [ "autoscaling.cast.ai" ]
-    resources: [ "*" ]
-    verbs: [ "get", "list", "watch", "patch", "create", "delete", "update" ]
   # For installing/updating CAST AI components.
   - apiGroups: [ "rbac.authorization.k8s.io" ]
     resources: [ "roles" ]


### PR DESCRIPTION
A Prospect needs to be able to deploy the workload optimization in a safe way to get the data without actually giving permissions to do so.