### PR TITLE
[castai-spot-handler] Adjust logging and timeout-per-call

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.34.0
-appVersion: "v0.22.0"
+version: 0.34.1
+appVersion: "v0.22.1"


### PR DESCRIPTION
Changes in this version:
* Adjusted logging levels, especially for initial timeout errors
* Reduced initial max timeout from 10 to 5s, made it configurable.
* Log all azure events that are raised, even if they are not sent to Cast.AI
* Log a message after first successful call to metadata services

---
### Kimchi Summary
### What changed
Bumps the `castai-spot-handler` Helm chart to version `0.34.1` and updates the application version to `v0.22.1`.

### Key changes
- `charts/castai-spot-handler/Chart.yaml`: 
  - Increment chart `version` from `0.34.0` to `0.34.1`
  - Update `appVersion` from `v0.22.0` to `v0.22.1`

### Impact
Patch release with no breaking changes. Users upgrading will automatically deploy Spot Handler `v0.22.1`.