### PR TITLE
[castai-agent] Consolidate the RBAC for the autoscaling api group.

### DIFF
--- a/charts/castai-agent/Chart.yaml
+++ b/charts/castai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-agent
 description: CAST AI agent deployment chart.
 type: application
-version: 0.151.0
+version: 0.152.0
 appVersion: "v0.123.0"

--- a/charts/castai-agent/templates/rbac.yaml
+++ b/charts/castai-agent/templates/rbac.yaml
@@ -166,7 +166,7 @@ rules:
   - apiGroups:
       - "autoscaling.cast.ai"
     resources:
-      - recommendations
+      - "*"
     verbs:
       - get
       - list
@@ -187,14 +187,6 @@ rules:
       - resourceclaimtemplates
       - resourceslices
       - devicetaintrules
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "autoscaling.cast.ai"
-    resources:
-      - custommetricsexporterconfigs
     verbs:
       - get
       - list


### PR DESCRIPTION
Consolidate permissions for `autoscaling.cast.ai` api group to incorporate access for the agent into various cast.ai api - specific purpose here to enable reading evictor config cr.

Ref: https://github.com/castai/helm-charts/pull/1310