### PR TITLE
[castai-hosted-model] Disable WOOP for LLM workloads

### DIFF
--- a/charts/castai-hosted-model/Chart.lock
+++ b/charts/castai-hosted-model/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.16.0
 - name: vllm
   repository: file://child-charts/vllm
-  version: 0.0.15
-digest: sha256:e3b02e3fa08825114ecdcd510f3a0c9b41fc32ba2860835823dc6df65c8911f2
-generated: "2025-08-14T15:53:30.547189+03:00"
+  version: 0.0.16
+digest: sha256:03be40903835607cec871b55c817c4dfa6d306313ce8f2d0a36329a6e9538031
+generated: "2025-08-20T08:32:19.86123+02:00"

--- a/charts/castai-hosted-model/Chart.yaml
+++ b/charts/castai-hosted-model/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-hosted-model
 description: CAST AI hosted model deployment chart.
 type: application
-version: 0.0.22
+version: 0.0.23
 appVersion: "v0.0.1"
 dependencies:
   - name: ollama
@@ -10,6 +10,6 @@ dependencies:
     repository: https://otwld.github.io/ollama-helm/
     condition: ollama.enabled
   - name: vllm
-    version: 0.0.15
+    version: 0.0.16
     repository: file://child-charts/vllm
     condition: vllm.enabled

--- a/charts/castai-hosted-model/README.md
+++ b/charts/castai-hosted-model/README.md
@@ -6,7 +6,7 @@ CAST AI hosted model deployment chart.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://child-charts/vllm | vllm | 0.0.15 |
+| file://child-charts/vllm | vllm | 0.0.16 |
 | https://otwld.github.io/ollama-helm/ | ollama | 1.16.0 |
 
 ## Values

--- a/charts/castai-hosted-model/child-charts/vllm/Chart.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vllm
 description: CAST AI hosted model deployment chart for vLLM.
 type: application
-version: 0.0.15
+version: 0.0.16
 appVersion: "v0.0.1"

--- a/charts/castai-hosted-model/child-charts/vllm/templates/deployment.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/templates/deployment.yaml
@@ -8,6 +8,12 @@ metadata:
     {{- with .Values.deployment.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    workloads.cast.ai/configuration: |
+      vertical:
+        optimization: off
+      horizontal:
+        optimization: off
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/castai-hosted-model/templates/placement-job.yaml
+++ b/charts/castai-hosted-model/templates/placement-job.yaml
@@ -8,6 +8,12 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: placement-job
+  annotations:
+      workloads.cast.ai/configuration: |
+        vertical:
+          optimization: off
+        horizontal:
+          optimization: off
 spec:
   backoffLimit: 0
   template:


### PR DESCRIPTION
Disable of the WOOP for hosted models that use vLLM and placement job.

Based on the docs:

- https://docs.cast.ai/docs/workload-autoscaler-annotations-reference