### PR TITLE
[castai-pod-mutator] add global registry support

### DIFF
--- a/charts/castai-pod-mutator/Chart.yaml
+++ b/charts/castai-pod-mutator/Chart.yaml
@@ -3,5 +3,5 @@ name: castai-pod-mutator
 description: CAST AI Pod Mutator.
 type: application
 
-version: 0.13.0
+version: 0.13.1
 appVersion: "v0.3.1"

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -1,6 +1,6 @@
 # castai-pod-mutator
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 CAST AI Pod Mutator.
 
@@ -34,9 +34,10 @@ CAST AI Pod Mutator.
 | enforcer.scanInterval | string | `"10s"` |  |
 | envFrom | list | `[]` | Used to set additional environment variables for the pod-mutator container via configMaps or secrets. |
 | fullnameOverride | string | `"castai-pod-mutator"` |  |
-| global | object | `{"commonAnnotations":{},"commonLabels":{}}` | Values to apply for the parent and child chart resources. |
+| global | object | `{"commonAnnotations":{},"commonLabels":{},"registry":""}` | Values to apply for the parent and child chart resources. |
 | global.commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | global.commonLabels | object | `{}` | Labels to add to all resources. |
+| global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | healthProbePort | int | `8081` | Port for liveness and readiness probes |
 | hostNetwork | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/castai-pod-mutator/templates/_helpers.tpl
+++ b/charts/castai-pod-mutator/templates/_helpers.tpl
@@ -98,6 +98,19 @@ Resolve tolerations: merge .Values.global.tolerations with .Values.tolerations.
 {{- end }}
 
 {{/*
+Resolve image repository: prepend global.registry if set.
+*/}}
+{{- define "pod-mutator.imageRepository" -}}
+{{- $repository := required "image.repository must be provided" .Values.image.repository -}}
+{{- $registry := ((.Values.global | default dict).registry) | default "" -}}
+{{- if $registry -}}
+{{- printf "%s/%s" (trimSuffix "/" $registry) $repository -}}
+{{- else -}}
+{{- $repository -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common Annotations
 */}}
 {{- define "pod-mutator.annotations" -}}

--- a/charts/castai-pod-mutator/templates/deployment.yaml
+++ b/charts/castai-pod-mutator/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ required "image.repository must be provided" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "pod-mutator.imageRepository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           {{- if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version }}
           lifecycle:

--- a/charts/castai-pod-mutator/templates/pre-upgrade-hook.yaml
+++ b/charts/castai-pod-mutator/templates/pre-upgrade-hook.yaml
@@ -43,7 +43,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ required "image.repository must be provided" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "pod-mutator.imageRepository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: ["castai-pod-mutator", "dependency-check"]
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           env:

--- a/charts/castai-pod-mutator/values.yaml
+++ b/charts/castai-pod-mutator/values.yaml
@@ -128,6 +128,9 @@ global:
   commonLabels: {}
   # -- Annotations to add to all resources.
   commonAnnotations: {}
+  # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
+  # When set, it is prepended to all image repositories.
+  registry: ""
 
 mutator:
   # processingDelay -- Delay in seconds before the pod-mutator processes the pod. Default is 30s


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for `global.registry` to allow users to specify a custom container registry prefix that is automatically prepended to all image repositories in the chart.

### Why
Enables deployment in air-gapped environments or when using private container registries without requiring manual overrides of individual image repository values.

### Key changes
- `values.yaml`: Adds `global.registry` configuration option for specifying a global container registry prefix (e.g., `my-registry.example.com`)
- `templates/_helpers.tpl`: Introduces `pod-mutator.imageRepository` helper template to resolve image repositories with optional global registry prefix
- `templates/deployment.yaml`: Updated to use `pod-mutator.imageRepository` helper for the main container image
- `templates/pre-upgrade-hook.yaml`: Updated to use `pod-mutator.imageRepository` helper for the hook container image
- `Chart.yaml`: Bumped chart version from `0.13.0` to `0.13.1`

### Impact
No breaking changes. When `global.registry` is unset (default empty string), the chart behaves exactly as before. Existing installations without this value configured require no migration steps.