### PR TITLE
[castai-ai-optimizer-proxy] Set fullnameOverride for castai-ai-optimizer-proxy

### DIFF
--- a/charts/castai-ai-optimizer-proxy/Chart.yaml
+++ b/charts/castai-ai-optimizer-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-ai-optimizer-proxy
 description: AI Optimizer Proxy deployment chart.
 type: application
-version: 0.0.24
+version: 0.0.25
 appVersion: "v1.1.17"
 dependencies:
   - name: aibrix

--- a/charts/castai-ai-optimizer-proxy/README.md
+++ b/charts/castai-ai-optimizer-proxy/README.md
@@ -43,7 +43,7 @@ In order to update the chart, use the [helmify-aibrix.sh](./helmify-aibrix.sh) s
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | createNamespace | bool | `false` | By default castai-llms namespace is expected to be created explicitly during onboarding. |
 | deploy | bool | `true` |  |
-| fullnameOverride | string | `""` |  |
+| fullnameOverride | string | `"castai-ai-optimizer-proxy"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/ai-optimizer-proxy"` |  |
 | image.tag | string | `""` |  |

--- a/charts/castai-ai-optimizer-proxy/values.yaml
+++ b/charts/castai-ai-optimizer-proxy/values.yaml
@@ -19,7 +19,7 @@ image:
 
 imagePullSecrets: []
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride: "castai-ai-optimizer-proxy"
 
 podAnnotations: {}
 


### PR DESCRIPTION
Cast AI requires the deployment to be named `castai-ai-optimizer-proxy` to property identify its installation.