### PR TITLE
[castai-db-optimizer] Add `nil` check for `cloudSqlProxy` to prevent upgrade failures when using `--reuse-values`

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.49.2
+version: 0.49.3

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.49.2](https://img.shields.io/badge/Version-0.49.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.49.3](https://img.shields.io/badge/Version-0.49.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -335,7 +335,7 @@ spec:
             periodSeconds: 20
         {{- end }}
         {{- end }}
-        {{- if .Values.cloudSqlProxy.enabled }}
+        {{- if and .Values.cloudSqlProxy .Values.cloudSqlProxy.enabled }}
         - name: cloud-sql-proxy
           image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "cloudSqlProxyImage" . }}"
           imagePullPolicy: {{ $.Values.cloudSqlProxyImage.pullPolicy }}


### PR DESCRIPTION
Adds a defensive `nil` check for the `cloudSqlProxy` configuration value in the deployment template to prevent this type of errors when upgrading with `--reuse-values` from older chart versions that lack this configuration:

```
Error: UPGRADE FAILED: template: castai-db-optimizer/templates/deployment.yaml:338:22: executing "castai-db-optimizer/templates/deployment.yaml" at <.Values.cloudSqlProxy.enabled>: nil pointer evaluating interface {}.enabled
```

The fix follows the same pattern already used for other features, ensuring backward compatibility and allowing seamless upgrades without requiring users to necessarily export and merge values manually.
