### PR TITLE
CID-671: create MR only for images in the allow list

### DIFF
--- a/.github/workflows/bump-cluster-agent-image.yml
+++ b/.github/workflows/bump-cluster-agent-image.yml
@@ -101,7 +101,7 @@ jobs:
           echo "skip=false" >> $GITHUB_OUTPUT
 
       - name: Clone kubecast
-        if: steps.image.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.image.outputs.skip != 'true'
         env:
           GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
         run: |
@@ -113,7 +113,7 @@ jobs:
 
       - name: Bump image tag and chart version
         id: bump
-        if: steps.image.outputs.skip != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.image.outputs.skip != 'true'
         env:
           COMPONENT: ${{ steps.check.outputs.component }}
           IMAGE_TAG: ${{ steps.image.outputs.image_tag }}
@@ -164,7 +164,7 @@ jobs:
           git commit -m "Bump ${COMPONENT} image to ${IMAGE_TAG}"
           git push origin HEAD:"$BRANCH"
 
-          curl -sf --fail-with-body \
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
             -X POST \
             -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
             -H "Content-Type: application/json" \
@@ -173,4 +173,11 @@ jobs:
               --arg source "$BRANCH" \
               --arg title "[castai-cluster-agent] Bump ${COMPONENT} to ${IMAGE_TAG}" \
               --arg desc "Automated image bump triggered by [helm-charts release ${RELEASE_TAG}](${RELEASE_URL}).\n\n| | |\n|---|---|\n| **Component** | \`${COMPONENT}\` |\n| **Old tag** | \`${OLD_TAG}\` |\n| **New tag** | \`${IMAGE_TAG}\` |\n| **Chart version** | \`${NEW_VERSION}\` |" \
-              '{source_branch: $source, target_branch: "master", title: $title, description: $desc}')"
+              '{source_branch: $source, target_branch: "master", title: $title, description: $desc, labels: "team::identity"}')")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "GitLab MR creation failed (HTTP ${HTTP_CODE}): ${BODY}"
+            exit 1
+          fi
+          echo "MR created: $(echo "$BODY" | jq -r '.web_url')"


### PR DESCRIPTION
create MR only for images in the allow list

---
### Kimchi Summary
### What changed
Fixes job step conditions in the `bump-cluster-agent-image` workflow so that `Clone kubecast` and `Bump image tag and chart version` are skipped when the check step indicates no update is needed. Also improves GitLab MR creation error handling and adds a team label.

### Why
Previously, downstream steps could run even when the check step set `skip=true`, causing unnecessary processing. Additionally, GitLab MR failures were hard to diagnose because the response body was not explicitly logged.

### Key changes
- `.github/workflows/bump-cluster-agent-image.yml`:
  - Updated `if` conditions on the `Clone kubecast` and `Bump image tag and chart version` steps to require both `steps.check.outputs.skip != 'true'` and `steps.image.outputs.skip != 'true'`.
  - Added `labels: "team::identity"` to the GitLab MR JSON payload.
  - Replaced `curl -sf --fail-with-body` with manual HTTP code extraction and explicit non-2xx error handling that prints the response body.
  - Added step output logging the created MR URL on success.

### Impact
Corrects workflow execution logic to avoid unnecessary runs. CI maintainers will now see explicit error messages if GitLab MR creation fails.