### PR TITLE
[castai-db-optimizer] integrate Google Cloud SQL Proxy

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.47.6
+version: 0.48.0

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.47.6](https://img.shields.io/badge/Version-0.47.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.48.0](https://img.shields.io/badge/Version-0.48.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 
@@ -13,6 +13,13 @@ CAST AI database cache deployment.
 | apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing DBO access to the API apiKey and apiKeySecretRef are mutually exclusive The referenced secret must provide the token in .data["API_KEY"]. |
 | apiURL | string | `"api.cast.ai"` | URL to the CAST AI API server. |
 | cacheGroupID | string | `""` | ID of the cache group for which cache configuration should be pulled.  |
+| cloudSqlProxy.autoIamAuthn | bool | `false` | Have the proxy connect with Automatic IAM authentication |
+| cloudSqlProxy.basePort | int | `10000` | Starting number from which unique ports are sequentially assigned to each upstream Cloud SQL instance |
+| cloudSqlProxy.enabled | bool | `false` | Enable Cloud SQL Proxy sidecar |
+| cloudSqlProxy.privateIp | bool | `false` | Have the proxy connect over private IP if connecting from a VPC-native GKE cluster |
+| cloudSqlProxyImage.pullPolicy | string | `"IfNotPresent"` |  |
+| cloudSqlProxyImage.repository | string | `"gcr.io/cloud-sql-connectors/cloud-sql-proxy"` |  |
+| cloudSqlProxyImage.tag | string | `""` |  |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | endpoints | list | `[{"hostname":"sample-db-hostname","name":null,"port":5433,"serviceDiscovery":{"dns_lookup_family":"ALL","dns_refresh_rate":"5000ms","respect_dns_ttl":true,"type":"LOGICAL_DNS"},"servicePort":5432,"targetPort":5432}]` | A list of upstream database endpoints |
@@ -25,8 +32,8 @@ CAST AI database cache deployment.
 | endpoints[0].targetPort | int | `5432` | Port of the upstream database instance. |
 | nodeSelector | object | `{}` | Pod node selector rules. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | pgcatImage.pullPolicy | string | `"IfNotPresent"` |  |
-| pgcatImage.repository | string | `"ghcr.io/postgresml/pgcat"` |  |
-| pgcatImage.tag | string | `"v1.2.0"` |  |
+| pgcatImage.repository | string | `"us-docker.pkg.dev/castai-hub/library/dbo-pooling-pgcat"` |  |
+| pgcatImage.tag | string | `"v1.2.0-embedded-ssl"` |  |
 | podAnnotations | object | `{}` | Extra annotations to add to the pod. |
 | podLabels | object | `{}` | Extra labels to add to the pod. |
 | pooling.banTime | int | `60` | Ban time in seconds |
@@ -96,6 +103,7 @@ CAST AI database cache deployment.
 | resources.proxy.memoryRequest | string | `"2Gi"` |  |
 | resources.queryProcessor.cpu | string | `"2"` |  |
 | resources.queryProcessor.memory | string | `"1Gi"` |  |
+| serviceAccountName | string | `""` | The name of the service account to be used by the pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | tolerations | object | `{}` | Pod toleration rules. Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 | upstreamPostgresHostname | string | `""` | deprecated: Hostname of the upstream Postgres instance. |
 | upstreamPostgresPort | int | `5432` | deprecated: Port of the upstream Postgres instance. |

--- a/charts/castai-db-optimizer/templates/_helpers.tpl
+++ b/charts/castai-db-optimizer/templates/_helpers.tpl
@@ -21,6 +21,10 @@ Create chart name and version as used by the chart label.
 {{-  default (include "defaultProxyVersion" .) .Values.proxyImage.tag }}
 {{- end }}
 
+{{- define "cloudSqlProxyImage" -}}
+{{-  default (include "defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
+{{- end }}
+
 {{/*
 Helpers for customizing proxy TLS settings.
 */}}

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,2 +1,3 @@
 {{- define "defaultProxyVersion" -}}v4.67.3{{- end -}}
 {{- define "defaultQueryProcessorVersion" -}}v0.21.0{{- end -}}
+{{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.drainTimeSeconds | default 60 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -45,7 +48,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-
 
       volumes:
         - name: envoy-config
@@ -344,4 +346,26 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
         {{- end }}
+        {{- end }}
+        {{- if .Values.cloudSqlProxy.enabled }}
+        - name: cloud-sql-proxy
+          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "cloudSqlProxyImage" . }}"
+          imagePullPolicy: {{ $.Values.cloudSqlProxyImage.pullPolicy }}
+          args:
+            {{- if .Values.cloudSqlProxy.privateIp }}
+            - "--private-ip"
+            {{- end }}
+            {{- if .Values.cloudSqlProxy.autoIamAuthn }}
+            - "--auto-iam-authn"
+            {{- end }}
+            - "--structured-logs"
+            {{- range $index, $endpoint := .Values.endpoints }}
+            - "{{ $endpoint.hostname }}?port={{ add $.Values.cloudSqlProxy.basePort $index }}"
+            {{- end }}
+          securityContext:
+            runAsNonRoot: true
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
         {{- end }}

--- a/charts/castai-db-optimizer/templates/envoy_config.yaml
+++ b/charts/castai-db-optimizer/templates/envoy_config.yaml
@@ -254,8 +254,11 @@ data:
                       address:
                         socket_address:
                           {{- if and $.Values.pooling $.Values.pooling.enabled }}
-                          address: 127.0.0.1 # local pgcat in same pod
+                          address: 127.0.0.1 # local pgcat container running in the same pod
                           port_value: {{ add $endpoint.port 100 }} # pgcat port
+                          {{- else if and $.Values.cloudSqlProxy $.Values.cloudSqlProxy.enabled }}
+                          address: 127.0.0.1 # local cloud-sql-proxy container running in the same pod
+                          port_value: {{ add $.Values.cloudSqlProxy.basePort $index }}
                           {{- else }}
                           address: {{ required "endpoint hostname must be provided" $endpoint.hostname }} # upstream database host
                           port_value: {{ required "endpoint targetPort is required" $endpoint.targetPort }} # upstream database port

--- a/charts/castai-db-optimizer/templates/pgcat-config.yaml
+++ b/charts/castai-db-optimizer/templates/pgcat-config.yaml
@@ -49,7 +49,11 @@ data:
     [pools.{{ $database }}.shards."0"]
     database = "{{ $database }}"
     servers = [
+      {{- if and $.Values.cloudSqlProxy $.Values.cloudSqlProxy.enabled }}
+      ["127.0.0.1", {{ add $.Values.cloudSqlProxy.basePort $index }}, "primary"]
+      {{- else }}
       ["{{ required "endpoint hostname must be provided" $endpoint.hostname }}", {{ required "endpoint targetPort is required" $endpoint.targetPort }}, "primary"]
+      {{- end }}
     ]
     
     [pools.{{ $database }}.users."0"]

--- a/charts/castai-db-optimizer/values.yaml
+++ b/charts/castai-db-optimizer/values.yaml
@@ -188,6 +188,16 @@ pooling:
   # -- Size of prepared statements cache
   preparedStatementsCacheSize: 1000
 
+cloudSqlProxy:
+  # -- Enable Cloud SQL Proxy sidecar
+  enabled: false
+  # -- Starting number from which unique ports are sequentially assigned to each upstream Cloud SQL instance
+  basePort: 10000
+  # -- Have the proxy connect over private IP if connecting from a VPC-native GKE cluster
+  privateIp: false
+  # -- Have the proxy connect with Automatic IAM authentication
+  autoIamAuthn: false
+
 queryProcessorImage:
   repository: us-docker.pkg.dev/castai-hub/library/query-processor
   pullPolicy: IfNotPresent
@@ -198,10 +208,19 @@ proxyImage:
   pullPolicy: IfNotPresent
   tag: ""  # uses values from _versions.tpl for default value
 
-pgcatImage:
-  repository: ghcr.io/postgresml/pgcat
+cloudSqlProxyImage:
+  repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
   pullPolicy: IfNotPresent
-  tag: "v1.2.0"
+  tag: ""  # uses values from _versions.tpl for default value
+
+pgcatImage:
+  repository: us-docker.pkg.dev/castai-hub/library/dbo-pooling-pgcat
+  pullPolicy: IfNotPresent
+  tag: "v1.2.0-embedded-ssl"
+
+# -- The name of the service account to be used by the pod.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+serviceAccountName: ""
 
 # -- Pod toleration rules.
 # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
This PR adds support for deploying a [Cloud SQL Proxy](https://cloud.google.com/sql/docs/mysql/sql-proxy) sidecar alongside the database optimizer. New configuration options allow enabling the proxy and toggling features like automatic IAM authentication and private IP usage.

To use this integration, users can specify the connection names of the upstream Cloud SQL instances when creating the Cache Group in the UI:

<img width="751" height="668" alt="image" src="https://github.com/user-attachments/assets/6d7af1ac-0094-4094-8ef4-083b53379c85" />

These should be identical to the connection names reported in the Google Cloud Console:

<img width="892" height="307" alt="image" src="https://github.com/user-attachments/assets/6b98087e-72cc-4177-bf9b-d78cdde72ff9" />

Additionaly, the following Helm values need to be set:

```yaml
cloudSqlProxy:
  enabled: true
  privateIp: true
  autoIamAuthn: true
```

 **Note:** `privateIp` and `autoIamAuthn` are optional and default to `false` if not explicitly specified.

This example setup would create the following endpoints:

**First endpoint**

<img width="757" height="253" alt="image" src="https://github.com/user-attachments/assets/c1cdf9f2-ca75-43f3-965c-bdaea29c6b2f" />


**Second endpoint**

<img width="759" height="253" alt="image" src="https://github.com/user-attachments/assets/9d79dd3e-e2eb-412c-a88e-9c3be31e1128" />

In the background, the Helm chart automatically maps each instance to a Cloud SQL Proxy listener using a specific port range determined by the `cloudSqlProxy.basePort` setting:

<img width="1084" height="198" alt="image" src="https://github.com/user-attachments/assets/952b8062-c994-4b96-a3d5-eb16857f32d9" />

This is also reflected in the generated Envoy config:

<img width="821" height="294" alt="image" src="https://github.com/user-attachments/assets/659c67e7-93ce-422a-8608-d08bf7fc9a1a" />
