### PR TITLE
[castai-watchdog] refactor chart and add support for HTTP notification webhooks

### DIFF
--- a/charts/castai-watchdog/Chart.yaml
+++ b/charts/castai-watchdog/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-watchdog
 description: CAST AI Watchdog
 type: application
-version: 0.1.0
-appVersion: "v0.0.1"
+version: 0.2.0
+appVersion: "8ea6cee6bfdb98894bb7190eec1f7ea8ceab5e3c"

--- a/charts/castai-watchdog/README.md
+++ b/charts/castai-watchdog/README.md
@@ -54,3 +54,4 @@ CAST AI Watchdog
 | webhook.failurePolicy | string | `"Ignore"` |  |
 | webhook.reinvocationPolicy | string | `"Never"` |  |
 | webhook.url | string | `""` |  |
+| webhooks | list | `[]` | List of webhooks, where to send Watchdog events about autoscaling |

--- a/charts/castai-watchdog/templates/config.yaml
+++ b/charts/castai-watchdog/templates/config.yaml
@@ -27,7 +27,7 @@ data:
     google:
       project: {{ .Values.gcp.project | quote }}
       location: {{ .Values.gcp.location | quote }}
-      clusterName {{ .Values.gcp.clusterName | quote }}
+      clusterName: {{ .Values.gcp.clusterName | quote }}
     {{- end }}
 
     certsRotation: true

--- a/charts/castai-watchdog/templates/config.yaml
+++ b/charts/castai-watchdog/templates/config.yaml
@@ -11,7 +11,31 @@ metadata:
     {{- include "watchdog.annotations" . | nindent 4 }}
   {{- end }}
 data:
-  API_URL: {{ required "castai.apiUrl must be provided" .Values.castai.apiUrl | quote }}
-  CLUSTER_ID: {{ required "clusterID must be provided" .Values.castai.clusterID | quote }}
-  ORGANIZATION_ID: {{ required "organizationID must be provided" .Values.castai.organizationID | quote }}
+  config.yaml: |
+    clusterId: {{ required "clusterID must be provided" .Values.castai.clusterID | quote }}
+    organizationId: {{ required "organizationID must be provided" .Values.castai.organizationID | quote }}
+    api:
+      url: {{ required "castai.apiUrl must be provided" .Values.castai.apiUrl | quote }}
+
+    log:
+      level: "0"
+
+    webhookName: {{ include "watchdog.webhookName" . }}
+    serviceName: {{ include "watchdog.fullname" . }}
+
+    {{- if .Values.gcp.clusterName }}
+    google:
+      project: {{ .Values.gcp.project | quote }}
+      location: {{ .Values.gcp.location | quote }}
+      clusterName {{ .Values.gcp.clusterName | quote }}
+    {{- end }}
+
+    certsRotation: true
+    certsSecret: {{ include "watchdog.certsSecretName" . }}
+
+    {{- with .Values.webhooks }}
+    webhooks:
+      webhooks: {{ . | toYaml | nindent 8 }}
+    {{- end }}
 {{- end }}
+

--- a/charts/castai-watchdog/templates/deployment.yaml
+++ b/charts/castai-watchdog/templates/deployment.yaml
@@ -67,7 +67,11 @@ spec:
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.castai.apiKeySecretRef }}
                 {{- end }}
             - configMapRef:
+                {{- if .Values.castai.configMapRef }}
+                name: {{ .Values.castai.configMapRef | quote }}
+                {{- else }}
                 name: {{ include "watchdog.fullname" . }}
