### PR TITLE
[castai-spot-handler] add global apiKeySecretRef support

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.35.0
+version: 0.35.1
 appVersion: "v0.23.0"

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -78,7 +78,8 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | envFrom | list | `[]` | Used to set additional environment variables for the spot handler container via configMaps or secrets. |
-| global | object | `{"registry":""}` | Global values propagated from parent charts. |
+| global | object | `{"apiKeySecretRef":"","registry":""}` | Global values propagated from parent charts. |
+| global.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/spot-handler"` |  |

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -106,15 +106,16 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- if and .Values.castai.apiKey .Values.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- if and .Values.castai.apiKey $resolvedSecretRef }}
             {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
           {{- end }}
-          {{- if or .Values.castai.apiKey .Values.apiKeySecretRef }}
+          {{- if or .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if .Values.castai.apiKey }}
                 name: {{ include "spot-handler.fullname" . -}}
                 {{- else }}
-                name: {{ .Values.apiKeySecretRef -}}
+                name: {{ $resolvedSecretRef -}}
                 {{- end }}
           {{- else }}
             - secretRef:

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -13,6 +13,9 @@ global:
   # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
   # When set, it is prepended to all image repositories.
   registry: ""
+  # global.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
+  # Takes effect when apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey.
+  apiKeySecretRef: ""
 
 image:
   repository: us-docker.pkg.dev/castai-hub/library/spot-handler


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for specifying the CAST AI API key secret via `global.apiKeySecretRef`, allowing parent charts to propagate the secret reference to the spot-handler subchart.

### Why
When spot-handler is used as a dependency, users need a way to centrally configure the API key secret once rather than setting it individually in each subchart.

### Key changes
- `values.yaml`: Added `global.apiKeySecretRef` field for configuring a pre-existing API key secret at the global level.
- `templates/daemonset.yaml`: Updated secret resolution logic to prefer the local `.Values.apiKeySecretRef` and fall back to `.Values.global.apiKeySecretRef`. Updated the mutual-exclusivity check between `castai.apiKey` and the resolved secret reference accordingly.
- `README.md`: Documented the new `global.apiKeySecretRef` parameter and its precedence over the local `apiKeySecretRef`.
- `Chart.yaml`: Bumped chart version from `0.35.0` to `0.35.1`.