### PR TITLE
[castai-pod-mutator] add global apiKeySecretRef support

### DIFF
--- a/charts/castai-pod-mutator/Chart.yaml
+++ b/charts/castai-pod-mutator/Chart.yaml
@@ -3,5 +3,5 @@ name: castai-pod-mutator
 description: CAST AI Pod Mutator.
 type: application
 
-version: 0.13.1
+version: 0.13.2
 appVersion: "v0.3.1"

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -1,6 +1,6 @@
 # castai-pod-mutator
 
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
+![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 CAST AI Pod Mutator.
 
@@ -34,7 +34,8 @@ CAST AI Pod Mutator.
 | enforcer.scanInterval | string | `"10s"` |  |
 | envFrom | list | `[]` | Used to set additional environment variables for the pod-mutator container via configMaps or secrets. |
 | fullnameOverride | string | `"castai-pod-mutator"` |  |
-| global | object | `{"commonAnnotations":{},"commonLabels":{},"registry":""}` | Values to apply for the parent and child chart resources. |
+| global | object | `{"apiKeySecretRef":"","commonAnnotations":{},"commonLabels":{},"registry":""}` | Values to apply for the parent and child chart resources. |
+| global.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
 | global.commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | global.commonLabels | object | `{}` | Labels to add to all resources. |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |

--- a/charts/castai-pod-mutator/templates/deployment.yaml
+++ b/charts/castai-pod-mutator/templates/deployment.yaml
@@ -123,15 +123,16 @@ spec:
             {{- end }}
           {{- end }}
           envFrom:
-          {{- if or .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- if or .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if .Values.castai.apiKey }}
-                  {{- if ne .Values.castai.apiKeySecretRef "" }}
+                  {{- if ne $resolvedSecretRef "" }}
                   {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
                   {{- end }}
                 name: pod-mutator
                 {{- else }}
-                name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.castai.apiKeySecretRef }}
+                name: {{ required "castai.apiKey or castai.apiKeySecretRef must be provided" $resolvedSecretRef }}
                 {{- end }}
           {{- else if not .Values.envFrom }}
           {{- fail "castai.apiKey, castai.apiKeySecretRef or envFrom must be provided" }}

--- a/charts/castai-pod-mutator/values.yaml
+++ b/charts/castai-pod-mutator/values.yaml
@@ -131,6 +131,9 @@ global:
   # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
   # When set, it is prepended to all image repositories.
   registry: ""
+  # global.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
+  # Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey.
+  apiKeySecretRef: ""
 
 mutator:
   # processingDelay -- Delay in seconds before the pod-mutator processes the pod. Default is 30s


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for resolving the CAST AI API key secret name from `global.apiKeySecretRef`, enabling parent charts to supply a single secret reference when `castai-pod-mutator` is used as a dependency.

### Why
This simplifies configuration in umbrella charts by allowing the API key secret to be defined once globally rather than repeated in every child chart's local values.

### Key changes
- `values.yaml`: Added `global.apiKeySecretRef` option to specify a pre-existing secret name at the global scope.
- `templates/deployment.yaml`: Introduced `$resolvedSecretRef` to prefer local `castai.apiKeySecretRef` and fall back to `global.apiKeySecretRef`; updated validation error messages accordingly.
- `README.md`: Documented the new `global.apiKeySecretRef` parameter.
- `Chart.yaml`: Bumped chart version from `0.13.1` to `0.13.2`.