### PR TITLE
[castai-evictor] Add support for dynamic volume

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.9
+version: 0.33.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -34,6 +34,8 @@ Cluster utilization defragmentation tool
 | dnsPolicy | string | `""` | DNS Policy Override - Needed when using some custom CNI's. |
 | dryRun | bool | `false` |  |
 | envFrom | list | `[]` | Additional environment sources for the evictor container. Accepts a list of `configMapRef` or `secretRef` entries, following the standard `envFrom` format. |
+| extraVolumeMounts | list | `[]` | Used to set additional volumemounts |
+| extraVolumes | list | `[]` | Used to set additional volumes |
 | fullnameOverride | string | `"castai-evictor"` |  |
 | hostNetwork.enabled | bool | `false` | Enable host networking. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -165,10 +165,16 @@ spec:
             - mountPath: /config
               name: cfg
               readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{ toYaml . | indent 12 }}
+            {{- end }}
       volumes:
         - name: cfg
           configMap:
             name: {{ include "evictor.name" . }}-config
+        {{- with .Values.extraVolumes }}
+        {{ toYaml . | indent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -209,3 +209,8 @@ overrideEnvFrom: false
 # -- Additional environment sources for the evictor container.
 # Accepts a list of `configMapRef` or `secretRef` entries, following the standard `envFrom` format.
 envFrom: []
+# -- Used to set additional volumes
+extraVolumes: []
+
+# -- Used to set additional volumemounts
+extraVolumeMounts: []


### PR DESCRIPTION
This PR adds support for injecting dynamic volumes and volumeMounts into the Helm chart templates. This enhancement enables users to provide arbitrary additional volumes and volume mounts via values.yaml, making the charts more flexible and extensible.

Motivation
Certain integrations (e.g. [Vault CSI Driver](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/csi/examples)) require the injection of specific volumes and mounts at runtime, such as:

```
CSI-mounted secrets
Custom configuration volumes
Sidecar data sharing
```

Previously, these could only be added by modifying the chart templates directly or forking them. With this change, they can be specified dynamically at deploy time.