### PR TITLE
[castai-cluster-controller] bugfix secret ns cluster-controller

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.85.0
+version: 0.85.1
 appVersion: "v0.60.0"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/templates/resource-quota.yaml
+++ b/charts/castai-cluster-controller/templates/resource-quota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: {{ include "cluster-controller.fullname" . }}-critical-pods
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-controller.labels" . | nindent 4 }}
   {{ if gt (len .Values.commonAnnotations) 0 -}}

--- a/charts/castai-cluster-controller/templates/secret.yaml
+++ b/charts/castai-cluster-controller/templates/secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: castai-cluster-controller
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-controller.labels" . | nindent 4 }}
   {{ if gt (len .Values.commonAnnotations) 0 -}}


### PR DESCRIPTION
- When running provisioning with terragrunt using this example [eks-clusters](https://github.com/castai/terraform-provider-castai/tree/master/examples/eks/eks_clusters) , we have identified the terragrunt is not retrieving properly the namespace. 

- Making the adjustment on tf like below, secret resource got created properly. 
```
    castai_cluster_controller_values = [
    <<-YAML
    createNamespace: true
    YAML
  ]
```

  - Based on that, I have added like others template resources the call for namespace like the best practices stand for. 