### PR TITLE
chore: allow to define author while doing helm release

### DIFF
--- a/.github/actions/remote-release/action.yaml
+++ b/.github/actions/remote-release/action.yaml
@@ -37,6 +37,14 @@ inputs:
     description: "If true, set chart version from release tag instead of auto-incrementing patch. Default: false (backwards compatible)"
     required: false
     default: "false"
+  git-author-name:
+    description: "Git author name for commits (defaults to github actor). Can be used to set github app as commit author"
+    required: false
+    default: ""
+  git-author-email:
+    description: "Git author email for commits (defaults to github actor email). Can be used to set github app as commit author"
+    required: false
+    default: ""
 
 outputs: {}
 
@@ -66,8 +74,10 @@ runs:
       shell: bash
       run: |
         cd helm-charts
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        GIT_AUTHOR_NAME="${{ inputs.git-author-name }}"
+        GIT_AUTHOR_EMAIL="${{ inputs.git-author-email }}"
+        git config user.name "${GIT_AUTHOR_NAME:-$GITHUB_ACTOR}"
+        git config user.email "${GIT_AUTHOR_EMAIL:-$GITHUB_ACTOR@users.noreply.github.com}"
 
     - name: Install Helm
       uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
@@ -139,8 +149,10 @@ runs:
       run: |
         git status
         git diff
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        GIT_AUTHOR_NAME="${{ inputs.git-author-name }}"
+        GIT_AUTHOR_EMAIL="${{ inputs.git-author-email }}"
+        git config user.name "${GIT_AUTHOR_NAME:-$GITHUB_ACTOR}"
+        git config user.email "${GIT_AUTHOR_EMAIL:-$GITHUB_ACTOR@users.noreply.github.com}"
         git checkout main
         git add ${{ inputs.chart-path }}/Chart.yaml
         git commit -m "[Release] Update Chart.yaml"
@@ -164,10 +176,12 @@ runs:
           echo "Sync chart with helm-charts github is disabled"
           exit 0
         fi
-        
+
         cd helm-charts
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        GIT_AUTHOR_NAME="${{ inputs.git-author-name }}"
+        GIT_AUTHOR_EMAIL="${{ inputs.git-author-email }}"
+        git config user.name "${GIT_AUTHOR_NAME:-$GITHUB_ACTOR}"
+        git config user.email "${GIT_AUTHOR_EMAIL:-$GITHUB_ACTOR@users.noreply.github.com}"
         git checkout main
         cp -r ${{ inputs.chart-path }}/* ./charts/${{ steps.parse-chart.outputs.name }}
         git add charts/${{ steps.parse-chart.outputs.name }}


### PR DESCRIPTION
this should allow to define github app as commit author. Having github app as author we can enable back branch protections and include app in by pass rule. Without this we can't have any branch protection rules when helm chart is being released

<img width="777" height="343" alt="image" src="https://github.com/user-attachments/assets/be46b37b-3c81-41f8-b5de-25d68fd54c3b" />
