### PR TITLE
[castai-evictor] Enable live migrations by default.

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.59
+version: 0.33.63
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.33.58
+version: 0.33.59
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -47,7 +47,7 @@ Cluster utilization defragmentation tool
 | kubernetesClient.rateLimiter.qps | int | `100` | QPS or queries per second. Controls how many queries per second the client should be allowed to issue, not accounting for bursts. |
 | leaderElection | object | `{"enabled":true}` | Specifies leader election parameters. |
 | leaderElection.enabled | bool | `true` | Whether to enable leader election. |
-| liveMigration | object | `{"enabled":false,"useK8sClientCache":true}` | Specifies LIVE migration settings. This options assumes that the CAST AI LIVE components are already installed in the cluster. |
+| liveMigration | object | `{"enabled":true,"useK8sClientCache":true}` | Specifies LIVE migration settings. This options assumes that the CAST AI LIVE components are already installed in the cluster. |
 | managedByCASTAI | bool | `true` | Specifies whether the Evictor was installed using mothership and is automatically updated by CAST AI. Alternative scenarios are, when CAST AI is not managing charts, and customers' are install them with Argo CD/Terraform or something else. |
 | maxNodesToEvictPerCycle | int | `20` | Specifies the max nodes evictor can evict in a single cycle. |
 | nameOverride | string | `""` |  |

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -47,7 +47,7 @@ liveMigration:
   # to another node without interrupting these workloads.
   # Evictor will only consider LIVE migrations for workloads that explicitly request it.
   # as long as they can be scheduled somewhere else.
-  enabled: false
+  enabled: true
   # If true, Evictor will use a cache for its LIVE-specific client.
   # This should reduce the amount of read requests issued to the API server when working with LIVE migrations.
   # When false, all LIVE-related read requests will go to the API server.


### PR DESCRIPTION
Testing:

- [x] Set up a clean cluster with Live Migrations, install Evictor as usual — check if Evictor works with CLM.
- [x] Remove some permissions from the castai-evictor RBAC, to simulate customers that have older RBAC clusters that don't have the castai-evictor-ext chart updated — check if Evictor gracefully reports errors and does the usual evictions.
- [x] Remove the castai-evictor RBAC altogether, so we have no permissions to access migrations to simulate customers that have old Evictors that don't wish to have extended capabilities — check if Evictor gracefully reports errors and does the usual evictions.
- [x] Remove the Live Migration components, especially the CRD itself and restart Evictor — check if Evictor gracefully reports errors and does the usual evictions. We had an incident with WOOP where not having the CRD in the cluster resulted in an incident. Evictor should correctly detect that we don't have the CRD, meaning no permission to create it, report it and use the usual evictions.
- [x] I’ll send you the relevant Evictor code through a different channel so you can understand this better and expand on the tests.
- [x] One scenario we currently don't cover is if Live CRDs are removed from the cluster AND Evictor is not restarted. Then, Evictor will still think it is capable of Live Migrations, but with the CRDs gone that is no longer true.