### PR TITLE
[castai-db-optimizer] fix broken service ports in service chart

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.42.0
+version: 0.42.1

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.42.0](https://img.shields.io/badge/Version-0.42.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.42.1](https://img.shields.io/badge/Version-0.42.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/service.yaml
+++ b/charts/castai-db-optimizer/templates/service.yaml
@@ -17,8 +17,8 @@ spec:
     {{- range $index, $endpoint := .Values.endpoints}}
     {{- if empty $endpoint.name }}
     - name: endpoint-{{$index}}
-      port: {{$endpoint.servicePort}}
-      targetPort: {{$endpoint.targetPort}}
+      port: {{$endpoint.port}} # envoy internal port
+      targetPort: {{$endpoint.targetPort}} # upstream database port
       protocol: TCP
     {{- end }}
     {{- end }}
@@ -50,8 +50,8 @@ metadata:
 spec:
   ports:
     - name: endpoint
-      port: {{$endpoint.servicePort}}
-      targetPort: {{$endpoint.targetPort}}
+      port: {{$endpoint.port}} # envoy internal port
+      targetPort: {{$endpoint.targetPort}} # upstream database port
       protocol: TCP
   selector:
     {{- include "selectorLabels" $ | nindent 4 }}


### PR DESCRIPTION
Fix service port mapping in service.yaml template to use correct endpoint.port instead of endpoint.servicePort. This ensures Kubernetes services expose the correct envoy internal ports and properly route to upstream database ports.

- Change service port from {{$endpoint.servicePort}} to {{$endpoint.port}}
- Add clarifying comments for port vs targetPort usage
- Bump chart version to 0.42.1 (production release)

The fix resolves service port mismatches where endpoints showed correct values but generated services had invalid port configurations.