### PR TITLE
[castai-spot-handler] bump version to v0.22.0 with log exporter enabled

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.33.0
-appVersion: "v0.21.0"
+version: 0.34.0
+appVersion: "v0.22.0"

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -6,7 +6,9 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| additionalEnv.LOG_LEVEL | string | `"5"` |  |
+| additionalEnv.LOG_EXPORTER_ENABLED | string | `"true"` |  |
+| additionalEnv.LOG_EXPORTER_LOG_LEVEL | string | `"info"` |  |
+| additionalEnv.LOG_LEVEL | string | `"debug"` |  |
 | additionalEnv.POLL_INTERVAL_SECONDS | string | `"3"` |  |
 | affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"eks.amazonaws.com/capacityType"` |  |
 | affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"In"` |  |

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -54,8 +54,10 @@ castai:
 podAnnotations: {}
 podLabels: {}
 additionalEnv:
-  LOG_LEVEL: "5"
+  LOG_LEVEL: "debug"
   POLL_INTERVAL_SECONDS: "3"
+  LOG_EXPORTER_ENABLED: "true"
+  LOG_EXPORTER_LOG_LEVEL: "info"
 
 # useHostNetwork -- Host network is used to access instance metadata endpoints which are not always available from pod network.
 useHostNetwork: true


### PR DESCRIPTION
- the new version supports log level as string
- the numeric values are deprecated
- log exporter enabled by default to send them to Cast

---
### Kimchi Summary
### What changed
Bumps `castai-spot-handler` to `v0.22.0` and adds opt-out log export functionality. Updates `LOG_LEVEL` configuration format from numeric values to human-readable strings.

### Why
Enables centralized log collection for spot instance scheduled events to improve observability and debugging capabilities.

### Key changes
- `Chart.yaml`: Bumps chart version to `0.34.0` and application version to `v0.22.0`
- `values.yaml`: 
  - Adds `LOG_EXPORTER_ENABLED` (default `"true"`) and `LOG_EXPORTER_LOG_LEVEL` (default `"info"`) environment variables
  - Changes `LOG_LEVEL` default from `"5"` to `"debug"`
- `README.md`: Updates documentation to reflect new environment variables and changed defaults

### Impact
- **Breaking change**: `LOG_LEVEL` now requires string values (`debug`, `info`, `warn`, `error`) instead of numeric levels. Update custom values files using numeric values (e.g., `"5"`) to string equivalents.
- Log exporter functionality runs by default, which may increase memory/CPU usage slightly. Set `LOG_EXPORTER_ENABLED` to `"false"` to disable.