### PR TITLE
[castai-db-optimizer] update proxy image with CLIENT_LOCAL_FILES capability 

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.77.0
+version: 0.77.1

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.77.0](https://img.shields.io/badge/Version-0.77.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.77.1](https://img.shields.io/badge/Version-0.77.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,4 +1,4 @@
-{{- define "defaultProxyVersion" -}}v4.83.0{{- end -}}
+{{- define "defaultProxyVersion" -}}v4.84.1{{- end -}}
 {{- define "defaultQueryProcessorVersion" -}}v0.45.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
 {{- define "defaultPgdogVersion" -}}v0.1.30{{- end -}}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates the CAST AI DB Optimizer Helm chart to version `0.77.1` and bumps the default proxy image tag from `v4.83.0` to `v4.84.1`.

### Key changes
- `charts/castai-db-optimizer/Chart.yaml`: Bumped chart version to `0.77.1`
- `charts/castai-db-optimizer/README.md`: Updated version badge to `0.77.1`
- `charts/castai-db-optimizer/templates/_versions.tpl`: Updated `defaultProxyVersion` from `v4.83.0` to `v4.84.1`

### Impact
No breaking changes. The new proxy version will be used by default on fresh installs or upgrades unless `proxy.image.tag` is explicitly overridden.