### PR TITLE
[castai-pod-mutator] Bump version to v0.3.0

### DIFF
--- a/charts/castai-pod-mutator/Chart.yaml
+++ b/charts/castai-pod-mutator/Chart.yaml
@@ -3,5 +3,5 @@ name: castai-pod-mutator
 description: CAST AI Pod Mutator.
 type: application
 
-version: 0.10.1
-appVersion: "v0.2.9"
+version: 0.11.0
+appVersion: "v0.3.0"

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -42,7 +42,8 @@ CAST AI Pod Mutator.
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/pod-mutator"` |  |
 | image.tag | string | `""` |  |
-| leaderElection | object | `{"enabled":false,"leaseName":"castai-pod-mutator-leader-election"}` | Controls controller-runtime leader election. Required when `enforcer.enabled` is true |
+| leaderElection.enabled | bool | `false` |  |
+| leaderElection.leaseName | string | `"castai-pod-mutator-leader-election"` |  |
 | mutator.processingDelay | string | `"30s"` |  |
 | nameOverride | string | `""` |  |
 | openshift.scc.enabled | bool | `true` |  |

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -1,6 +1,6 @@
 # castai-pod-mutator
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.9](https://img.shields.io/badge/AppVersion-v0.2.9-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
 
 CAST AI Pod Mutator.
 
@@ -29,6 +29,9 @@ CAST AI Pod Mutator.
 | dependencyCheck.enabled | bool | `true` | Enable or disable dependency check preinstall hook |
 | dnsPolicy | string | `""` | DNS Policy Override - Needed when using custom CNI's. Defaults to "ClusterFirstWithHostNet" if hostNetwork is true |
 | enableTopologySpreadConstraints | bool | `false` |  |
+| enforcer.enabled | bool | `false` |  |
+| enforcer.maxEvictionsPerMinute | int | `60` |  |
+| enforcer.scanInterval | string | `"10s"` |  |
 | envFrom | list | `[]` | Used to set additional environment variables for the pod-mutator container via configMaps or secrets. |
 | fullnameOverride | string | `"castai-pod-mutator"` |  |
 | global | object | `{"commonAnnotations":{},"commonLabels":{}}` | Values to apply for the parent and child chart resources. |
@@ -39,6 +42,7 @@ CAST AI Pod Mutator.
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/pod-mutator"` |  |
 | image.tag | string | `""` |  |
+| leaderElection | object | `{"enabled":false,"leaseName":"castai-pod-mutator-leader-election"}` | Controls controller-runtime leader election. Required when `enforcer.enabled` is true |
 | mutator.processingDelay | string | `"30s"` |  |
 | nameOverride | string | `""` |  |
 | openshift.scc.enabled | bool | `true` |  |

--- a/charts/castai-pod-mutator/templates/cluster-role.yaml
+++ b/charts/castai-pod-mutator/templates/cluster-role.yaml
@@ -54,7 +54,16 @@ rules:
       - pods
     verbs:
       - patch
-      - update 
+      - update
+  # ---
+  # Eviction API — required for the enforcement eviction loop
+  # ---
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
   # ---
   # Read only permissions to view pods/deployments/rollouts
   # ---

--- a/charts/castai-pod-mutator/templates/deployment.yaml
+++ b/charts/castai-pod-mutator/templates/deployment.yaml
@@ -1,3 +1,9 @@
+{{- if and .Values.enforcer.enabled (not .Values.leaderElection.enabled) }}
+{{- fail "enforcer.enabled=true requires leaderElection.enabled=true to avoid duplicate evictions across replicas" }}
+{{- end }}
+{{- if and .Values.enforcer.enabled (le (int .Values.enforcer.maxEvictionsPerMinute) 0) }}
+{{- fail "enforcer.maxEvictionsPerMinute must be greater than 0" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,6 +78,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: LEADER_ELECTION_ENABLED
+              value: {{ .Values.leaderElection.enabled | quote }}
+            - name: LEADER_ELECTION_LEASE_NAME
+              value: {{ .Values.leaderElection.leaseName | quote }}
+            - name: ENFORCER_ENABLED
+              value: {{ .Values.enforcer.enabled | quote }}
+            - name: ENFORCER_SCAN_INTERVAL
+              value: {{ .Values.enforcer.scanInterval | quote }}
+            - name: ENFORCER_MAX_EVICTIONS_PER_MINUTE
+              value: {{ .Values.enforcer.maxEvictionsPerMinute | quote }}
             - name: WEBHOOK_NAME
               value: {{ include "pod-mutator.webhookName" . }}
             - name: SERVICE_NAME

--- a/charts/castai-pod-mutator/templates/role.yaml
+++ b/charts/castai-pod-mutator/templates/role.yaml
@@ -23,3 +23,28 @@ rules:
       - get
       - update
       - patch
+{{- if .Values.leaderElection.enabled }}
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - list
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    resourceNames:
+      - {{ .Values.leaderElection.leaseName }}
+    verbs:
+      - get
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+{{- end }}

--- a/charts/castai-pod-mutator/values.yaml
+++ b/charts/castai-pod-mutator/values.yaml
@@ -111,7 +111,7 @@ leaderElection:
 
 enforcer:
   # enabled -- Enable the mismatch detection and eviction enforcement loop.
-  # Requires leaderElection.enabled=true when replicas > 1.
+  # Requires leaderElection.enabled=true.
   enabled: false
   # scanInterval -- How often the Detector scans all ReplicaSets for mutation drift.
   scanInterval: "10s"

--- a/charts/castai-pod-mutator/values.yaml
+++ b/charts/castai-pod-mutator/values.yaml
@@ -103,6 +103,21 @@ resources:
   limits:
     memory: 512Mi
 
+# leaderElection -- Controls controller-runtime leader election.
+# Required when `enforcer.enabled` is true
+leaderElection:
+  enabled: false
+  leaseName: "castai-pod-mutator-leader-election"
+
+enforcer:
+  # enabled -- Enable the mismatch detection and eviction enforcement loop.
+  # Requires leaderElection.enabled=true when replicas > 1.
+  enabled: false
+  # scanInterval -- How often the Detector scans all ReplicaSets for mutation drift.
+  scanInterval: "10s"
+  # maxEvictionsPerMinute -- Global rate limit for pod evictions across all workloads.
+  maxEvictionsPerMinute: 60
+
 hostNetwork: false
 # dnsPolicy -- DNS Policy Override - Needed when using custom CNI's. Defaults to "ClusterFirstWithHostNet" if hostNetwork is true
 dnsPolicy: ""

--- a/charts/castai-pod-mutator/values.yaml
+++ b/charts/castai-pod-mutator/values.yaml
@@ -103,10 +103,10 @@ resources:
   limits:
     memory: 512Mi
 
-# leaderElection -- Controls controller-runtime leader election.
-# Required when `enforcer.enabled` is true
 leaderElection:
+  # enabled -- Enable controller-runtime leader election. Required when `enforcer.enabled` is true.
   enabled: false
+  # leaseName -- Name of the Lease resource used for leader election.
   leaseName: "castai-pod-mutator-leader-election"
 
 enforcer:


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds an optional enforcement loop to the pod-mutator that detects mutation drift in ReplicaSets and evicts non-compliant pods to force re-mutation. This includes leader election support to ensure only one replica performs enforcement actions.

### Why
Ensures long-running workloads remain compliant with CAST AI mutation policies by automatically remediating configuration drift that occurs outside the standard pod creation webhook flow.

### Key changes
- `values.yaml`: Added `enforcer.enabled`, `enforcer.scanInterval`, and `enforcer.maxEvictionsPerMinute` settings to configure the drift detection and eviction behavior; added `leaderElection.enabled` and `leaderElection.leaseName` for HA coordination.
- `templates/deployment.yaml`: Added startup validation requiring `leaderElection.enabled=true` when `enforcer.enabled=true`; injected `ENFORCER_*` and `LEADER_ELECTION_*` environment variables.
- `templates/cluster-role.yaml`: Granted `create` permission on `pods/eviction` resource to allow the enforcement loop to evict pods.
- `templates/role.yaml`: Added conditional RBAC rules for `coordination.k8s.io/leases` (get, watch, update, create, list) and core `events` (create) when leader election is enabled.
- `Chart.yaml`: Bumped chart version to `0.11.0` and app version to `v0.3.0`.

### Impact
- **Breaking/RBAC**: Deployments enabling the enforcer require new cluster-level eviction permissions and namespace-level lease permissions.
- **Configuration requirement**: `enforcer.enabled=true` now mandates `leaderElection.enabled=true`; Helm will fail validation if misconfigured.
- **Rate limiting**: Enforcement is capped at `maxEvictionsPerMinute` (default 60) to prevent excessive pod churn.