### PR TITLE
CID-671: fix gitlab token auth

### DIFF
--- a/.github/workflows/bump-cluster-agent-image.yml
+++ b/.github/workflows/bump-cluster-agent-image.yml
@@ -105,12 +105,10 @@ jobs:
         env:
           GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
         run: |
-          git clone https://gitlab.com/castai/kubecast.git kubecast
+          git clone "https://oauth2:${GITLAB_TOKEN}@gitlab.com/castai/kubecast.git" kubecast
           cd kubecast
           git config user.email "ci@cast.ai"
           git config user.name "GitHub Actions"
-          git config --local credential.helper \
-            '!f() { echo "username=oauth2"; echo "password='"${GITLAB_TOKEN}"'"; }; f'
 
       - name: Bump image tag and chart version
         id: bump

--- a/.github/workflows/bump-cluster-agent-image.yml
+++ b/.github/workflows/bump-cluster-agent-image.yml
@@ -105,7 +105,8 @@ jobs:
         env:
           GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
         run: |
-          git clone "https://oauth2:${GITLAB_TOKEN}@gitlab.com/castai/kubecast.git" kubecast
+          git config --global credential.helper '!f() { echo "username=oauth2"; echo "password='"${GITLAB_TOKEN}"'"; }; f'
+          git clone https://gitlab.com/castai/kubecast.git kubecast
           cd kubecast
           git config user.email "ci@cast.ai"
           git config user.name "GitHub Actions"


### PR DESCRIPTION
Fix authentication that was failing ( [example](https://github.com/castai/helm-charts/actions/runs/25739264286/job/75584742836) )

---
### Kimchi Summary
### What changed
Fixes GitLab authentication in the `bump-cluster-agent-image` workflow by configuring the Git credential helper globally before cloning the `kubecast` repository.

### Why
The workflow was failing to authenticate against GitLab during `git clone` because the credential helper was previously configured with `--local` only after entering the cloned repository, making the token unavailable when it was first needed.

### Key changes
- `.github/workflows/bump-cluster-agent-image.yml`:
  - Moved `git config --global credential.helper` to run immediately before `git clone`
  - Removed the post-clone `--local` credential helper configuration that was insufficient for the initial authentication step
  - Unchanged: `user.email` and `user.name` are still configured after entering the repository directory