### PR TITLE
[castai-cluster-controller] double k8s client rate limits and add dedicated value for max in progress actions

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.83.0
+version: 0.83.1
 appVersion: "v0.59.0"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -122,6 +122,10 @@ spec:
             - name: KUBECLIENT_QPS
               value: {{ .Values.k8sApiClient.rateLimit.qps | quote }}
           {{- end }}
+          {{- if .Values.maxActionsInProgress }}
+            - name: MAX_ACTIONS_IN_PROGRESS
+              value: {{ .Values.maxActionsInProgress | quote }}
+          {{- end }}
           {{- if not .Values.autoscaling.enabled }}
             - name: AUTOSCALING_DISABLED
               value: "true"

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -162,8 +162,11 @@ k8sApiClient:
   # rateLimit -- Client uses token based rate limiting. By default, client has 200 api request burst limit set.
   # Buffer is refilled with 100 tokens every second. During sustained load client will be capped at 100 requests / sec.
   rateLimit:
-    burst: 200
-    qps: 100
+    burst: 400
+    qps: 200
+
+# -- Max number of actions, which are done concurrently.
+maxActionsInProgress: 1000
 
 # workloadAutoscaling -- Settings for managing CAST autoscaling CRDs.
 workloadAutoscaling:


### PR DESCRIPTION
… in progress actions