### PR TITLE
[castai-spot-handler] bump version to v0.22.2

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.34.1
-appVersion: "v0.22.1"
+version: 0.34.2
+appVersion: "v0.22.2"


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the Spot Handler application version from `v0.22.1` to `v0.22.2` and updates the Helm chart version to `0.34.2`.

### Key changes
- `charts/castai-spot-handler/Chart.yaml`: Updated `appVersion` to `"v0.22.2"` and incremented chart `version` from `0.34.1` to `0.34.2`.