### PR TITLE
[castai-cluster-controller] Bump Helm chart to use v0.58.0

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.81.14
-appVersion: "v0.57.5"
+version: 0.82.0
+appVersion: "v0.58.0"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:


### PR DESCRIPTION
Changelog for application: https://github.com/castai/cluster-controller/releases/tag/v0.58.0 