### PR TITLE
[castai-cluster-controller] add global apiKeySecretRef support

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.92.1
+version: 0.92.2
 appVersion: "v0.62.1"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/README.md
+++ b/charts/castai-cluster-controller/README.md
@@ -37,7 +37,8 @@ Cluster controller is responsible for handling certain Kubernetes actions such a
 | extraVolumeMounts | list | `[]` | Used to set additional volume mounts |
 | extraVolumes | list | `[]` | Used to set additional volumes |
 | fullnameOverride | string | `"castai-cluster-controller"` |  |
-| global | object | `{"commonAnnotations":{},"commonLabels":{},"registry":""}` | Global values that are propagated to child charts. |
+| global | object | `{"apiKeySecretRef":"","commonAnnotations":{},"commonLabels":{},"registry":""}` | Global values that are propagated to child charts. |
+| global.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
 | global.commonAnnotations | object | `{}` | Annotations to add to all resources (including child charts). |
 | global.commonLabels | object | `{}` | Labels to add to all resources (including child charts). |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -187,15 +187,16 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- if or .Values.apiKey .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- if or .Values.apiKey .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if or .Values.apiKey .Values.castai.apiKey }}
-                  {{- if ne .Values.castai.apiKeySecretRef "" }}
+                  {{- if ne $resolvedSecretRef "" }}
                   {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
                   {{- end }}
                 name: castai-cluster-controller
                 {{- else }}
-                name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.castai.apiKeySecretRef }}
+                name: {{ required "castai.apiKey or castai.apiKeySecretRef must be provided" $resolvedSecretRef }}
                 {{- end }}
           {{- else if not .Values.envFrom }}
           {{- fail "castai.apiKey or castai.apiKeySecretRef must be provided" }}
@@ -302,15 +303,16 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- if or .Values.apiKey .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- if or .Values.apiKey .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if or .Values.apiKey .Values.castai.apiKey }}
-                  {{- if ne .Values.castai.apiKeySecretRef "" }}
+                  {{- if ne $resolvedSecretRef "" }}
                   {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
                   {{- end }}
                 name: castai-cluster-controller
                 {{- else }}
-                name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.castai.apiKeySecretRef }}
+                name: {{ required "castai.apiKey or castai.apiKeySecretRef must be provided" $resolvedSecretRef }}
                 {{- end }}
           {{- else if not .Values.envFrom }}
           {{- fail "castai.apiKey or castai.apiKeySecretRef must be provided" }}

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -11,6 +11,9 @@ global:
   # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
   # When set, it is prepended to all image repositories.
   registry: ""
+  # global.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
+  # Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey.
+  apiKeySecretRef: ""
 
 # replicas -- Number of replicas for castai-cluster-controller deployment.
 replicas: 2


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for configuring the API key secret reference globally via `global.apiKeySecretRef`. The deployment now resolves the secret name by checking the local `castai.apiKeySecretRef` first, then falling back to the global value.

### Why
This allows parent charts or unified value files to define the API key secret once and have it propagate to `castai-cluster-controller` when used as a dependency.

### Key changes
- `values.yaml`: Introduced `global.apiKeySecretRef` (default `""`).
- `templates/deployment.yaml`: Added `$resolvedSecretRef` logic in both container `secretRef` blocks to prefer `.Values.castai.apiKeySecretRef` over `.Values.global.apiKeySecretRef`. Updated validation error messages to reference `castai.apiKey` and `castai.apiKeySecretRef`.
- `README.md`: Documented `global.apiKeySecretRef` with its precedence and mutual exclusivity rules.
- `Chart.yaml`: Incremented chart version from `0.92.1` to `0.92.2`.

### Impact
No breaking changes. Existing installations that set `castai.apiKey` or `castai.apiKeySecretRef` directly are unaffected.