### PR TITLE
[castai-pod-mutator] Bump version to 0.12.0

### DIFF
--- a/charts/castai-pod-mutator/Chart.yaml
+++ b/charts/castai-pod-mutator/Chart.yaml
@@ -3,5 +3,5 @@ name: castai-pod-mutator
 description: CAST AI Pod Mutator.
 type: application
 
-version: 0.11.0
+version: 0.12.0
 appVersion: "v0.3.0"

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -1,6 +1,6 @@
 # castai-pod-mutator
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
 
 CAST AI Pod Mutator.
 

--- a/charts/castai-pod-mutator/templates/crd.yaml
+++ b/charts/castai-pod-mutator/templates/crd.yaml
@@ -633,6 +633,15 @@ spec:
                   - operations
                   type: object
                 type: array
+              podEviction:
+                description: PodEviction defines whether pods should be evicted when
+                  they no longer match the mutation.
+                properties:
+                  enabled:
+                    description: Enabled controls whether non-conforming pods are
+                      eligible for eviction.
+                    type: boolean
+                type: object
               restartPolicy:
                 description: RestartPolicy defines the policy for restarting the pod
                 enum:


### PR DESCRIPTION
Add podEviction field to CRD

---
### Kimchi Summary
### What changed
Adds a `podEviction` configuration field to the Pod Mutator CRD, allowing users to enable eviction of pods that no longer conform to their defined mutations.

### Why
Enables enforcement of mutations by removing non-conforming pods, ensuring cluster state remains consistent with the desired configuration.

### Key changes
- `charts/castai-pod-mutator/Chart.yaml`: Bumped chart version from `0.11.0` to `0.12.0`
- `charts/castai-pod-mutator/templates/crd.yaml`: Added `podEviction` object to the CRD spec containing an `enabled` boolean field to control eviction eligibility
- `charts/castai-pod-mutator/README.md`: Updated version badge to `0.12.0`

### Impact
New optional `podEviction.enabled` field in the CRD. Fully backward compatible; existing resources without this field will not trigger evictions.