### PR TITLE
[castai-evictor] Update cpvpa from 0.8.4 to 0.8.10

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.43
+version: 0.35.44
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -22,7 +22,7 @@ Cluster utilization defragmentation tool
 | clusterIdConfigMapKeyRef.name | string | `""` | name and of the config map with cluster id |
 | clusterIdSecretKeyRef.key | string | `"CLUSTER_ID"` |  |
 | clusterIdSecretKeyRef.name | string | `""` |  |
-| clusterVPA | object | `{"enabled":true,"pollPeriodSeconds":300,"repository":"registry.k8s.io/cpa/cpvpa","resources":{},"version":"v0.8.4"}` | Cluster proportional vertical autoscaler for the evictor deployment https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler. |
+| clusterVPA | object | `{"enabled":true,"pollPeriodSeconds":300,"repository":"registry.k8s.io/cpa/cpvpa","resources":{},"version":"v0.8.10"}` | Cluster proportional vertical autoscaler for the evictor deployment https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler. |
 | commonAnnotations | object | `{}` |  |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | configMapLabels | object | `{}` |  |

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -214,7 +214,7 @@ apiKeySecretRef: ""
 clusterVPA:
   repository: "registry.k8s.io/cpa/cpvpa"
   enabled: true
-  version: v0.8.4
+  version: v0.8.10
   pollPeriodSeconds: 300
   resources: {}
   # configOverride -- Override the default ClusterVPA calculation configuration.


### PR DESCRIPTION
0.8.10 is latest, yet trivy shows more CVEs, so not sure if worth merging

```
trivy image registry.k8s.io/cpa/cpvpa:v0.8.4

Report Summary

┌────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                     Target                     │  Type  │ Vulnerabilities │ Secrets │
├────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ registry.k8s.io/cpa/cpvpa:v0.8.4 (debian 11.3) │ debian │        5        │    -    │
└────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘

Total: 5 (UNKNOWN: 5, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────┬───────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────┐
│ Library │ Vulnerability │ Severity │ Status │ Installed Version │  Fixed Version  │             Title              │
├─────────┼───────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────┤
│ tzdata  │ DLA-3972-1    │ UNKNOWN  │ fixed  │ 2021a-1+deb11u4   │ 2024b-0+deb11u1 │ tzdata - new timezone database │
│         ├───────────────┤          │        │                   ├─────────────────┤                                │
│         │ DLA-4085-1    │          │        │                   │ 2025a-0+deb11u1 │                                │
│         ├───────────────┤          │        │                   ├─────────────────┤                                │
│         │ DLA-4105-1    │          │        │                   │ 2025b-0+deb11u1 │                                │
│         ├───────────────┤          │        │                   ├─────────────────┤                                │
│         │ DLA-4403-1    │          │        │                   │ 2025b-0+deb11u2 │                                │
│         ├───────────────┤          │        │                   ├─────────────────┤                                │
│         │ DLA-4569-1    │          │        │                   │ 2026b-0+deb11u1 │                                │
└─────────┴───────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────┘
```

