### PR TITLE
[castai-db-optimizer] generate self-signed cert for ProxySQL to support MySQL StarTLS relay

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.76.0
+version: 0.77.0

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.76.0](https://img.shields.io/badge/Version-0.76.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.77.0](https://img.shields.io/badge/Version-0.77.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -135,6 +135,10 @@ spec:
                 -e "s|\${PROXY_SQL_USERNAME}|$PROXY_SQL_USERNAME|g" \
                 -e "s|\${PROXY_SQL_PASSWORD}|$PROXY_SQL_PASSWORD|g" \
                 /etc/proxysql-template/proxysql.cnf > /etc/proxysql/proxysql.cnf
+              openssl req -x509 -newkey rsa:2048 \
+                -keyout /etc/proxysql/proxysql.key \
+                -out /etc/proxysql/proxysql.crt \
+                -days 3650 -nodes -subj "/CN=proxysql"
           env:
             {{- $proxySqlSecretName := ternary .Values.proxySql.usersSecretRef (printf "%s-proxysql-users" (include "name" .)) (ne .Values.proxySql.usersSecretRef "") }}
             - name: PROXY_SQL_USERNAME

--- a/charts/castai-db-optimizer/templates/envoy_config.yaml
+++ b/charts/castai-db-optimizer/templates/envoy_config.yaml
@@ -164,7 +164,6 @@ data:
                           address: {{ required "endpoint hostname must be provided" $endpoint.hostname }} # upstream database host
                           port_value: {{ required "endpoint targetPort is required" $endpoint.targetPort }} # upstream database port
                           {{- end }}
-          {{- if not (and $.Values.proxySql $.Values.proxySql.enabled) }}
           transport_socket:
             name: envoy.transport_sockets.start_tls
             typed_config:
@@ -174,7 +173,6 @@ data:
                 common_tls_context:
                   tls_params:
                     tls_maximum_protocol_version: TLSv1_3
-          {{- end }}
         {{- end }}
 
         - name: query_processor_service

--- a/charts/castai-db-optimizer/templates/proxysql-config.yaml
+++ b/charts/castai-db-optimizer/templates/proxysql-config.yaml
@@ -46,6 +46,9 @@ data:
         connect_timeout_server={{ $mergedConfig.connect_timeout_server | int64 }}
         auto_increment_delay_multiplex={{ $mergedConfig.auto_increment_delay_multiplex | int64 }}
         monitor_enabled=false
+        have_ssl=true
+        ssl_cert="/etc/proxysql/proxysql.crt"
+        ssl_key="/etc/proxysql/proxysql.key"
     }
 
     mysql_servers=


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Enabled TLS encryption for ProxySQL frontend connections by generating self-signed certificates at pod startup and configuring ProxySQL to terminate TLS. Also ensures Envoy consistently uses TLS transport for upstream connections regardless of ProxySQL configuration.

### Why
Fixes missing TLS certificate setup for ProxySQL, allowing database clients to establish encrypted connections to the cache layer.

### Key changes
- `templates/deployment.yaml`: Added `openssl` command in the init container to generate 2048-bit RSA self-signed certificates (`proxysql.crt` and `proxysql.key`) valid for 10 years
- `templates/proxysql-config.yaml`: Added `have_ssl=true`, `ssl_cert`, and `ssl_key` configuration parameters to enable SSL listening in ProxySQL
- `templates/envoy_config.yaml`: Removed conditional `if not` block that previously excluded TLS transport socket configuration when ProxySQL was enabled
- `Chart.yaml`: Bumped chart version from `0.76.0` to `0.77.0`

### Impact
Clients connecting to ProxySQL must now use TLS. The generated certificates are self-signed; clients may need to configure SSL mode to allow self-signed certificates or skip verification. This may be a breaking change for clients previously connecting over plaintext.