### PR TITLE
CID-671: Support for manual image bump trigger

### DIFF
--- a/.github/workflows/bump-cluster-agent-image.yml
+++ b/.github/workflows/bump-cluster-agent-image.yml
@@ -8,6 +8,11 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to simulate (e.g. castai-agent-7.0.0)'
+        required: true
 
 jobs:
   bump:
@@ -17,7 +22,7 @@ jobs:
         id: parse
         # Pass the tag via env to avoid shell injection from ${{ }} interpolation.
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
         run: |
           VERSION=$(echo "$TAG" | grep -oP '\d+\.\d+\.\d+$' || true)
           if [ -z "$VERSION" ]; then


### PR DESCRIPTION
Support for manual image bump trigger to allow testing without waiting for a new release

---
### Kimchi Summary
### What changed
Adds a `workflow_dispatch` trigger to the `bump-cluster-agent-image` workflow so it can be run manually with a specified release tag. The workflow now falls back to the dispatch input when not triggered by a published release.

### Why
Supports manually bumping the cluster-agent image when automated release triggers are unavailable or need to be rerun.

### Key changes
- `.github/workflows/bump-cluster-agent-image.yml`: Added `workflow_dispatch` event with required `tag_name` input.
- `.github/workflows/bump-cluster-agent-image.yml`: Updated `TAG` environment variable to `${{ github.event.release.tag_name || inputs.tag_name }}` to support both release and manual triggers.