### PR TITLE
feat: dynamic volumes / volumemounts

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.107.0
+version: 0.107.1
 appVersion: "v0.91.0"

--- a/charts/castai-agent/templates/deployment.yaml
+++ b/charts/castai-agent/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
       volumes:
         - name: shared-metadata
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: {{ .Values.priorityClass.name }}
       {{- end }}
@@ -81,6 +84,9 @@ spec:
           volumeMounts:
             - name: shared-metadata
               mountPath: /agent-metadata
+            {{- with .Values.extraVolumeMounts }}
+            {{ toYaml . | indent 12 }}
+            {{- end }}
           env:
             - name: SELF_POD_NAME
               valueFrom:

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -175,3 +175,9 @@ metadataStore:
 
 # -- Used to set additional environment variables for the pod-mutator container via configMaps or secrets.
 envFrom: []
+
+# -- Used to set additional volumes
+extraVolumes: []
+
+# -- Used to set additional volumemounts
+extraVolumeMounts: []

--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.81.11
+version: 0.81.12
 appVersion: "v0.57.4"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         - name: shared-metadata
           emptyDir:
             sizeLimit: 10Mi
+        {{- with .Values.extraVolumes }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version) (.Values.priorityClass | default dict).enabled }}
       priorityClassName: {{ .Values.priorityClass.name }}
       {{- end }}
@@ -92,6 +95,9 @@ spec:
           volumeMounts:
             - name: shared-metadata
               mountPath: /controller-metadata
+            {{- with .Values.extraVolumeMounts }}
+            {{ toYaml . | indent 12 }}
+            {{- end }}
           env:
           {{- if .Values.leaderElectionEnabled }}
             - name: LEADER_ELECTION_ENABLED

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -177,3 +177,9 @@ autoscaling:
 
 # -- Used to set additional environment variables for the cluster-controller container via configMaps or secrets.
 envFrom: []
+
+# -- Used to set additional volumes
+extraVolumes: []
+
+# -- Used to set additional volumemounts
+extraVolumeMounts: []

--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.9
+version: 0.33.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -165,10 +165,16 @@ spec:
             - mountPath: /config
               name: cfg
               readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{ toYaml . | indent 12 }}
+            {{- end }}
       volumes:
         - name: cfg
           configMap:
             name: {{ include "evictor.name" . }}-config
+        {{- with .Values.extraVolumes }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -209,3 +209,9 @@ overrideEnvFrom: false
 # -- Additional environment sources for the evictor container.
 # Accepts a list of `configMapRef` or `secretRef` entries, following the standard `envFrom` format.
 envFrom: []
+
+# -- Used to set additional volumes
+extraVolumes: []
+
+# -- Used to set additional volumemounts
+extraVolumeMounts: []


### PR DESCRIPTION
This PR adds support for injecting dynamic volumes and volumeMounts into the Helm chart templates. This enhancement enables users to provide arbitrary additional volumes and volume mounts via values.yaml, making the charts more flexible and extensible.

**Motivation**
Certain integrations (e.g. [Vault CSI Driver](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/csi/examples)) require the injection of specific volumes and mounts at runtime, such as:

    CSI-mounted secrets
    Custom configuration volumes
    Sidecar data sharing

Previously, these could only be added by modifying the chart templates directly or forking them. With this change, they can be specified dynamically at deploy time.