### PR TITLE
[castai-db-optimizer] Truncate `dbo-collector` name label to 63 chars

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.45.3-rc4
+version: 0.45.3-rc5

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.45.3-rc4](https://img.shields.io/badge/Version-0.45.3--rc4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.45.3-rc5](https://img.shields.io/badge/Version-0.45.3--rc5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/dbo-collector.yaml
+++ b/charts/castai-db-optimizer/templates/dbo-collector.yaml
@@ -11,12 +11,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "name" . }}-index-advisor-collector
+      app.kubernetes.io/name: {{ printf "%s-index-advisor-collector" (include "name" .) | trunc 63 }}
       app.kubernetes.io/component: index-advisor-collector
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "name" . }}-index-advisor-collector
+        app.kubernetes.io/name: {{ printf "%s-index-advisor-collector" (include "name" .) | trunc 63 }}
         app.kubernetes.io/component: index-advisor-collector
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Addresses deployment errors such as:

```
error when patching "/dev/shm/1297378085": Deployment.apps "db-optimizer-**************************************-index-advisor-collector" is invalid: [spec.selector.matchLabels: Invalid value: "db-optimizer-**************************************-index-advisor-collector": must be no more than 63 characters, spec.selector: Invalid value: v1.LabelSelector{MatchLabels:
```