### PR TITLE
[castai-db-optimizer] elevated security context for dbo diagnostics

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.45.2-rc1
+version: 0.45.2-rc2

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.45.2-rc1](https://img.shields.io/badge/Version-0.45.2--rc1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.45.2-rc2](https://img.shields.io/badge/Version-0.45.2--rc2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/ci/test-values.yaml
+++ b/charts/castai-db-optimizer/ci/test-values.yaml
@@ -36,6 +36,7 @@ proxy:
     maxRequests: 1024
     maxRetries: 3
   dnsLookupFamily: V4_ONLY
+  coredumpCollectionMode: "Full"
 
 podLabels:
   podLabel: label

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -197,6 +197,12 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 5
           {{- end}}
+          {{- if eq .Values.proxy.coredumpCollectionMode "Full"}}
+          securityContext:
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            runAsUser: 0
+          {{- else }}
           securityContext:
             capabilities:
               drop:
@@ -204,6 +210,7 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000
+          {{- end }}
           command:
             - /home/castai/coredumpwrapper.sh
           args:


### PR DESCRIPTION
In order to collect core dumps, `proxy` container (part of DBO) needs to run as root and has the write access to root.
This happens only if `proxy.coredumpCollectionMode` is set to `"Full"`, otherwise the restrictive security context is used.