### PR TITLE
[castai-spot-handler] bumping spot-handler version

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.34.4
-appVersion: "v0.22.2"
+version: 0.34.5
+appVersion: "v0.22.3"

--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -3,4 +3,4 @@ name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
 version: 0.34.5
-appVersion: "v0.22.3"
+appVersion: "v0.23.0"

--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.34.5
+version: 0.35.0
 appVersion: "v0.23.0"


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates the `castai-spot-handler` Helm chart to version `0.35.0` and the underlying application to `v0.23.0`.

### Key changes
- `charts/castai-spot-handler/Chart.yaml`: bumped `version` from `0.34.4` to `0.35.0` and `appVersion` from `"v0.22.2"` to `"v0.23.0"`.