### PR TITLE
[castai-agent] Only create service account if Values.serviceAccount.create is true

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.118.0
+version: 0.119.0
 appVersion: "v0.100.0"

--- a/charts/castai-agent/templates/rbac.yaml
+++ b/charts/castai-agent/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -16,7 +16,9 @@ metadata:
     {{- toYaml . | nindent 4}}
     {{- end }}
   {{- end }}
+{{- end }}
 
+{{- if .Values.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Currently, a service account is created if `Values.rbac.enabled` is true but that's incorrect: it should be created if `Values.serviceAccount.create` is true.