### PR TITLE
chore: artifacthub verification

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: 6197c8b0-c99b-498a-a64f-55e60a9800a1
+owners:
+  - name: Cast AI
+    email: devs@cast.ai


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds an `artifacthub-repo.yml` verification file to the `gh-pages` branch so Artifact Hub can verify ownership of the `castai/helm-charts` repository.

### Why
Artifact Hub requires this metadata file to confirm repository ownership and grant verified publisher status for the Helm charts published on that branch.

### Key changes
- Added `artifacthub-repo.yml` containing the `repositoryID` and `owners` fields required by Artifact Hub for repository verification.