### PR TITLE
[castai-umbrella] add support for global registry var

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.33.72
+version: 0.34.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/README.md
+++ b/charts/castai-umbrella/README.md
@@ -274,6 +274,7 @@ helm upgrade castai castai-helm/castai \
 | global.castai.apiURL | string | `"https://api.cast.ai"` |  |
 | global.castai.grpcURL | string | `"grpc.cast.ai:443"` |  |
 | global.castai.provider | string | `""` |  |
+| global.registry | string | `""` |  |
 | global.tolerations | list | `[]` |  |
 | kent.enabled | bool | `false` |  |
 | kent.preflight.enabled | bool | `true` |  |

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -10,10 +10,10 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.0 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.31 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.11.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.8 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.8 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.37 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.0 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.10 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.10 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -10,14 +10,14 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.0 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.31 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.37 |
 | https://castai.github.io/helm-charts | castai-kvisor | 1.0.155 |
-| https://castai.github.io/helm-charts | castai-live | 0.90.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.11.0 |
-| https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.1 |
-| https://castai.github.io/helm-charts | castai-spot-handler | 0.34.1 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.8 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.8 |
+| https://castai.github.io/helm-charts | castai-live | 0.91.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.0 |
+| https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.3 |
+| https://castai.github.io/helm-charts | castai-spot-handler | 0.34.2 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.10 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.10 |
 | https://castai.github.io/helm-charts | gpu-metrics-exporter | 0.1.29 |
 
 ## Values

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -10,13 +10,13 @@ Wrapper chart for CAST AI Kent profile.
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.0 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.131 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.0.155 |
-| https://castai.github.io/helm-charts | castai-live | 0.90.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.11.0 |
-| https://castai.github.io/helm-charts | castai-spot-handler | 0.34.1 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.8 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 0.0.117 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.135 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.0.156 |
+| https://castai.github.io/helm-charts | castai-live | 0.91.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.0 |
+| https://castai.github.io/helm-charts | castai-spot-handler | 0.34.2 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.10 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.10 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values

--- a/charts/castai-umbrella/values.yaml
+++ b/charts/castai-umbrella/values.yaml
@@ -10,6 +10,9 @@ global:
     provider: ""
   # tolerations -- Global tolerations applied to all sub-chart pods (can be overridden per sub-chart).
   tolerations: []
+  # registry -- Container registry prefix for all sub-chart images (e.g. "my-registry.example.com").
+  # When set, it is prepended to all image repositories in sub-charts that support it.
+  registry: ""
 
 kent:
   enabled: false


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Introduces a `global.registry` configuration option to the umbrella chart, allowing users to specify a custom container registry prefix for all sub-chart images. Also bumps the chart version to `0.34.0` and updates sub-chart dependencies to versions that support this global override.

### Why
Enables deployments in air-gapped environments or organizations requiring private container registries without needing to configure registry settings individually for each component.

### Key changes
- `values.yaml`: Added `global.registry` parameter (default `""`) to set a container registry prefix for all sub-chart images
- `Chart.yaml`: Bumped chart version from `0.33.72` to `0.34.0`
- `README.md`: Documented the new `global.registry` value in the configuration table
- Updated sub-chart dependencies across `autoscaler`, `autoscaler-anywhere`, and `kent` profiles to latest versions supporting global registry configuration

### Impact
- **Non-breaking**: Existing deployments continue to use default registries when `global.registry` is unset
- **Convenience**: Users can now set a single value (e.g., `"my-registry.example.com"`) instead of configuring each sub-chart's image registry individually
- **Air-gapped support**: Simplifies installation in environments without direct access to public container registries