### PR TITLE
[castai-db-agent] Bumped db-agent image version

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.17.3
+version: 0.17.4

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -1,6 +1,6 @@
 # castai-db-agent
 
-![Version: 0.17.3](https://img.shields.io/badge/Version-0.17.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.17.4](https://img.shields.io/badge/Version-0.17.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI DB agent deployment.
 

--- a/charts/castai-db-agent/templates/_versions.tpl
+++ b/charts/castai-db-agent/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultDbAgentVersion" -}}v0.17.3{{- end -}}
+{{- define "defaultDbAgentVersion" -}}v0.17.4{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the `castai-db-agent` Helm chart and default agent image version to `0.17.4`.

### Key changes
- `Chart.yaml`: Updated chart `version` from `0.17.3` to `0.17.4`.
- `README.md`: Updated version badge to `0.17.4`.
- `templates/_versions.tpl`: Updated `defaultDbAgentVersion` helper value from `v0.17.3` to `v0.17.4`.

### Impact
New deployments and upgrades will roll out the `v0.17.4` agent image by default. No breaking changes or migration steps required.