### PR TITLE
[castai-umbrella] remove castai-evictor from kent subchart

### DIFF
--- a/charts/castai-umbrella/Chart.lock
+++ b/charts/castai-umbrella/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kent
   repository: file://charts/kent
-  version: 0.12.0
+  version: 0.11.0
 - name: autoscaler-anywhere
   repository: file://charts/autoscaler-anywhere
   version: 0.4.0
@@ -11,5 +11,5 @@ dependencies:
 - name: autoscaler
   repository: file://charts/autoscaler
   version: 0.1.0
-digest: sha256:e4cc3e13c1a87fa0f0ad9c326d5e9fcd3b603cb43cf406bab261230c4e20af02
-generated: "2026-04-14T16:01:19.003996+03:00"
+digest: sha256:60538f7222399f986741c9766df2c648e4d767dc35f73ecb3567cb8b6cd26c66
+generated: "2026-04-14T16:13:44.080811+03:00"

--- a/charts/castai-umbrella/Chart.lock
+++ b/charts/castai-umbrella/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kent
   repository: file://charts/kent
-  version: 0.10.1
+  version: 0.11.0
 - name: autoscaler-anywhere
   repository: file://charts/autoscaler-anywhere
   version: 0.4.0
@@ -11,5 +11,5 @@ dependencies:
 - name: autoscaler
   repository: file://charts/autoscaler
   version: 0.1.0
-digest: sha256:d5fae77ecb20fdd2891c950ee1340f6d571ecce0b54ba4c18f22b106ebdea196
-generated: "2026-04-09T12:25:59.310764+02:00"
+digest: sha256:60538f7222399f986741c9766df2c648e4d767dc35f73ecb3567cb8b6cd26c66
+generated: "2026-04-14T15:21:10.404305+03:00"

