### PR TITLE
[castai-spot-handler] add global registry support

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.34.2
+version: 0.34.3
 appVersion: "v0.22.2"

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -78,6 +78,8 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | envFrom | list | `[]` | Used to set additional environment variables for the spot handler container via configMaps or secrets. |
+| global | object | `{"registry":""}` | Global values propagated from parent charts. |
+| global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/spot-handler"` |  |
 | image.tag | string | `""` |  |

--- a/charts/castai-spot-handler/templates/_helpers.tpl
+++ b/charts/castai-spot-handler/templates/_helpers.tpl
@@ -88,6 +88,18 @@ Resolve tolerations: merge .Values.global.tolerations with .Values.tolerations.
 {{- end }}
 
 {{/*
+Resolve image repository: prepend global.registry if set.
+*/}}
+{{- define "spot-handler.imageRepository" -}}
+{{- $registry := ((.Values.global | default dict).registry) | default "" -}}
+{{- if $registry -}}
+{{- printf "%s/%s" (trimSuffix "/" $registry) .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve cloud provider: prefer .Values.castai.provider, fall back to .Values.global.castai.provider.
 Accepts both cloud names (aws, azure, gcp) and k8s names (eks, aks, gke).
 */}}

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
       {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: spot-handler
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "spot-handler.imageRepository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -8,6 +8,12 @@ commonLabels: {}
 # commonAnnotations -- Annotations to add to all resources.
 commonAnnotations: {}
 
+# global -- Global values propagated from parent charts.
+global:
+  # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
+  # When set, it is prepended to all image repositories.
+  registry: ""
+
 image:
   repository: us-docker.pkg.dev/castai-hub/library/spot-handler
   # Tag is set using Chart.yaml appVersion field.


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for a global registry configuration option that allows overriding the container image registry via `global.registry`. When set, the registry prefix is prepended to the image repository.

### Why
Enables users in air-gapped environments or using private container registries to easily redirect image pulls without modifying individual repository values. This also allows parent charts to propagate registry settings to this subchart.

### Key changes
- `values.yaml`: Added `global.registry` value (default empty) for specifying a custom registry prefix
- `templates/_helpers.tpl`: Added `spot-handler.imageRepository` helper template to prepend `global.registry` to the image repository when set
- `templates/daemonset.yaml`: Updated image reference to use the new `spot-handler.imageRepository` helper
- `README.md`: Documented the new `global.registry` configuration parameter
- `Chart.yaml`: Bumped chart version from `0.34.2` to `0.34.3`

### Impact
Backward compatible. Existing installations continue to work unchanged; only users who explicitly set `global.registry` will see behavior changes.