### PR TITLE
[castai-spot-handler] permission to read pods if pod deletion is enabled

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.34.3
+version: 0.34.4
 appVersion: "v0.22.2"

--- a/charts/castai-spot-handler/templates/rbac.yaml
+++ b/charts/castai-spot-handler/templates/rbac.yaml
@@ -113,6 +113,7 @@ rules:
     resources:
       - pods
     verbs:
+      - list
       - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Added `list` permission for pods to the Spot Handler's RBAC ClusterRole and bumped the Helm chart version to `0.34.4`.

### Key changes
- `charts/castai-spot-handler/templates/rbac.yaml`: Added `list` verb to the `pods` resource rules, granting the Spot Handler permission to list pods in addition to deleting them.
- `charts/castai-spot-handler/Chart.yaml`: Incremented chart version from `0.34.3` to `0.34.4`.

### Impact
- The Spot Handler now has read access to list pod resources across the cluster.
- This is an additive RBAC change with no breaking changes or migration steps required.