### PR TITLE
[castai-evictor] add global registry support

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.38
+version: 0.35.39
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -37,6 +37,8 @@ Cluster utilization defragmentation tool
 | extraVolumeMounts | list | `[]` | Used to set additional volume mounts. |
 | extraVolumes | list | `[]` | Used to set additional volumes. |
 | fullnameOverride | string | `"castai-evictor"` |  |
+| global | object | `{"registry":""}` | Global values propagated from parent charts. |
+| global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | hostNetwork.enabled | bool | `false` | Enable host networking. |
 | ignorePodDisruptionBudgets | bool | `false` | Specifies whether the Evictor should ignore Pod Disruption Budgets (PDBs). If true, evictor will attempt to evict pods even if it would violate a PDB. Use with caution as this may disrupt application availability guarantees. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/castai-evictor/templates/_helpers.tpl
+++ b/charts/castai-evictor/templates/_helpers.tpl
@@ -88,6 +88,18 @@ Resolve tolerations: merge .Values.global.tolerations with .Values.tolerations.
 {{- end }}
 
 {{/*
+Resolve image repository: prepend global.registry if set.
+*/}}
+{{- define "evictor.imageRepository" -}}
+{{- $registry := ((.Values.global | default dict).registry) | default "" -}}
+{{- if $registry -}}
+{{- printf "%s/%s" (trimSuffix "/" $registry) .Values.image.repository -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Pass the customConfig to the configMap
 */}}
 {{- define "evictor.configMap.customConfig" -}}

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "evictor.imageRepository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -10,6 +10,12 @@ commonLabels: {}
 # annotations - Annotations to add to all resources.
 commonAnnotations: {}
 
+# global -- Global values propagated from parent charts.
+global:
+  # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
+  # When set, it is prepended to all image repositories.
+  registry: ""
+
 # dryRyn -- Specifies whether the Evictor should run in dryRun mode (Read-Only).
 # if true, evictor will just log action(s) it would perform
 # instead of actually performing them.


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for a global container registry prefix via `global.registry`. When set, this value is prepended to all image repository URLs, enabling deployments from private or mirrored registries.

### Why
Required for air-gapped environments and organizations that must pull images from internal registries rather than public ones. This follows the standard Helm pattern for global image registry configuration in parent/umbrella charts.

### Key changes
- **`values.yaml`**: Added `global.registry` field (default empty) to accept registry prefix (e.g., `"my-registry.example.com"`).
- **`templates/_helpers.tpl`**: Added `evictor.imageRepository` helper template to conditionally prepend `global.registry` to image repositories.
- **`templates/deployment.yaml`**: Updated container image reference to use `include "evictor.imageRepository"` instead of direct `.Values.image.repository` reference.
- **`README.md`**: Documented the new `global.registry` configuration option.
- **`Chart.yaml`**: Bumped chart version to `0.35.39`.

### Impact
- **Non-breaking**: When `global.registry` is empty (default), image resolution behavior remains unchanged.
- **Migration**: Users in restricted environments can now set `global.registry` at the parent chart level instead of overriding individual image repositories.