### PR TITLE
[castai-db-optimizer] support RDS IAM Authentication

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.17.4
+version: 0.18.0

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -1,6 +1,6 @@
 # castai-db-agent
 
-![Version: 0.17.4](https://img.shields.io/badge/Version-0.17.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI DB agent deployment.
 
@@ -24,12 +24,13 @@ CAST AI DB agent deployment.
 | collectors.metadata.runsEvery | string | `"15m"` | Frequency in which table metadata is collected |
 | collectors.queries.runsEvery | string | `"15m"` | Frequency in which query statistics are collected |
 | database.autoDiscoveryDatabase | string | `"postgres"` | Database name to use for connecting to database instance for auto-discovering logical databases. This is only required for Postgres |
-| database.credentialsSecretRef | string | `""` | Name of secret with database credentials (username and password). Not required when using useIAMAuth with inline username. |
+| database.credentialsSecretRef | string | `""` | Name of secret with database credentials (username and password). Not required when using useCloudSQLIAMAuth or useRDSIAMAuth with inline username. |
 | database.host | string | `""` |  |
-| database.password | string | `""` | Password for database authentication (not required when useIAMAuth is true) |
+| database.password | string | `""` | Password for database authentication (not required when useCloudSQLIAMAuth is true) |
 | database.port | int | `5432` |  |
 | database.protocol | string | `"postgres"` | Database protocol to use. Supported values: postgres, mysql. |
-| database.useIAMAuth | bool | `false` | Enable IAM authentication for database connection (GCP Cloud SQL IAM). Requires Workload Identity setup. See IAM_AUTH_SETUP.md for details. |
+| database.useCloudSQLIAMAuth | bool | `false` | Enable IAM authentication for database connection (GCP Cloud SQL IAM). Requires Workload Identity setup. See IAM_AUTH_SETUP.md for details. |
+| database.useRDSIAMAuth | bool | `false` | Enable IAM authentication for database connection (AWS RDS IAM). Requires IAM role with rds-db:connect permission. |
 | database.username | string | `""` | Username for database authentication. For IAM auth, use the format: "service-account-name@project-id.iam" |
 | gRPCEndpoint | string | `""` | URL to the CAST AI API gRPC endpoint. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -26,7 +26,7 @@ CAST AI DB agent deployment.
 | database.autoDiscoveryDatabase | string | `"postgres"` | Database name to use for connecting to database instance for auto-discovering logical databases. This is only required for Postgres |
 | database.credentialsSecretRef | string | `""` | Name of secret with database credentials (username and password). Not required when using useCloudSQLIAMAuth or useRDSIAMAuth with inline username. |
 | database.host | string | `""` |  |
-| database.password | string | `""` | Password for database authentication (not required when useCloudSQLIAMAuth is true) |
+| database.password | string | `""` | Password for database authentication (not required when useCloudSQLIAMAuth or useRDSIAMAuth is true) |
 | database.port | int | `5432` |  |
 | database.protocol | string | `"postgres"` | Database protocol to use. Supported values: postgres, mysql. |
 | database.useCloudSQLIAMAuth | bool | `false` | Enable IAM authentication for database connection (GCP Cloud SQL IAM). Requires Workload Identity setup. See IAM_AUTH_SETUP.md for details. |

--- a/charts/castai-db-agent/templates/_versions.tpl
+++ b/charts/castai-db-agent/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultDbAgentVersion" -}}v0.17.4{{- end -}}
+{{- define "defaultDbAgentVersion" -}}v0.18.1{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}

--- a/charts/castai-db-agent/templates/db-user-secret.yaml
+++ b/charts/castai-db-agent/templates/db-user-secret.yaml
@@ -1,3 +1,9 @@
+{{- if and .Values.database.useCloudSQLIAMAuth .Values.database.useRDSIAMAuth }}
+{{- fail "database.useCloudSQLIAMAuth and database.useRDSIAMAuth are mutually exclusive" }}
+{{- end }}
+{{- if and .Values.database.password (or .Values.database.useCloudSQLIAMAuth .Values.database.useRDSIAMAuth) }}
+{{- fail "database.password must not be set when useCloudSQLIAMAuth or useRDSIAMAuth is enabled" }}
+{{- end }}
 {{- if ne .Values.database.username "" }}
 apiVersion: v1
 kind: Secret
@@ -7,7 +13,7 @@ metadata:
     {{- include "labels" . | nindent 4 }}
 data:
   DATABASE_USERNAME: {{ .Values.database.username | b64enc | quote }}
-  {{- if not .Values.database.useIAMAuth }}
-  DATABASE_PASSWORD: {{ required "database.password must be provided when useIAMAuth is false" .Values.database.password | b64enc | quote }}
+  {{- if and (not .Values.database.useCloudSQLIAMAuth) (not .Values.database.useRDSIAMAuth) }}
+  DATABASE_PASSWORD: {{ required "database.password must be provided when useCloudSQLIAMAuth and useRDSIAMAuth are both false" .Values.database.password | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/castai-db-agent/templates/deployment.yaml
+++ b/charts/castai-db-agent/templates/deployment.yaml
@@ -50,8 +50,10 @@ spec:
             - name: DATABASE_SSL_MODE
               value: "disable"
               {{- end }}
-            - name: DATABASE_USE_IAM_AUTH
-              value: "{{ .Values.database.useIAMAuth }}"
+            - name: DATABASE_USE_CLOUD_SQL_IAM_AUTH
+              value: "{{ .Values.database.useCloudSQLIAMAuth }}"
+            - name: DATABASE_USE_RDS_IAM_AUTH
+              value: "{{ .Values.database.useRDSIAMAuth }}"
             - name: DATABASE_PROTOCOL
               value: "{{ .Values.database.protocol }}"
             - name: DATABASE_AUTO_DISCOVERY_DATABASE

--- a/charts/castai-db-agent/values.yaml
+++ b/charts/castai-db-agent/values.yaml
@@ -14,12 +14,14 @@ database:
   port: 5432
   # -- Username for database authentication. For IAM auth, use the format: "service-account-name@project-id.iam"
   username: ""
-  # -- Password for database authentication (not required when useIAMAuth is true)
+  # -- Password for database authentication (not required when useCloudSQLIAMAuth is true)
   password: ""
-  # -- Name of secret with database credentials (username and password). Not required when using useIAMAuth with inline username.
+  # -- Name of secret with database credentials (username and password). Not required when using useCloudSQLIAMAuth or useRDSIAMAuth with inline username.
   credentialsSecretRef: ""
   # -- Enable IAM authentication for database connection (GCP Cloud SQL IAM). Requires Workload Identity setup. See IAM_AUTH_SETUP.md for details.
-  useIAMAuth: false
+  useCloudSQLIAMAuth: false
+  # -- Enable IAM authentication for database connection (AWS RDS IAM). Requires IAM role with rds-db:connect permission.
+  useRDSIAMAuth: false
   # -- Database protocol to use. Supported values: postgres, mysql.
   protocol: postgres
   # -- Database name to use for connecting to database instance for auto-discovering logical databases. This is only required for Postgres

--- a/charts/castai-db-agent/values.yaml
+++ b/charts/castai-db-agent/values.yaml
@@ -14,7 +14,7 @@ database:
   port: 5432
   # -- Username for database authentication. For IAM auth, use the format: "service-account-name@project-id.iam"
   username: ""
-  # -- Password for database authentication (not required when useCloudSQLIAMAuth is true)
+  # -- Password for database authentication (not required when useCloudSQLIAMAuth or useRDSIAMAuth is true)
   password: ""
   # -- Name of secret with database credentials (username and password). Not required when using useCloudSQLIAMAuth or useRDSIAMAuth with inline username.
   credentialsSecretRef: ""


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Added support for AWS RDS IAM authentication and replaced the generic `useIAMAuth` toggle with provider-specific flags for GCP Cloud SQL and AWS RDS.

### Why
The previous `useIAMAuth` option only covered GCP Cloud SQL. Introducing separate, provider-specific flags enables the DB agent to support AWS RDS IAM authentication and makes the configuration intent explicit per cloud provider.

### Key changes
- `values.yaml`: Replaced `database.useIAMAuth` with `database.useCloudSQLIAMAuth` and added `database.useRDSIAMAuth`.
- `templates/deployment.yaml`: Replaced the `DATABASE_USE_IAM_AUTH` environment variable with `DATABASE_USE_CLOUD_SQL_IAM_AUTH` and `DATABASE_USE_RDS_IAM_AUTH`.
- `templates/db-user-secret.yaml`: Added validation ensuring `useCloudSQLIAMAuth` and `useRDSIAMAuth` are mutually exclusive, and that `database.password` is unset when either IAM option is enabled. Updated the password requirement check.
- `Chart.yaml` & `README.md`: Bumped chart version to `0.18.0`.
- `templates/_versions.tpl`: Bumped default DB agent version to `v0.18.1`.

### Impact
**Breaking change**: Existing deployments using `database.useIAMAuth` for GCP Cloud SQL IAM must update their configuration to use `database.useCloudSQLIAMAuth` before upgrading. The two new provider-specific flags are mutually exclusive and cannot be enabled at the same time.