### PR TITLE
[castai-cluster-controller] add global registry support

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.92.0
+version: 0.92.1
 appVersion: "v0.62.1"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/README.md
+++ b/charts/castai-cluster-controller/README.md
@@ -37,9 +37,10 @@ Cluster controller is responsible for handling certain Kubernetes actions such a
 | extraVolumeMounts | list | `[]` | Used to set additional volume mounts |
 | extraVolumes | list | `[]` | Used to set additional volumes |
 | fullnameOverride | string | `"castai-cluster-controller"` |  |
-| global | object | `{"commonAnnotations":{},"commonLabels":{}}` | Global values that are propagated to child charts. |
+| global | object | `{"commonAnnotations":{},"commonLabels":{},"registry":""}` | Global values that are propagated to child charts. |
 | global.commonAnnotations | object | `{}` | Annotations to add to all resources (including child charts). |
 | global.commonLabels | object | `{}` | Labels to add to all resources (including child charts). |
+| global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | hostNetwork.enabled | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/cluster-controller"` |  |

--- a/charts/castai-cluster-controller/ci/test-values-global-registry.yaml
+++ b/charts/castai-cluster-controller/ci/test-values-global-registry.yaml
@@ -1,0 +1,5 @@
+global:
+  registry: "my-registry.example.com"
+castai:
+  apiKey: "test"
+  clusterID: "test"

--- a/charts/castai-cluster-controller/templates/_helpers.tpl
+++ b/charts/castai-cluster-controller/templates/_helpers.tpl
@@ -93,6 +93,18 @@ Resolve tolerations: merge .Values.global.tolerations with .Values.tolerations.
 {{- end -}}
 {{- end }}
 
+{{/*
+Resolve image repository: prepend global.registry if set.
+*/}}
+{{- define "cluster-controller.imageRepository" -}}
+{{- $registry := ((.Values.global | default dict).registry) | default "" -}}
+{{- if $registry -}}
+{{- printf "%s/%s" (trimSuffix "/" $registry) .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end }}
+
 {{- define "cluster-controller.workloadAutoscalingEnabled" -}}
   {{- $workloadAutoscalingEnabled := true -}}
   {{- if .Values.workloadAutoscaling -}}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
       {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: cluster-controller
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "cluster-controller.imageRepository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: shared-metadata
@@ -231,7 +231,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
         - name: monitor
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "cluster-controller.imageRepository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - castai-cluster-controller

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -8,6 +8,9 @@ global:
   commonLabels: {}
   # global.commonAnnotations -- Annotations to add to all resources (including child charts).
   commonAnnotations: {}
+  # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
+  # When set, it is prepended to all image repositories.
+  registry: ""
 
 # replicas -- Number of replicas for castai-cluster-controller deployment.
 replicas: 2


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for configuring a global container registry prefix via `global.registry`. When set, this value is automatically prepended to all image repository URLs in the deployment.

### Why
This simplifies deployment in environments that require pulling images from private or internal registries (e.g., air-gapped clusters or to avoid public registry rate limits), allowing users to set the registry once globally rather than overriding each image individually.

### Key changes
- `values.yaml`: Added `global.registry` configuration option to specify a container registry prefix (e.g., `"my-registry.example.com"`)
- `templates/_helpers.tpl`: Added `cluster-controller.imageRepository` helper template to prepend `global.registry` to image repositories when set
- `templates/deployment.yaml`: Updated both `cluster-controller` and `monitor` containers to use the new helper template for image resolution
- `README.md`: Documented the new `global.registry` parameter
- `ci/test-values-global-registry.yaml`: Added test values to validate global registry configuration
- `Chart.yaml`: Bumped chart version from `0.92.0` to `0.92.1`

### Impact
Fully backward compatible. If `global.registry` is unset (default empty string), behavior remains unchanged. Users can migrate by setting `global.registry` to their private registry hostname.