### PR TITLE
[castai-hosted-models]: Remove unused cache directory

### DIFF
--- a/charts/castai-hosted-model/Chart.lock
+++ b/charts/castai-hosted-model/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.16.0
 - name: vllm
   repository: file://child-charts/vllm
-  version: 0.0.18
-digest: sha256:e61e356dadfdaad8961f9b85c292a344e7446f99d091ac3514cea08ff0701132
-generated: "2025-08-21T14:58:55.708798+03:00"
+  version: 0.0.19
+digest: sha256:93ddcb74e6da61595c3d768d021790a33f9514f38adec78da2f3f093c83d1c12
+generated: "2025-08-27T10:20:31.282131+02:00"

--- a/charts/castai-hosted-model/Chart.yaml
+++ b/charts/castai-hosted-model/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     repository: https://otwld.github.io/ollama-helm/
     condition: ollama.enabled
   - name: vllm
-    version: 0.0.18
+    version: 0.0.19
     repository: file://child-charts/vllm
     condition: vllm.enabled

--- a/charts/castai-hosted-model/child-charts/vllm/Chart.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vllm
 description: CAST AI hosted model deployment chart for vLLM.
 type: application
-version: 0.0.18
+version: 0.0.19
 appVersion: "v0.0.1"

--- a/charts/castai-hosted-model/child-charts/vllm/templates/deployment.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/templates/deployment.yaml
@@ -35,12 +35,6 @@ spec:
             medium: Memory
             sizeLimit: "10Gi"
         {{- end }}
-        {{- if .Values.mountImageCache }}
-        - name: llm-cache
-          hostPath:
-            path: /cache
-            type: Directory
-        {{- end }}
         {{- if include "requiresRegistry" (list "gcs" .) }}
         - name: gcs-credentials
           secret:
@@ -87,7 +81,7 @@ spec:
             {{- if .Values.toolCallParser }}
             - "--tool-call-parser={{ .Values.toolCallParser }}"
             {{- end }}
-            - "--download-dir=/cache"
+            - "--download-dir=/models"
             {{- if .Values.maxModelLen }}
             - "--max-model-len={{ .Values.maxModelLen }}"
             {{- end }}
@@ -98,6 +92,8 @@ spec:
             - "--quantization={{ .Values.quantization }}"
             {{- end }}
           env:
+            - name: HF_HOME # Otherwise transformers will not respect download dir in vLLM
+              value: /models
             - name: LD_LIBRARY_PATH
               value: "/usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}"
             {{- if .Values.useRunAiStreamer }}
@@ -153,10 +149,6 @@ spec:
           {{- if .Values.tensorParallelSize }}
             - name: shm
               mountPath: /dev/shm
-          {{- end }}
-          {{- if .Values.mountImageCache }}
-            - name: llm-cache
-              mountPath: /cache
           {{- end }}
             - name: models
               mountPath: /models

--- a/charts/castai-hosted-model/child-charts/vllm/values.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/values.yaml
@@ -49,7 +49,6 @@ service:
   type: ClusterIP
   port: 8000
 
-mountImageCache: false
 task: "generate"
 enableChunkedPrefill: true
 maxNumBatchedTokens: 10000


### PR DESCRIPTION
- Removes un-needed cache directory
   -  Before this change only model weights were written to the cache directory which was not mounted but anyways was created by HF on disk. Rest of the model files were scattered in the default `.cache` path
- Adds `HF_HOME` to configure transformers to download all model related files to the same directory
- Sets `--download-dir` to be `/models`
    - With this change all of the data related to models apart from CUDA caches and FlashKernel caches will be written in the `/models` dir. Which makes it easier to move to PVC if needed in the future