### PR TITLE
CID-671: Fix gitlab MR and yaml formatting

### DIFF
--- a/.github/scripts/bump-kubecast-image.py
+++ b/.github/scripts/bump-kubecast-image.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Bumps a component's image.tag in castai-cluster-agent/chart/values.yaml
+and increments the patch version in Chart.yaml, preserving file formatting.
+
+Usage:
+    bump-kubecast-image.py <values.yaml> <Chart.yaml> <component> <image_tag>
+
+Exits 0 with "changed=false" output when the tag is already up to date.
+Exits 0 with "changed=true" and "new_version=x.y.z" output on success.
+"""
+
+import re
+import sys
+
+
+def replace_preserving_format(content, pattern, replacement):
+    match = re.search(pattern, content)
+    if not match:
+        print(f"Pattern not found: {pattern}", file=sys.stderr)
+        sys.exit(1)
+    return content[: match.start(1)] + replacement + content[match.end(1) :]
+
+
+def bump_patch(version):
+    parts = version.strip().split(".")
+    return f"{parts[0]}.{parts[1]}.{int(parts[2]) + 1}"
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(f"Usage: {sys.argv[0]} <values.yaml> <Chart.yaml> <component> <image_tag>", file=sys.stderr)
+        sys.exit(1)
+
+    values_path, chart_path, component, image_tag = sys.argv[1:]
+
+    with open(values_path) as f:
+        values = f.read()
+
+    # Find current tag under the component block.
+    # Matches:  <component>:\n  ...\n    image:\n      tag: <value>
+    pattern = rf"(?m)^{re.escape(component)}:.*?image:\s*\n\s+tag:\s*(\S+)"
+    match = re.search(pattern, values, re.DOTALL)
+    if not match:
+        print(f"Could not find {component}.image.tag in {values_path}", file=sys.stderr)
+        sys.exit(1)
+
+    current_tag = match.group(1).strip('"').strip("'")
+    if current_tag == image_tag:
+        print(f"Image tag is already {image_tag} — nothing to do.")
+        print("changed=false")
+        sys.exit(0)
+
+    values = values[: match.start(1)] + image_tag + values[match.end(1) :]
+    with open(values_path, "w") as f:
+        f.write(values)
+
+    with open(chart_path) as f:
+        chart = f.read()
+
+    version_match = re.search(r"(?m)^version:\s*(\S+)", chart)
+    if not version_match:
+        print(f"Could not find version in {chart_path}", file=sys.stderr)
+        sys.exit(1)
+
+    current_version = version_match.group(1)
+    new_version = bump_patch(current_version)
+    chart = chart[: version_match.start(1)] + new_version + chart[version_match.end(1) :]
+    with open(chart_path, "w") as f:
+        f.write(chart)
+
+    print(f"Bumped {component} image: {current_tag} -> {image_tag}")
+    print(f"Bumped chart version: {current_version} -> {new_version}")
+    print("changed=true")
+    print(f"old_tag={current_tag}")
+    print(f"new_version={new_version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/bump-kubecast-image.py
+++ b/.github/scripts/bump-kubecast-image.py
@@ -14,16 +14,11 @@ import re
 import sys
 
 
-def replace_preserving_format(content, pattern, replacement):
-    match = re.search(pattern, content)
-    if not match:
-        print(f"Pattern not found: {pattern}", file=sys.stderr)
-        sys.exit(1)
-    return content[: match.start(1)] + replacement + content[match.end(1) :]
-
-
 def bump_patch(version):
     parts = version.strip().split(".")
+    if len(parts) != 3 or not parts[2].isdigit():
+        print(f"Unexpected version format: {version!r} (expected x.y.z)", file=sys.stderr)
+        sys.exit(1)
     return f"{parts[0]}.{parts[1]}.{int(parts[2]) + 1}"
 
 
@@ -37,23 +32,23 @@ def main():
     with open(values_path) as f:
         values = f.read()
 
-    # Find current tag under the component block.
-    # Matches:  <component>:\n  ...\n    image:\n      tag: <value>
-    pattern = rf"(?m)^{re.escape(component)}:.*?image:\s*\n\s+tag:\s*(\S+)"
+    # Capture optional surrounding quotes so we can preserve them in the replacement.
+    # Matches:  <component>:\n  ...\n    image:\n      tag: ["']?<value>["']?
+    pattern = rf"(?m)^{re.escape(component)}:.*?image:\s*\n\s+tag:\s*([\"']?)(\S+?)\1\s*$"
     match = re.search(pattern, values, re.DOTALL)
     if not match:
         print(f"Could not find {component}.image.tag in {values_path}", file=sys.stderr)
         sys.exit(1)
 
-    current_tag = match.group(1).strip('"').strip("'")
+    quote = match.group(1)
+    current_tag = match.group(2)
     if current_tag == image_tag:
         print(f"Image tag is already {image_tag} — nothing to do.")
         print("changed=false")
         sys.exit(0)
 
-    values = values[: match.start(1)] + image_tag + values[match.end(1) :]
-    with open(values_path, "w") as f:
-        f.write(values)
+    # Compute new values content (write deferred until both mutations succeed).
+    new_values = values[: match.start(1)] + quote + image_tag + quote + values[match.end(1) :]
 
     with open(chart_path) as f:
         chart = f.read()
@@ -65,9 +60,13 @@ def main():
 
     current_version = version_match.group(1)
     new_version = bump_patch(current_version)
-    chart = chart[: version_match.start(1)] + new_version + chart[version_match.end(1) :]
+    new_chart = chart[: version_match.start(1)] + new_version + chart[version_match.end(1) :]
+
+    # Both mutations validated — safe to write.
+    with open(values_path, "w") as f:
+        f.write(new_values)
     with open(chart_path, "w") as f:
-        f.write(chart)
+        f.write(new_chart)
 
     print(f"Bumped {component} image: {current_tag} -> {image_tag}")
     print(f"Bumped chart version: {current_version} -> {new_version}")

--- a/.github/workflows/bump-cluster-agent-image.yml
+++ b/.github/workflows/bump-cluster-agent-image.yml
@@ -123,25 +123,12 @@ jobs:
           COMPONENT: ${{ steps.check.outputs.component }}
           IMAGE_TAG: ${{ steps.image.outputs.image_tag }}
         run: |
-          VALUES=kubecast/castai-cluster-agent/chart/values.yaml
-          CHART_YAML=kubecast/castai-cluster-agent/chart/Chart.yaml
-
-          CURRENT_TAG=$(yq e ".\"${COMPONENT}\".image.tag" "$VALUES")
-          if [ "$CURRENT_TAG" = "$IMAGE_TAG" ]; then
-            echo "Image tag is already ${IMAGE_TAG} — nothing to do."
-            echo "changed=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          yq e -i ".\"${COMPONENT}\".image.tag = \"${IMAGE_TAG}\"" "$VALUES"
-
-          CURRENT_VERSION=$(yq e '.version' "$CHART_YAML")
-          NEW_VERSION=$(echo "$CURRENT_VERSION" | awk -F. '{printf "%d.%d.%d", $1, $2, $3+1}')
-          yq e -i ".version = \"${NEW_VERSION}\"" "$CHART_YAML"
-
-          echo "changed=true" >> $GITHUB_OUTPUT
-          echo "old_tag=${CURRENT_TAG}" >> $GITHUB_OUTPUT
-          echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          python3 .github/scripts/bump-kubecast-image.py \
+            kubecast/castai-cluster-agent/chart/values.yaml \
+            kubecast/castai-cluster-agent/chart/Chart.yaml \
+            "${COMPONENT}" \
+            "${IMAGE_TAG}" \
+            | tee /tmp/bump-output.txt | grep -E '^(changed|old_tag|new_version)=' >> $GITHUB_OUTPUT
 
       - name: Push branch and open GitLab MR
         if: steps.bump.outputs.changed == 'true'
@@ -177,8 +164,14 @@ jobs:
             -d "$(jq -n \
               --arg source "$BRANCH" \
               --arg title "[castai-cluster-agent] Bump ${COMPONENT} to ${IMAGE_TAG}" \
-              --arg desc "Automated image bump triggered by [helm-charts release ${RELEASE_TAG}](${RELEASE_URL}).\n\n| | |\n|---|---|\n| **Component** | \`${COMPONENT}\` |\n| **Old tag** | \`${OLD_TAG}\` |\n| **New tag** | \`${IMAGE_TAG}\` |\n| **Chart version** | \`${NEW_VERSION}\` |" \
-              '{source_branch: $source, target_branch: "master", title: $title, description: $desc, labels: "team::identity"}')")
+              --arg component "$COMPONENT" \
+              --arg old_tag "$OLD_TAG" \
+              --arg new_tag "$IMAGE_TAG" \
+              --arg chart_version "$NEW_VERSION" \
+              --arg release_tag "$RELEASE_TAG" \
+              --arg release_url "$RELEASE_URL" \
+              '{ source_branch: $source, target_branch: "master", title: $title, labels: "team::identity",
+                 description: ("Automated image bump triggered by [helm-charts release \($release_tag)](\($release_url)).\n\n| | |\n|---|---|\n| **Component** | `\($component)` |\n| **Old tag** | `\($old_tag)` |\n| **New tag** | `\($new_tag)` |\n| **Chart version** | `\($chart_version)` |") }')")
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
           BODY=$(echo "$RESPONSE" | head -n -1)
           if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Replaces the `yq`-based image bump logic in the cluster-agent release workflow with a dedicated Python script that updates component image tags and chart patch versions while preserving the original YAML file formatting.

### Why
The previous inline `yq` commands rewrote entire `values.yaml` and `Chart.yaml` files, causing unnecessary formatting drift. The new script performs targeted replacements so only the specific values are modified.

### Key changes
*   `.github/scripts/bump-kubecast-image.py`: Added script that bumps a component's `image.tag` in `values.yaml` and increments the patch `version` in `Chart.yaml`. Preserves surrounding quotes and exits with `changed=false` when the tag is already current.
*   `.github/workflows/bump-cluster-agent-image.yml`: Replaced inline `yq` and `awk` logic with a call to `bump-kubecast-image.py`. Refactored the GitLab MR `jq` payload to use `--arg` bindings for safe variable interpolation.