### PR TITLE
[castai-hosted-model] Set GPU requests for placement job

### DIFF
--- a/charts/castai-hosted-model/Chart.yaml
+++ b/charts/castai-hosted-model/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-hosted-model
 description: CAST AI hosted model deployment chart.
 type: application
-version: 0.0.13
+version: 0.0.14
 appVersion: "v0.0.1"
 dependencies:
   - name: ollama

--- a/charts/castai-hosted-model/README.md
+++ b/charts/castai-hosted-model/README.md
@@ -19,7 +19,7 @@ CAST AI hosted model deployment chart.
 | placementJob.image.repository | string | `"us-docker.pkg.dev/castai-hub/library/busybox"` | The image to use for the job |
 | placementJob.image.tag | string | `"1.37.0"` | The image tag |
 | placementJob.requiredGPUTotalMemoryMiB | string | `nil` | Total GPU memory MiB (GPU count * GPU memory MiB) of the node that should be provisioned for this job |
-| placementJob.resources | object | `{}` | Resources for the job |
+| placementJob.resources | object | `{"limits":{"nvidia.com/gpu":1},"requests":{"nvidia.com/gpu":1}}` | Resources for the job |
 | podAutoscaler.downFluctuationTolerance | float | `0.2` | which means no scaling down will occur unless the currentMetricValue is less than the targetValue by more than downFluctuationTolerance |
 | podAutoscaler.enabled | bool | `false` | Specifies if pod autoscaler should be enabled. It is only relevant for vllm deployments |
 | podAutoscaler.maxReplicas | int | `3` | Max number of replicas |

--- a/charts/castai-hosted-model/values.yaml
+++ b/charts/castai-hosted-model/values.yaml
@@ -20,7 +20,11 @@ placementJob:
     pullPolicy: IfNotPresent
 
   # -- Resources for the job
-  resources: {}
+  resources:
+    requests:
+      nvidia.com/gpu: 1
+    limits:
+      nvidia.com/gpu: 1
 podAutoscaler:
   # -- Specifies if pod autoscaler should be enabled. It is only relevant for vllm deployments
   enabled: false


### PR DESCRIPTION
We need to set the GPU requests for GPU node placement job, otherwise, when adding custom instances, autoscaler gets into node provisioning loop, as it assumes the placement job's pod does not require GPUs.