+                {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:

--- a/charts/castai-watchdog/templates/deployment.yaml
+++ b/charts/castai-watchdog/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             - mountPath: /certs
               name: certs
               readOnly: true
+            - mountPath: /etc/cast-watchdog
+              name: config
+              readOnly: true
             {{- if .Values.gcp.credentialsJSON }}
             - mountPath: /gcp
               name: gcp
@@ -104,6 +107,9 @@ spec:
           secret:
             defaultMode: 420
             secretName: {{ include "watchdog.certsSecretName" . }}
+        - name: config
+          configMap:
+            name: {{ include "watchdog.fullname" . }}
         {{- if .Values.gcp.credentialsJSON }}
         - name: gcp
           secret:

--- a/charts/castai-watchdog/templates/deployment.yaml
+++ b/charts/castai-watchdog/templates/deployment.yaml
@@ -49,24 +49,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: WEBHOOK_NAME
-              value: {{ include "watchdog.webhookName" . }}
-            - name: SERVICE_NAME
-              value: {{ include "watchdog.fullname" . }}
-            - name: LOG_LEVEL
-              value: "0"
-            - name: CERTS_ROTATION
-              value: "true"
-            - name: CERTS_SECRET
-              value: {{ include "watchdog.certsSecretName" . }}
-            {{- if .Values.gcp.clusterName }}
-            - name: GOOGLE_PROJECT
-              value: {{ .Values.gcp.project | quote }}
-            - name: GOOGLE_CLUSTER_ZONE
-              value: {{ .Values.gcp.location | quote }}
-            - name: GOOGLE_CLUSTER_NAME
-              value: {{ .Values.gcp.clusterName | quote }}
-            {{- end }}
             {{- if .Values.gcp.credentialsJSON }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /gcp/credentials.json
@@ -85,11 +67,7 @@ spec:
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.castai.apiKeySecretRef }}
                 {{- end }}
             - configMapRef:
-                {{- if .Values.castai.clusterID }}
                 name: {{ include "watchdog.fullname" . }}
-                {{- else }}
-                name: {{ required "configMapRef or (organizationID, clusterID and apiUrl) must be provided" .Values.castai.configMapRef }}
-                {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
           volumeMounts:

--- a/charts/castai-watchdog/templates/service-account.yaml
+++ b/charts/castai-watchdog/templates/service-account.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "watchdog.serviceAccountName" . }}
-  labels:
-  {{- include "watchdog.labels" . | nindent 4 }}
+  labels: {{- include "watchdog.labels" . | nindent 4 }}
+  annotations: {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}

--- a/charts/castai-watchdog/values.yaml
+++ b/charts/castai-watchdog/values.yaml
@@ -104,6 +104,8 @@ castai:
   # organization ID -- ID of the organization
   organizationID: ""
 
+webhooks: []
+
 gcp:
   project: ""
   location: ""

--- a/charts/castai-watchdog/values.yaml
+++ b/charts/castai-watchdog/values.yaml
@@ -104,7 +104,34 @@ castai:
   # organization ID -- ID of the organization
   organizationID: ""
 
+# -- List of webhooks, where to send Watchdog events about autoscaling
 webhooks: []
+# - url: https://example.com/slack-webhook
+#   method: POST
+#   headers:
+#     x-header: header-value
+#   payloadTemplate: |
+#     {{- $e := .Event -}}
+#     {
+#       "attachments": [
+#         {
+#           "color": {{ if eq $e.Type "StartAutoscaling" }}"#36a64f"{{ else if eq $e.Type "StopAutoscaling" }}"#a63636"{{ else }}"#cccccc"{{ end }},
+#           "title": "{{ if eq $e.Type "StartAutoscaling" }}Autoscaling started{{ else if eq $e.Type "StopAutoscaling" }}Autoscaling stopped{{ end }}",
+#           "fields": [
+#             {
+#               "title": "Time",
+#               "value": "{{ $e.Timestamp.Format "2006-01-02 15:04:05 MST" }}",
+#               "short": true
+#             },
+#             {
+#               "title": "Reason",
+#               "value": "{{ $e.Reason }}",
+#               "short": false
+#             }
+#           ]
+#         }
+#       ]
+#     }
 
 gcp:
   project: ""


### PR DESCRIPTION
- add support for notifications via HTTP webhooks
- refactor the config management a bit, use a config file instead of environment variables, where it was possible