### PR TITLE
[castai-db-optimizer] NOJIRA: Revert Merge Commit 7bc1252

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.36.1
+version: 0.36.2

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.36.1](https://img.shields.io/badge/Version-0.36.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.36.2](https://img.shields.io/badge/Version-0.36.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/ci/test-values.yaml
+++ b/charts/castai-db-optimizer/ci/test-values.yaml
@@ -3,43 +3,16 @@ apiKey: "456"
 
 upstreamPostgresHostname: random.hostname
 
-protocol: "PostgreSQL"  # protocol configuration required for endpoints
-
-endpoints:
-  # named endpoints (will create separate named services)
-  - name: "db1"  # This will create a named service: <chart-name>-db1
-    hostname: "db1.example.com"  # Upstream database DNS address
-    port: 5433  # Port on which the proxy will listen
-    targetPort: 5432  # Port on the target database
-    servicePort: 5433  # Port exposed by the service
-
-  - name: "db2"
-    hostname: "db2.example.com"
-    port: 5434
-    targetPort: 5432
-    servicePort: 5434
-
-  # unnamed endpoint (will not create a separate named service)
-  - hostname: "db3.example.com"
-    port: 5435
-    targetPort: 5432
-    servicePort: 5435
-
 proxy:
   readinessProbeEnabled: true
   livenessProbeEnabled: true
-  connectionLimits:
-    maxConnections: 1024
-    maxPendingRequests: 1024
-    maxRequests: 1024
-    maxRetries: 3
-  dnsLookupFamily: V4_ONLY
 
 podLabels:
   podLabel: label
 
 podAnnotations:
   podAnnotation: annotation
+
 
 commonLabels:
   commonLabel: label

--- a/charts/castai-db-optimizer/templates/service.yaml
+++ b/charts/castai-db-optimizer/templates/service.yaml
@@ -17,8 +17,8 @@ spec:
     {{- range $index, $endpoint := .Values.endpoints}}
     {{- if empty $endpoint.name }}
     - name: endpoint-{{$index}}
-      port: {{$endpoint.servicePort}}
-      targetPort: {{$endpoint.targetPort}}
+      port: {{$endpoint.port}}
+      targetPort: {{$endpoint.port}}
       protocol: TCP
     {{- end }}
     {{- end }}
@@ -51,7 +51,7 @@ spec:
   ports:
     - name: endpoint
       port: {{$endpoint.servicePort}}
-      targetPort: {{$endpoint.targetPort}}
+      targetPort: {{$endpoint.port}}
       protocol: TCP
   selector:
     {{- include "selectorLabels" $ | nindent 4 }}


### PR DESCRIPTION
servicePort and targetPort values being saved as `0` for deployments. Reverted kubecast changes, need to revert the matching changes here, too.