### PR TITLE
[castai-db-optimizer] fix broken service ports in service chart

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.43.0
+version: 0.43.1

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.43.0](https://img.shields.io/badge/Version-0.43.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.43.1](https://img.shields.io/badge/Version-0.43.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/envoy_config.yaml
+++ b/charts/castai-db-optimizer/templates/envoy_config.yaml
@@ -241,8 +241,8 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: {{ required "endpoint hostname must be provided" $endpoint.hostname }}
-                          port_value: {{ required "endpoint targetPort is required" $endpoint.targetPort }}
+                          address: {{ required "endpoint hostname must be provided" $endpoint.hostname }} # upstream database host
+                          port_value: {{ required "endpoint targetPort is required" $endpoint.targetPort }} # upstream database port
           transport_socket:
             name: envoy.transport_sockets.start_tls
             typed_config:

--- a/charts/castai-db-optimizer/templates/service.yaml
+++ b/charts/castai-db-optimizer/templates/service.yaml
@@ -17,8 +17,8 @@ spec:
     {{- range $index, $endpoint := .Values.endpoints}}
     {{- if empty $endpoint.name }}
     - name: endpoint-{{$index}}
-      port: {{$endpoint.servicePort}}
-      targetPort: {{$endpoint.targetPort}}
+      port: {{$endpoint.servicePort}} # exposed service port ->
+      targetPort: {{$endpoint.port}} # -> port to DBO Proxy pod
       protocol: TCP
     {{- end }}
     {{- end }}
@@ -50,8 +50,8 @@ metadata:
 spec:
   ports:
     - name: endpoint
-      port: {{$endpoint.servicePort}}
-      targetPort: {{$endpoint.targetPort}}
+      port: {{$endpoint.servicePort}} # exposed service port ->
+      targetPort: {{$endpoint.port}} # -> port to DBO Proxy pod
       protocol: TCP
   selector:
     {{- include "selectorLabels" $ | nindent 4 }}


### PR DESCRIPTION
- Fix service  references to use correct endpoint value
- Add comments clarifying port mapping flow in service templates
- Update Envoy config comments for upstream database endpoints
- Bump chart version to 0.43.1

This fixes a critical issue where services were referencing the wrong port field, causing connection failures between services and the database optimizer proxy pods.