### PR TITLE
[castai-cluster-controller] Add support for dynamic volume

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.81.11
+version: 0.81.12
 appVersion: "v0.57.4"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/README.md
+++ b/charts/castai-cluster-controller/README.md
@@ -34,6 +34,8 @@ Cluster controller is responsible for handling certain Kubernetes actions such a
 | dnsPolicy | string | `""` | DNS Policy Override - Needed when using some custom CNI's. |
 | enableTopologySpreadConstraints | bool | `false` |  |
 | envFrom | list | `[]` | Used to set additional environment variables for the cluster-controller container via configMaps or secrets. |
+| extraVolumeMounts | list | `[]` | Used to set additional volumemounts |
+| extraVolumes | list | `[]` | Used to set additional volumes |
 | fullnameOverride | string | `"castai-cluster-controller"` |  |
 | hostNetwork.enabled | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         - name: shared-metadata
           emptyDir:
             sizeLimit: 10Mi
+        {{- with .Values.extraVolumes }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
       {{- if and (.Capabilities.APIVersions.Has "scheduling.k8s.io/v1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version) (.Values.priorityClass | default dict).enabled }}
       priorityClassName: {{ .Values.priorityClass.name }}
       {{- end }}
@@ -92,6 +95,9 @@ spec:
           volumeMounts:
             - name: shared-metadata
               mountPath: /controller-metadata
+            {{- with .Values.extraVolumeMounts }}
+            {{ toYaml . | indent 12 }}
+            {{- end }}
           env:
           {{- if .Values.leaderElectionEnabled }}
             - name: LEADER_ELECTION_ENABLED

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -177,3 +177,9 @@ autoscaling:
 
 # -- Used to set additional environment variables for the cluster-controller container via configMaps or secrets.
 envFrom: []
+
+# -- Used to set additional volumes
+extraVolumes: []
+
+# -- Used to set additional volumemounts
+extraVolumeMounts: []


### PR DESCRIPTION
This PR adds support for injecting dynamic volumes and volumeMounts into the Helm chart templates. This enhancement enables users to provide arbitrary additional volumes and volume mounts via values.yaml, making the charts more flexible and extensible.

Motivation
Certain integrations (e.g. [Vault CSI Driver](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/csi/examples)) require the injection of specific volumes and mounts at runtime, such as:

```
CSI-mounted secrets
Custom configuration volumes
Sidecar data sharing
```

Previously, these could only be added by modifying the chart templates directly or forking them. With this change, they can be specified dynamically at deploy time.