### PR TITLE
[castai-pod-pinner] Add toleration for resuming nodes

### DIFF
--- a/charts/castai-pod-pinner/Chart.yaml
+++ b/charts/castai-pod-pinner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-pod-pinner
 description: CAST AI Pod Pinning deployment chart.
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: "v1.8.0"
 dependencies:
   - name: castai-pod-pinner-ext

--- a/charts/castai-pod-pinner/README.md
+++ b/charts/castai-pod-pinner/README.md
@@ -1,6 +1,6 @@
 # castai-pod-pinner
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.8.0](https://img.shields.io/badge/AppVersion-v1.8.0-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.8.0](https://img.shields.io/badge/AppVersion-v1.8.0-informational?style=flat-square)
 
 CAST AI Pod Pinning deployment chart.
 

--- a/charts/castai-pod-pinner/templates/deployment.yaml
+++ b/charts/castai-pod-pinner/templates/deployment.yaml
@@ -176,6 +176,10 @@ spec:
         - key: "scheduling.cast.ai/pod-pinning-preparing"
           operator: "Exists"
           effect: "NoSchedule"
+        - key: "provisioning.cast.ai/temporary"
+          operator: "Equal"
+          value: "resuming"
+          effect: "NoSchedule"
       {{- with .Values.tolerations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Add non-overridable toleration to allow pod-pinner to schedule on nodes with the provisioning.cast.ai/temporary=resuming taint. This ensures pod-pinner can run during node resuming operations.

Changes:
- Add toleration to deployment.yaml
- Bump chart version to 1.5.1
- Regenerate chart documentation