### PR TITLE
[castai-spot-handler] KUBE-1504: Use new spot-handler version with ProviderID

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.27.0
-appVersion: "v0.17.3"
+version: 0.28.0
+appVersion: "v0.18.0"


### PR DESCRIPTION
New version sends providerID to Cast.AI to enable processing interruption events for non-cast nodes as well. 
See https://github.com/castai/spot-handler/pull/31 