### PR TITLE
[castai-db-agent] add missing updated values.yaml

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.19.0
+version: 0.19.1

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -1,6 +1,6 @@
 # castai-db-agent
 
-![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.19.1](https://img.shields.io/badge/Version-0.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI DB agent deployment.
 

--- a/charts/castai-db-agent/values.yaml
+++ b/charts/castai-db-agent/values.yaml
@@ -56,3 +56,13 @@ cloudSqlProxyImage:
   repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
   pullPolicy: IfNotPresent
   tag: ""  # uses values from _versions.tpl for default value
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: false
+  # -- Annotations to add to the service account (e.g. for AWS IRSA: eks.amazonaws.com/role-arn: <ARN>)
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, the chart name is used.
+  # If not set and create is false, "default" is used.
+  name: ""


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds the missing `serviceAccount` configuration defaults to the `castai-db-agent` Helm chart and bumps the patch version to `0.19.1`.

### Why
The chart templates likely reference `.Values.serviceAccount.*`, but no defaults were previously provided in `values.yaml`.

### Key changes
- `values.yaml`: Added `serviceAccount` block containing defaults:
  - `create: false`
  - `annotations: {}`
  - `name: ""`
- `Chart.yaml`: Bumped version from `0.19.0` to `0.19.1`.
- `README.md`: Updated version badge to `0.19.1`.