```
trivy image registry.k8s.io/cpa/cpvpa:v0.8.10

Report Summary
┌──────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                      Target                      │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ registry.k8s.io/cpa/cpvpa:v0.8.10 (debian 12.13) │  debian  │        0        │    -    │
├──────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ cpvpa                                            │ gobinary │       43        │    -    │
└──────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘

Total: 43 (UNKNOWN: 8, LOW: 1, MEDIUM: 22, HIGH: 11, CRITICAL: 1)

┌─────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬──────────────────────────────────────────────────────────────┐
│       Library       │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                            Title                             │
├─────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net    │ CVE-2025-22872 │ MEDIUM   │ fixed  │ v0.36.0           │ 0.38.0                       │ golang.org/x/net/html: Incorrect Neutralization of Input     │
│                     │                │          │        │                   │                              │ During Web Page Generation in x/net in...                    │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-22872                   │
├─────────────────────┼────────────────┼──────────┤        ├───────────────────┼──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/oauth2 │ CVE-2025-22868 │ HIGH     │        │ v0.23.0           │ 0.27.0                       │ golang.org/x/oauth2/jws: Unexpected memory consumption       │
│                     │                │          │        │                   │                              │ during token parsing in golang.org/x/oauth2/jws              │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-22868                   │
├─────────────────────┼────────────────┼──────────┤        ├───────────────────┼──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib              │ CVE-2025-68121 │ CRITICAL │        │ v1.24.0           │ 1.24.13, 1.25.7, 1.26.0-rc.3 │ crypto/tls: crypto/tls: Incorrect certificate validation     │
│                     │                │          │        │                   │                              │ during TLS session resumption                                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-68121                   │
│                     ├────────────────┼──────────┤        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-22874 │ HIGH     │        │                   │ 1.24.4                       │ crypto/x509: Usage of ExtKeyUsageAny disables policy         │
│                     │                │          │        │                   │                              │ validation in crypto/x509                                    │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-22874                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-47907 │          │        │                   │ 1.23.12, 1.24.6              │ database/sql: Postgres Scan Race Condition                   │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-47907                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-58183 │          │        │                   │ 1.24.8, 1.25.2               │ golang: archive/tar: Unbounded allocation when parsing GNU   │
│                     │                │          │        │                   │                              │ sparse map                                                   │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-58183                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-61726 │          │        │                   │ 1.24.12, 1.25.6              │ golang: net/url: Memory exhaustion in query parameter        │
│                     │                │          │        │                   │                              │ parsing in net/url                                           │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-61726                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-61728 │          │        │                   │                              │ golang: archive/zip: Excessive CPU consumption when building │
│                     │                │          │        │                   │                              │ archive index in archive/zip                                 │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-61728                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-61729 │          │        │                   │ 1.24.11, 1.25.5              │ crypto/x509: golang: Denial of Service due to excessive      │
│                     │                │          │        │                   │                              │ resource consumption via crafted...                          │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-61729                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-25679 │          │        │                   │ 1.25.8, 1.26.1               │ net/url: Incorrect parsing of IPv6 host literals in net/url  │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-25679                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-32280 │          │        │                   │ 1.25.9, 1.26.2               │ crypto/x509: crypto/tls: golang: Go: Denial of Service       │
│                     │                │          │        │                   │                              │ vulnerability in certificate chain building...               │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-32280                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-32281 │          │        │                   │                              │ crypto/x509: golang: Go crypto/x509: Denial of Service via   │
│                     │                │          │        │                   │                              │ inefficient certificate chain validation...                  │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-32281                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-32283 │          │        │                   │                              │ crypto/tls: golang: Go crypto/tls: Denial of Service via     │
│                     │                │          │        │                   │                              │ multiple TLS 1.3 key...                                      │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-32283                   │
│                     ├────────────────┼──────────┤        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-0913  │ MEDIUM   │        │                   │ 1.23.10, 1.24.4              │ Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows │
│                     │                │          │        │                   │                              │ in os in syscall...                                          │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-0913                    │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-22870 │          │        │                   │ 1.23.7, 1.24.1               │ golang.org/x/net/proxy: golang.org/x/net/http/httpproxy:     │
│                     │                │          │        │                   │                              │ HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net    │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-22870                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-22871 │          │        │                   │ 1.23.8, 1.24.2               │ net/http: Request smuggling due to acceptance of invalid     │
│                     │                │          │        │                   │                              │ chunked data in net/http...                                  │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-22871                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-22873 │          │        │                   │ 1.23.9, 1.24.3               │ os: os: Information disclosure via path traversal using      │
│                     │                │          │        │                   │                              │ specially crafted filenames                                  │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-22873                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-4673  │          │        │                   │ 1.23.10, 1.24.4              │ net/http: Sensitive headers not cleared on cross-origin      │
│                     │                │          │        │                   │                              │ redirect in net/http                                         │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-4673                    │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-47906 │          │        │                   │ 1.23.12, 1.24.6              │ os/exec: Unexpected paths returned from LookPath in os/exec  │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-47906                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-47912 │          │        │                   │ 1.24.8, 1.25.2               │ net/url: Insufficient validation of bracketed IPv6 hostnames │
│                     │                │          │        │                   │                              │ in net/url                                                   │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-47912                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-58185 │          │        │                   │                              │ encoding/asn1: Parsing DER payload can cause memory          │
│                     │                │          │        │                   │                              │ exhaustion in encoding/asn1                                  │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-58185                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-58186 │          │        │                   │                              │ golang.org/net/http: Lack of limit when parsing cookies can  │
│                     │                │          │        │                   │                              │ cause memory exhaustion in...                                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-58186                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-58187 │          │        │                   │ 1.24.9, 1.25.3               │ crypto/x509: Quadratic complexity when checking name         │
│                     │                │          │        │                   │                              │ constraints in crypto/x509                                   │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-58187                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-58188 │          │        │                   │ 1.24.8, 1.25.2               │ crypto/x509: golang: Panic when validating certificates with │
│                     │                │          │        │                   │                              │ DSA public keys in crypto/x509...                            │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-58188                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-58189 │          │        │                   │                              │ crypto/tls: go crypto/tls ALPN negotiation error contains    │
│                     │                │          │        │                   │                              │ attacker controlled information                              │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-58189                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-61723 │          │        │                   │                              │ encoding/pem: Quadratic complexity when parsing some invalid │
│                     │                │          │        │                   │                              │ inputs in encoding/pem                                       │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-61723                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-61724 │          │        │                   │                              │ net/textproto: Excessive CPU consumption in                  │
│                     │                │          │        │                   │                              │ Reader.ReadResponse in net/textproto                         │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-61724                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-61725 │          │        │                   │                              │ net/mail: Excessive CPU consumption in ParseAddress in       │
│                     │                │          │        │                   │                              │ net/mail                                                     │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-61725                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-61727 │          │        │                   │ 1.24.11, 1.25.5              │ golang: crypto/x509: excluded subdomain constraint does not  │
│                     │                │          │        │                   │                              │ restrict wildcard SANs                                       │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-61727                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2025-61730 │          │        │                   │ 1.24.12, 1.25.6              │ During the TLS 1.3 handshake if multiple messages are sent   │
│                     │                │          │        │                   │                              │ in records...                                                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2025-61730                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-27142 │          │        │                   │ 1.25.8, 1.26.1               │ html/template: URLs in meta content attribute actions are    │
│                     │                │          │        │                   │                              │ not escaped in html/template...                              │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-27142                   │
│                     ├────────────────┤          │        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-32282 │          │        │                   │ 1.25.9, 1.26.2               │ golang: internal/syscall/unix: Root.Chmod can follow         │
│                     │                │          │        │                   │                              │ symlinks out of the root                                     │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-32282                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-32288 │          │        │                   │                              │ archive/tar: golang: Go's archive/tar package: Denial of     │
│                     │                │          │        │                   │                              │ Service via maliciously-crafted archive                      │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-32288                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-32289 │          │        │                   │                              │ html/template: golang: html/template: Cross-Site Scripting   │
│                     │                │          │        │                   │                              │ (XSS) via improper context and brace depth...                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-32289                   │
│                     ├────────────────┼──────────┤        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-27139 │ LOW      │        │                   │ 1.25.8, 1.26.1               │ os: FileInfo can escape from a Root in golang os module      │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-27139                   │
│                     ├────────────────┼──────────┤        │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-33811 │ UNKNOWN  │        │                   │ 1.25.10, 1.26.3              │ When using LookupCNAME with the cgo DNS resolver, a very     │
│                     │                │          │        │                   │                              │ long CNAME...                                                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-33811                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-33814 │          │        │                   │                              │ When processing HTTP/2 SETTINGS frames, transport will enter │
│                     │                │          │        │                   │                              │ an infini ...                                                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-33814                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-39820 │          │        │                   │                              │ Well-crafted inputs reaching ParseAddress, ParseAddressList, │
│                     │                │          │        │                   │                              │ and Parse ...                                                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-39820                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-39823 │          │        │                   │                              │ CVE-2026-27142 fixed a vulnerability in which URLs were not  │
│                     │                │          │        │                   │                              │ correctly ......                                             │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-39823                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-39825 │          │        │                   │                              │ ReverseProxy can forward queries containing parameters not   │
│                     │                │          │        │                   │                              │ visible to ...                                               │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-39825                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-39826 │          │        │                   │                              │ If a trusted template author were to write a <script> tag    │
│                     │                │          │        │                   │                              │ containing...                                                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-39826                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-39836 │          │        │                   │                              │ Panic in Dial and LookupPort when handling NUL byte on       │
│                     │                │          │        │                   │                              │ Windows in...                                                │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-39836                   │
│                     ├────────────────┤          │        │                   │                              ├──────────────────────────────────────────────────────────────┤
│                     │ CVE-2026-42499 │          │        │                   │                              │ Pathological inputs could cause DoS through consumePhrase    │
│                     │                │          │        │                   │                              │ when parsing ...                                             │
│                     │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-42499                   │
└─────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

---
### Kimchi Summary
### What changed
Bumps the default Cluster Proportional Vertical Autoscaler (CPVPA) image version in the `castai-evictor` Helm chart from `v0.8.4` to `v0.8.10`.

### Key changes
- `charts/castai-evictor/values.yaml`: Updates default `clusterVPA.version` to `v0.8.10`.
- `charts/castai-evictor/README.md`: Syncs the documented default `clusterVPA` version to `v0.8.10`.

### Impact
Clusters using the default `clusterVPA` configuration will deploy the `v0.8.10` image on the next chart upgrade. No breaking changes or manual migration steps are required.