### PR TITLE
Add dynamic volume support

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.107.0
+version: 0.107.1
 appVersion: "v0.91.0"

--- a/charts/castai-agent/templates/deployment.yaml
+++ b/charts/castai-agent/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
       volumes:
         - name: shared-metadata
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: {{ .Values.priorityClass.name }}
       {{- end }}
@@ -81,6 +84,9 @@ spec:
           volumeMounts:
             - name: shared-metadata
               mountPath: /agent-metadata
+            {{- with .Values.extraVolumeMounts }}
+            {{ toYaml . | indent 12 }}
+            {{- end }}
           env:
             - name: SELF_POD_NAME
               valueFrom:

--- a/charts/castai-agent/values.yaml
+++ b/charts/castai-agent/values.yaml
@@ -175,3 +175,8 @@ metadataStore:
 
 # -- Used to set additional environment variables for the pod-mutator container via configMaps or secrets.
 envFrom: []
+# -- Used to set additional volumes
+extraVolumes: []
+
+# -- Used to set additional volumemounts
+extraVolumeMounts: []


### PR DESCRIPTION
This PR adds support for injecting dynamic volumes and volumeMounts into the Helm chart templates. This enhancement enables users to provide arbitrary additional volumes and volume mounts via values.yaml, making the charts more flexible and extensible.

Motivation
Certain integrations (e.g. [Vault CSI Driver](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/csi/examples)) require the injection of specific volumes and mounts at runtime, such as:

```
CSI-mounted secrets
Custom configuration volumes
Sidecar data sharing
```

Previously, these could only be added by modifying the chart templates directly or forking them. With this change, they can be specified dynamically at deploy time.