### PR TITLE
fix: Respect custom resources configuration with clusterVPA enabled

### DIFF
--- a/charts/castai-agent/templates/deployment.yaml
+++ b/charts/castai-agent/templates/deployment.yaml
@@ -145,7 +145,7 @@ spec:
           {{- end }}
           {{/* we don't set resources if Cluster proportional vertical autoscaler is enabled */}}
           resources:
-          {{- if .Values.clusterVPA.enabled -}}
+          {{- if and .Values.clusterVPA.enabled (not .Values.resources) -}}
           {{/* we hardcode CPU req/limit for now */}}
             requests:
               cpu: 100m

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
           {{- end }}
           {{/* we don't set resources if Cluster proportional vertical autoscaler is enabled */}}
           resources:
-          {{- if .Values.clusterVPA.enabled -}}
+          {{- if and .Values.clusterVPA.enabled (not .Values.resources) -}}
           {{/* we hardcode CPU req/limit for now */}}
             requests:
               cpu: 100m


### PR DESCRIPTION
Allows explicit resource configuration to override CVPA defaults when `clusterVPA.enabled` is true.

### Problem
Previously, when `clusterVPA.enabled` was true, the chart always used hardcoded CPU values and completely ignored `.Values.resources`. This made it impossible to set other resource types like `ephemeral-storage`, which can cause deployment failures when enforced by admission controllers.

### Solution
Modified the condition to only use hardcoded CPU defaults when CVPA is enabled **and** no resources are explicitly configured. Now users can provide custom resources (including `ephemeral-storage`) even when VPA is enabled.

### Example
Without this change, the following would be ignored when CVPA is enabled:

```yaml
resources:
  requests:
    ephemeral-storage: 1Gi
  limits:
    ephemeral-storage: 2Gi
```

This could block deployments in clusters with admission controllers requiring ephemeral-storage requests & limits.