### PR TITLE
[castai-evictor] add global apiKeySecretRef support

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.53
+version: 0.35.54
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -37,7 +37,8 @@ Cluster utilization defragmentation tool
 | extraVolumeMounts | list | `[]` | Used to set additional volume mounts. |
 | extraVolumes | list | `[]` | Used to set additional volumes. |
 | fullnameOverride | string | `"castai-evictor"` |  |
-| global | object | `{"registry":""}` | Global values propagated from parent charts. |
+| global | object | `{"apiKeySecretRef":"","registry":""}` | Global values propagated from parent charts. |
+| global.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when apiKeySecretRef is not set locally. |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | hostNetwork.enabled | bool | `false` | Enable host networking. |
 | ignorePodDisruptionBudgets | bool | `false` | Specifies whether the Evictor should ignore Pod Disruption Budgets (PDBs). If true, evictor will attempt to evict pods even if it would violate a PDB. Use with caution as this may disrupt application availability guarantees. |

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -133,12 +133,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if not .Values.overrideEnvFrom}}
+          {{- $resolvedSecretRef := or .Values.apiKeySecretRef .Values.global.apiKeySecretRef }}
             - secretRef:
-                {{- if .Values.apiKeySecretRef }}
-                name: {{ .Values.apiKeySecretRef }}
-                {{- else }}
-                name: castai-cluster-controller
-                {{- end }}
+                name: {{ or $resolvedSecretRef "castai-cluster-controller" }}
                 optional: false
             - configMapRef:
                 name: castai-cluster-controller

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -15,6 +15,9 @@ global:
   # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
   # When set, it is prepended to all image repositories.
   registry: ""
+  # global.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
+  # Takes effect when apiKeySecretRef is not set locally.
+  apiKeySecretRef: ""
 
 # dryRyn -- Specifies whether the Evictor should run in dryRun mode (Read-Only).
 # if true, evictor will just log action(s) it would perform


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for resolving the API key secret reference from global Helm values. The evictor deployment now falls back to `global.apiKeySecretRef` when the local `apiKeySecretRef` value is not configured.

### Why
This enables parent or umbrella charts to propagate a single API key secret configuration to the evictor subchart, reducing duplication across dependent charts.

### Key changes
- `values.yaml`: Introduced `global.apiKeySecretRef` field for specifying a pre-existing Secret name at the global level.
- `templates/deployment.yaml`: Updated secret reference resolution logic to prioritize local `apiKeySecretRef` and fall back to `global.apiKeySecretRef`, defaulting to `castai-cluster-controller` if neither is set.
- `README.md`: Documented the new `global.apiKeySecretRef` parameter and updated the global values table.
- `Chart.yaml`: Incremented chart version from `0.35.53` to `0.35.54`.