### PR TITLE
[castai-db-optimizer] Change `dbo-collector` deployment labels to prevent its pods from being included in `dbo-proxy` named service endpoints

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.45.3-rc3
+version: 0.45.3-rc4

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.45.3-rc3](https://img.shields.io/badge/Version-0.45.3--rc3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.45.3-rc4](https://img.shields.io/badge/Version-0.45.3--rc4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/dbo-collector.yaml
+++ b/charts/castai-db-optimizer/templates/dbo-collector.yaml
@@ -11,11 +11,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "name" . }}-index-advisor
+      app.kubernetes.io/component: index-advisor
   template:
     metadata:
       labels:
-        {{- include "selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "name" . }}-index-advisor
+        app.kubernetes.io/component: index-advisor
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This PR updates the `dbo-collector` deployment labels so that its pods are no longer picked up by the  `dbo-proxy` named service endpoints.

Consider the following list of pods:

```sh
$ kubectl get pods -n castai-db-optimizer -o custom-columns="NAME:.metadata.name,IP:.status.podIP"

NAME                                                              IP
db-optimizer-test-b7799-8547f8c655-p7tb7                          192.168.194.56
db-optimizer-test-b7799-index-advisor-collector-96fcc7cb9-lcb8c   192.168.194.57
```

Here, the `dbo-collector` (`index-advisor`) pod is incorrectly selected by the `dbo-proxy` default endpoint service, even though it doesn't expose a database endpoint:

<img width="721" height="774" alt="image" src="https://github.com/user-attachments/assets/ef91c215-5d7a-4e0e-b18c-5482b604e3ff" />

As a result, downstream consumers of the service may be routed to the wrong pod, encountering unexpected connection errors.
