### PR TITLE
[castai-hosted-model] Bump chart version and set auto as default value to the kvcache dtype…

### DIFF
--- a/charts/castai-hosted-model/Chart.lock
+++ b/charts/castai-hosted-model/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.16.0
 - name: vllm
   repository: file://child-charts/vllm
-  version: 0.0.13
-digest: sha256:bde52b50909f2f9c2a946280be10863a2ce12c8db94919345651e5624bd7ec88
-generated: "2025-08-11T09:21:55.648116+02:00"
+  version: 0.0.14
+digest: sha256:fdf869806511d176a920cc960a3f342e4f1290e64f4a211a8fd6e4cf89b3a8cd
+generated: "2025-08-14T10:19:23.1914+02:00"

--- a/charts/castai-hosted-model/Chart.yaml
+++ b/charts/castai-hosted-model/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-hosted-model
 description: CAST AI hosted model deployment chart.
 type: application
-version: 0.0.20
+version: 0.0.21
 appVersion: "v0.0.1"
 dependencies:
   - name: ollama

--- a/charts/castai-hosted-model/Chart.yaml
+++ b/charts/castai-hosted-model/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     repository: https://otwld.github.io/ollama-helm/
     condition: ollama.enabled
   - name: vllm
-    version: 0.0.13
+    version: 0.0.14
     repository: file://child-charts/vllm
     condition: vllm.enabled

--- a/charts/castai-hosted-model/README.md
+++ b/charts/castai-hosted-model/README.md
@@ -6,7 +6,7 @@ CAST AI hosted model deployment chart.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://child-charts/vllm | vllm | 0.0.13 |
+| file://child-charts/vllm | vllm | 0.0.14 |
 | https://otwld.github.io/ollama-helm/ | ollama | 1.16.0 |
 
 ## Values

--- a/charts/castai-hosted-model/child-charts/vllm/Chart.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vllm
 description: CAST AI hosted model deployment chart for vLLM.
 type: application
-version: 0.0.13
+version: 0.0.14
 appVersion: "v0.0.1"

--- a/charts/castai-hosted-model/child-charts/vllm/README.md
+++ b/charts/castai-hosted-model/child-charts/vllm/README.md
@@ -13,7 +13,7 @@ CAST AI hosted model deployment chart for vLLM.
 | enableChunkedPrefill | bool | `true` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/vllm-openai"` |  |
 | image.tag | string | `"v0.9.2"` |  |
-| kvCacheDtype | string | `"fp8_e5m2"` |  |
+| kvCacheDtype | string | `"auto"` |  |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health"},"initialDelaySeconds":15,"periodSeconds":10}` | Liveness probe configuration |
 | livenessProbe.failureThreshold | int | `3` | Number of times after which if a probe fails in a row, Kubernetes considers that the overall check has failed: the container is not alive |
 | livenessProbe.httpGet | object | `{"path":"/health"}` | Configuration of the Kubelet http request on the server |

--- a/charts/castai-hosted-model/child-charts/vllm/values.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/values.yaml
@@ -15,7 +15,7 @@ enableChunkedPrefill: true
 maxNumBatchedTokens: 10000
 enableAutoToolChoice: false
 dtype: "half"
-kvCacheDtype: "fp8_e5m2"
+kvCacheDtype: "auto" # Same as default in the vLLM engine. It will read models config and use the same dtype for cache.
 
 startupProbe:
   initialDelaySeconds: 20


### PR DESCRIPTION
We don't want to use `kv_cache_dtype` unless necessary as it triggers usage of V0 engine in vLLM which is deprecated and has lacks optimizations for MM models. 