### PR TITLE
[castai-spot-handler] add optional pod delete RBAC permission

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.34.2
+version: 0.34.3
 appVersion: "v0.22.2"

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -77,6 +77,7 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 | castai.provider | string | `""` | Cloud provider (azure, gcp, aws). |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
+| deletePodPermissions | bool | `false` |  |
 | envFrom | list | `[]` | Used to set additional environment variables for the spot handler container via configMaps or secrets. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/spot-handler"` |  |

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -77,12 +77,12 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 | castai.provider | string | `""` | Cloud provider (azure, gcp, aws). |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
-| deletePodPermissions | bool | `false` |  |
 | envFrom | list | `[]` | Used to set additional environment variables for the spot handler container via configMaps or secrets. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/spot-handler"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | object | `{}` | what secret should be used for pulling the image |
+| interruption.podDeletionEnabled | bool | `false` | Enable pod deletion on interrupted nodes to speed up eviction via SIGTERM. |
 | nodeSelector | object | `{}` |  |
 | phase2Permissions | bool | `true` |  |
 | podAnnotations | object | `{}` |  |

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -92,6 +92,8 @@ spec:
               value: {{ include "spot-handler.provider" . | quote }}
             - name: PHASE2_PERMISSIONS
               value: {{ .Values.phase2Permissions | quote }}
+            - name: DELETE_PODS_PERMISSIONS
+              value: {{ .Values.deletePodPermissions | quote }}
             {{- range $k, $v := .Values.additionalEnv }}
             - name: {{ $k }}
               value: "{{ $v }}"

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -92,8 +92,8 @@ spec:
               value: {{ include "spot-handler.provider" . | quote }}
             - name: PHASE2_PERMISSIONS
               value: {{ .Values.phase2Permissions | quote }}
-            - name: DELETE_PODS_PERMISSIONS
-              value: {{ .Values.deletePodPermissions | quote }}
+            - name: INTERRUPTION_POD_DELETION_ENABLED
+              value: {{ .Values.interruption.podDeletionEnabled | quote }}
             {{- range $k, $v := .Values.additionalEnv }}
             - name: {{ $k }}
               value: "{{ $v }}"

--- a/charts/castai-spot-handler/templates/rbac.yaml
+++ b/charts/castai-spot-handler/templates/rbac.yaml
@@ -93,4 +93,44 @@ subjects:
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
+
+{{- if .Values.deletePodPermissions }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: castai-spot-handler-delete-pods
+  labels:
+    {{- include "spot-handler.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "spot-handler.annotations" . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: castai-spot-handler-delete-pods
+  labels:
+    {{- include "spot-handler.labels" . | nindent 4 }}
+  {{ if gt (len .Values.commonAnnotations) 0 -}}
+  annotations:
+    {{- include "spot-handler.annotations" . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: castai-spot-handler-delete-pods
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/castai-spot-handler/templates/rbac.yaml
+++ b/charts/castai-spot-handler/templates/rbac.yaml
@@ -34,6 +34,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/castai-spot-handler/templates/rbac.yaml
+++ b/charts/castai-spot-handler/templates/rbac.yaml
@@ -95,7 +95,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- end }}
 
-{{- if .Values.deletePodPermissions }}
+{{- if .Values.interruption.podDeletionEnabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -70,8 +70,9 @@ updateStrategy: {}
 # Phase 2 (true): Include permissions for tainting nodes
 phase2Permissions: true
 
-# deletePodPermissions enable pod deletion capabilities
-deletePodPermissions: false
+interruption:
+  # interruption.podDeletionEnabled -- Enable pod deletion on interrupted nodes to speed up eviction via SIGTERM.
+  podDeletionEnabled: false
 
 resources:
   requests:

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -70,6 +70,9 @@ updateStrategy: {}
 # Phase 2 (true): Include permissions for tainting nodes
 phase2Permissions: true
 
+# deletePodPermissions enable pod deletion capabilities
+deletePodPermissions: false
+
 resources:
   requests:
     cpu: 20m


### PR DESCRIPTION
When a spot/preemptible node receives an interruption notice, the handler needs to delete pods directly to send SIGTERM immediately, rather than waiting for the node lifecycle to drain them naturally.

---
### Kimchi Summary
### What changed
Add optional RBAC permissions that allow the spot-handler to delete pods. This functionality is disabled by default and controlled via the `deletePodPermissions` configuration value.

### Key changes
- `values.yaml`: Add `deletePodPermissions` boolean flag (default `false`)
- `templates/rbac.yaml`: Add conditional `ClusterRole` and `ClusterRoleBinding` that grant `delete` verb on `pods` resource when `deletePodPermissions` is enabled

### Impact
No breaking changes. Existing deployments are unaffected unless `deletePodPermissions` is explicitly set to `true`. Enabling this option requires sufficient cluster privileges to apply the new RBAC rules.

---
### Kimchi Summary
### What changed
Added an optional `interruption.podDeletionEnabled` setting that allows the spot-handler to directly delete pods on interrupted nodes, speeding up eviction via SIGTERM. This is disabled by default.

### Why
When spot instances are interrupted, Kubernetes eviction can be slow. Enabling direct pod deletion allows faster graceful termination of workloads upon receiving interruption notices.

### Key changes
- `values.yaml`: Added `interruption.podDeletionEnabled` (default `false`) to configure the feature.
- `templates/daemonset.yaml`: Injected `INTERRUPTION_POD_DELETION_ENABLED` environment variable from the new config value.
- `templates/rbac.yaml`: 
  - Added `watch` verb to existing node permissions.
  - Added conditional `ClusterRole` and `ClusterRoleBinding` (`castai-spot-handler-delete-pods`) granting `delete` permissions on pods when the feature is enabled.
- `Chart.yaml`: Bumped chart version from `0.34.2` to `0.34.3`.
- `README.md`: Documented the `interruption.podDeletionEnabled` parameter.

### Impact
- **Opt-in only**: The feature is disabled by default; no breaking changes for existing installations.
- **RBAC requirements**: When enabled, the service account requires `delete` permissions on pods across the cluster.
- **Migration**: To enable, set `interruption.podDeletionEnabled: true` in your values.