### PR TITLE
[castai-db-optimizer] Add `appProtocol` field to database service ports

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.49.4
+version: 0.49.5

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.49.4](https://img.shields.io/badge/Version-0.49.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.49.5](https://img.shields.io/badge/Version-0.49.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/service.yaml
+++ b/charts/castai-db-optimizer/templates/service.yaml
@@ -13,6 +13,7 @@ spec:
       port: 5432
       targetPort: postgres
       protocol: TCP
+      appProtocol: postgresql
     {{- end}}
     {{- range $index, $endpoint := .Values.endpoints}}
     {{- if empty $endpoint.name }}
@@ -20,6 +21,11 @@ spec:
       port: {{$endpoint.servicePort}} # exposed service port ->
       targetPort: {{$endpoint.port}} # -> port to DBO Proxy pod
       protocol: TCP
+      {{- if eq $.Values.protocol "MySQL" }}
+      appProtocol: mysql
+      {{- else if eq $.Values.protocol "PostgreSQL" }}
+      appProtocol: postgresql
+      {{- end }}
     {{- end }}
     {{- end }}
     - name: grpc
@@ -53,6 +59,11 @@ spec:
       port: {{$endpoint.servicePort}} # exposed service port ->
       targetPort: {{$endpoint.port}} # -> port to DBO Proxy pod
       protocol: TCP
+      {{- if eq $.Values.protocol "MySQL" }}
+      appProtocol: mysql
+      {{- else if eq $.Values.protocol "PostgreSQL" }}
+      appProtocol: postgresql
+      {{- end }}
   selector:
     {{- include "selectorLabels" $ | nindent 4 }}
 


### PR DESCRIPTION
This PR adds the `appProtocol` field to all database service ports in the `castai-db-optimizer` chart to enable [explicit protocol selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection) for Istio. 

The `appProtocol` field on each service port is conditionally set to either `mysql` or `postgresql` (the [IANA standard names](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml) for these services) based on the `.Values.protocol` configuration.

Beyond Istio, this field could serve as a hint for other tools and applications to offer richer protocol-specific behavior.