### PR TITLE
LLM-665: Use vllm-openai:v0.10.2 by default in the castai-hosted-model chart

### DIFF
--- a/charts/castai-hosted-model/Chart.yaml
+++ b/charts/castai-hosted-model/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-hosted-model
 description: CAST AI hosted model deployment chart.
 type: application
-version: 0.0.28
+version: 0.0.30
 appVersion: "v0.0.1"
 dependencies:
   - name: ollama
@@ -10,6 +10,5 @@ dependencies:
     repository: https://otwld.github.io/ollama-helm/
     condition: ollama.enabled
   - name: vllm
-    version: 0.0.21
-    repository: file://child-charts/vllm
+    version: 0.0.22
     condition: vllm.enabled

--- a/charts/castai-hosted-model/README.md
+++ b/charts/castai-hosted-model/README.md
@@ -6,7 +6,7 @@ CAST AI hosted model deployment chart.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://child-charts/vllm | vllm | 0.0.21 |
+|  | vllm | 0.0.22 |
 | https://otwld.github.io/ollama-helm/ | ollama | 1.16.0 |
 
 ## Values

--- a/charts/castai-hosted-model/child-charts/vllm/Chart.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vllm
 description: CAST AI hosted model deployment chart for vLLM.
 type: application
-version: 0.0.21
+version: 0.0.22
 appVersion: "v0.0.1"

--- a/charts/castai-hosted-model/child-charts/vllm/README.md
+++ b/charts/castai-hosted-model/child-charts/vllm/README.md
@@ -12,7 +12,7 @@ CAST AI hosted model deployment chart for vLLM.
 | enableAutoToolChoice | bool | `false` |  |
 | enableChunkedPrefill | bool | `true` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/vllm-openai"` |  |
-| image.tag | string | `"v0.9.2"` |  |
+| image.tag | string | `"v0.10.2"` |  |
 | kvCacheDtype | string | `"auto"` |  |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health"},"initialDelaySeconds":15,"periodSeconds":10}` | Liveness probe configuration |
 | livenessProbe.failureThreshold | int | `3` | Number of times after which if a probe fails in a row, Kubernetes considers that the overall check has failed: the container is not alive |

--- a/charts/castai-hosted-model/child-charts/vllm/values.yaml
+++ b/charts/castai-hosted-model/child-charts/vllm/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: "us-docker.pkg.dev/castai-hub/library/vllm-openai"
-  tag: "v0.9.2"
+  tag: "v0.10.2"
 
 replicaCount: 1
 resources: {}


### PR DESCRIPTION
This PR upgrades the default `vllm-openai` image to `v0.10.2` in the castai-hosted-model chart.