--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.22.32
+version: 0.23.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/README.md
+++ b/charts/castai-umbrella/README.md
@@ -19,7 +19,7 @@ This chart bundles three independent product profiles. Enable exactly one per in
 |--------|-----------|----------------|-----------|
 | **autoscaler** | `tags.<mode>=true` | Managed cloud (EKS, AKS, GKE) | Mode-dependent — see [Autoscaler](#autoscaler) |
 | **autoscaler-anywhere** | `tags.autoscaler-anywhere=true` | Non-managed (bare metal, on-prem, edge) | castai-agent, castai-cluster-controller, castai-workload-autoscaler, castai-workload-autoscaler-exporter, castai-evictor, castai-pod-mutator |
-| **kent** | `kent.enabled=true` | EKS only | castai-agent, castai-cluster-controller, castai-kentroller, castai-workload-autoscaler, castai-live, castai-pod-mutator, castai-evictor |
+| **kent** | `kent.enabled=true` | EKS only | castai-agent, castai-cluster-controller, castai-kentroller, castai-workload-autoscaler, castai-live, castai-pod-mutator |
 
 ---
 

--- a/charts/castai-umbrella/README.md.gotmpl
+++ b/charts/castai-umbrella/README.md.gotmpl
@@ -12,7 +12,7 @@ This chart bundles three independent product profiles. Enable exactly one per in
 |--------|-----------|----------------|-----------|
 | **autoscaler** | `tags.<mode>=true` | Managed cloud (EKS, AKS, GKE) | Mode-dependent — see [Autoscaler](#autoscaler) |
 | **autoscaler-anywhere** | `tags.autoscaler-anywhere=true` | Non-managed (bare metal, on-prem, edge) | castai-agent, castai-cluster-controller, castai-workload-autoscaler, castai-workload-autoscaler-exporter, castai-evictor, castai-pod-mutator |
-| **kent** | `kent.enabled=true` | EKS only | castai-agent, castai-cluster-controller, castai-kentroller, castai-workload-autoscaler, castai-live, castai-pod-mutator, castai-evictor |
+| **kent** | `kent.enabled=true` | EKS only | castai-agent, castai-cluster-controller, castai-kentroller, castai-workload-autoscaler, castai-live, castai-pod-mutator |
 
 ---
 

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -10,10 +10,10 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.151.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.91.1 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.17 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.8.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 0.1.202 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 0.0.123 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.25 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.9.0 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 0.1.204 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 0.0.125 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/Chart.lock
+++ b/charts/castai-umbrella/charts/autoscaler/Chart.lock
@@ -1,36 +1,36 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.149.0
+  version: 0.151.0
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
   version: 0.32.0
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.0.140
+  version: 1.0.148
 - name: gpu-metrics-exporter
   repository: https://castai.github.io/helm-charts
   version: 0.1.29
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
-  version: 0.91.0
+  version: 0.91.1
 - name: castai-evictor
   repository: https://castai.github.io/helm-charts
-  version: 0.35.3
+  version: 0.35.25
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.5.0
+  version: 0.9.0
 - name: castai-pod-pinner
   repository: https://castai.github.io/helm-charts
   version: 1.11.0
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.75.1
+  version: 0.82.1
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 0.1.191
+  version: 0.1.204
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 0.0.112
-digest: sha256:ffa282fb0c0c08adc74014c4829203d7d8c797b685fd51bd01f338facae0f224
-generated: "2026-03-20T13:36:15.226369+01:00"
+  version: 0.0.125
+digest: sha256:c2d401e2a3ff788999a6f2a77ec9e7679b6e1aa0250744167d5db20aa3b9c7e0
+generated: "2026-04-14T15:30:51.043569+03:00"

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -10,14 +10,14 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.151.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.91.1 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.17 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.0.145 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.25 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.0.148 |
 | https://castai.github.io/helm-charts | castai-live | 0.82.1 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.8.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.9.0 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.11.0 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.32.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 0.1.202 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 0.0.123 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 0.1.204 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 0.0.125 |
 | https://castai.github.io/helm-charts | gpu-metrics-exporter | 0.1.29 |
 
 ## Values

--- a/charts/castai-umbrella/charts/kent/Chart.lock
+++ b/charts/castai-umbrella/charts/kent/Chart.lock
@@ -10,21 +10,18 @@ dependencies:
   version: 0.1.113
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 0.1.202
+  version: 0.1.204
 - name: castai-live
   repository: https://castai.github.io/helm-charts
   version: 0.82.1
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.8.0
-- name: castai-evictor
-  repository: https://castai.github.io/helm-charts
-  version: 0.35.17
+  version: 0.9.0
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
   version: 0.32.0
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
   version: 3.13.0
-digest: sha256:35a97a5f35174ea573d22b067f3117c8466795d371ae772e088b1a9b9a9f895d
-generated: "2026-04-09T12:25:25.699491+02:00"
+digest: sha256:55311aa1fa220e935afd09ec312e14622d7a165bc9b2a261e84d10cb2f510dc0
+generated: "2026-04-14T15:20:35.477268+03:00"

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kent
 description: Wrapper chart for CAST AI Kent profile.
 type: application
-version: 0.12.0
+version: 0.11.0
 dependencies:
   - name: castai-agent
     version: "0.151.0"

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kent
 description: Wrapper chart for CAST AI Kent profile.
 type: application
-version: 0.10.1
+version: 0.11.0
 dependencies:
   - name: castai-agent
     version: "0.151.0"
@@ -28,10 +28,6 @@ dependencies:
     version: "0.9.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-pod-mutator.enabled
-  - name: castai-evictor
-    version: "0.35.25"
-    repository: "https://castai.github.io/helm-charts"
-    condition: castai-evictor.enabled
   - name: castai-spot-handler
     version: "0.32.0"
     repository: "https://castai.github.io/helm-charts"

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -1,6 +1,6 @@
 # kent
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Kent profile.
 
@@ -10,12 +10,11 @@ Wrapper chart for CAST AI Kent profile.
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.151.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.91.1 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.17 |
 | https://castai.github.io/helm-charts | castai-kentroller | 0.1.113 |
 | https://castai.github.io/helm-charts | castai-live | 0.82.1 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.8.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.9.0 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.32.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 0.1.202 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 0.1.204 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values
@@ -32,13 +31,6 @@ Wrapper chart for CAST AI Kent profile.
 | castai-cluster-controller.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
 | castai-cluster-controller.enabled | bool | `true` |  |
 | castai-cluster-controller.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
-| castai-evictor.aggressiveMode | bool | `true` |  |
-| castai-evictor.enabled | bool | `true` |  |
-| castai-evictor.envFrom[0].secretRef.name | string | `"castai-credentials"` |  |
-| castai-evictor.envFrom[1].configMapRef.name | string | `"castai-agent-metadata"` |  |
-| castai-evictor.karpenterMode.enabled | bool | `true` |  |
-| castai-evictor.overrideEnvFrom | bool | `true` |  |
-| castai-evictor.replicaCount | int | `0` |  |
 | castai-kentroller.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
 | castai-kentroller.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-kentroller.enabled | bool | `true` |  |

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -1,6 +1,6 @@
 # kent
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Kent profile.
 

--- a/charts/castai-umbrella/charts/kent/values.yaml
+++ b/charts/castai-umbrella/charts/kent/values.yaml
@@ -65,19 +65,6 @@ castai-spot-handler:
       name: castai-agent-metadata
       key: CLUSTER_ID
 
-castai-evictor:
-  enabled: true
-  replicaCount: 0
-  karpenterMode:
-    enabled: true
-  aggressiveMode: true
-  overrideEnvFrom: true
-  envFrom:
-    - secretRef:
-        name: castai-credentials
-    - configMapRef:
-        name: castai-agent-metadata
-
 # Disabled by default — most clusters already provide the metrics.k8s.io API.
 metrics-server:
   enabled: false


### PR DESCRIPTION
KENT mode includes the Continuous Rebalancer (CRB) which subsumes evictor's functionality, making evictor redundant in that profile. Removed `castai-evictor` as a dependency from the `kent `subchart and updated the umbrella README template accordingly. All other modes (autoscaler, autoscaler-anywhere) are unaffected.