### PR TITLE
[castai-spot-handler] OMNI-289: allow overriding providerID

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.28.2
-appVersion: "v0.18.0"
+version: 0.28.3
+appVersion: "v0.18.1"


### PR DESCRIPTION
New version adds the option to override the providerID sent to CAST. If the node has provisioner.cast.ai/override-provider-id annotation set, it will take precedence over providerID from node Spec.
See [castai/spot-handler#32](https://github.com/castai/spot-handler/pull/32)