### PR TITLE
[castai-db-optimizer] core dump collection for dbo proxy

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.44.0-rc7
+version: 0.44.0-rc8

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.44.0-rc7](https://img.shields.io/badge/Version-0.44.0--rc7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.44.0-rc8](https://img.shields.io/badge/Version-0.44.0--rc8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 
@@ -52,6 +52,7 @@ CAST AI database cache deployment.
 | protocol | string | `"PostgreSQL"` | Specifies database protocol to be used for communication and query parsing. |
 | proxy.concurrency | int | `12` | Number of parallel processing streams. This needs to be balanced with cpu resources for proxy and QP. |
 | proxy.connectionLimits | object | `{"maxConnections":1024,"maxPendingRequests":1024,"maxRequests":1024,"maxRetries":3}` | Envoy upstream connection limits, numbers given are the envoy defaults. |
+| proxy.coredumpCollectionMode | string | `"None"` | Disable core dump collection by default |
 | proxy.dataStorageMedium | string | `"Memory"` | Defines "emptyDir.medium" value for data storage volume. Set to "Memory" for tmpfs disk |
 | proxy.dnsLookupFamily | string | `"V4_PREFERRED"` | DNS lookup mode when communicating to outside. will prioritize IPV4 addresses. change to V6_ONLY to use v6 addresses instead. |
 | proxy.drainPreHook | int | `2` | Predrain timeout in seconds. |

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultProxyVersion" -}}v4.64.14{{- end -}}
+{{- define "defaultProxyVersion" -}}v4.65.0{{- end -}}
 {{- define "defaultQueryProcessorVersion" -}}v0.18.0{{- end -}}

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -205,8 +205,9 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
           command:
-            - /home/castai/envoy
+            - /home/castai/coredumpwrapper.sh
           args:
+            - /home/castai/envoy
             - -c
             - /home/castai/envoy.yaml
             - --component-log-level
@@ -230,6 +231,15 @@ spec:
             {{- if .Values.resources.proxy.memoryLimit }}
             limits:
               memory: {{ .Values.resources.proxy.memoryLimit }}
+            {{- end }}
+          env:
+            - name: API_URL
+              value: {{ required "apiURL must be provided" .Values.apiURL | printf "https://%s" }}
+            - name: CACHE_GROUP_ID
+              value: {{ .Values.cacheGroupID | required ".Values.cacheGroupID is required." | quote }}
+            {{- if .Values.proxy.coredumpCollectionMode }}
+            - name: COREDUMP_COLLECTION_MODE
+              value: {{ .Values.proxy.coredumpCollectionMode }}
             {{- end }}
           envFrom:
             - secretRef:

--- a/charts/castai-db-optimizer/values.yaml
+++ b/charts/castai-db-optimizer/values.yaml
@@ -103,6 +103,8 @@ proxy:
     maxPendingRequests: 1024       # Maximum requests queued while waiting for a connection
     maxRequests: 1024              # Maximum parallel requests per connection
     maxRetries: 3                  # Maximum parallel retries
+  # -- Disable core dump collection by default
+  coredumpCollectionMode: "None"
 
 queryProcessor:
   # -- Default query-processor log level.


### PR DESCRIPTION
Adding required env variables for core dump collection to work properly:
`API_URL` -- same as for query-processor
`CACHE_GROUP_ID` -- same as for query-processor
`COREDUMP_COLLECTION` -- by default "None" which disables the collection. To enable switch to "Full".

Changing the entrypoint for proxy container -- now it's a shell wrapper that monitors envoy binary and collects coredumps if needed.