### PR TITLE
[castai-db-agent] Add configurable Postgres SSL mode and bump db-agent to v0.19.0

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.19.1
+version: 0.20.0

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -1,6 +1,6 @@
 # castai-db-agent
 
-![Version: 0.19.1](https://img.shields.io/badge/Version-0.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI DB agent deployment.
 
@@ -29,6 +29,7 @@ CAST AI DB agent deployment.
 | database.password | string | `""` | Password for database authentication (not required when useCloudSQLIAMAuth or useRDSIAMAuth is true) |
 | database.port | int | `5432` |  |
 | database.protocol | string | `"postgres"` | Database protocol to use. Supported values: postgres, mysql. |
+| database.sslMode | string | `"require"` | SSL mode for database connection (Postgres only). Forced to "disable" when cloudSqlProxy is enabled. |
 | database.useCloudSQLIAMAuth | bool | `false` | Enable IAM authentication for database connection (GCP Cloud SQL IAM). Requires Workload Identity setup. See IAM_AUTH_SETUP.md for details. |
 | database.useRDSIAMAuth | bool | `false` | Enable IAM authentication for database connection (AWS RDS IAM). Requires IAM role with rds-db:connect permission. |
 | database.username | string | `""` | Username for database authentication. For IAM auth, use the format: "service-account-name@project-id.iam" |

--- a/charts/castai-db-agent/templates/_versions.tpl
+++ b/charts/castai-db-agent/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultDbAgentVersion" -}}v0.18.1{{- end -}}
+{{- define "defaultDbAgentVersion" -}}v0.19.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}

--- a/charts/castai-db-agent/templates/deployment.yaml
+++ b/charts/castai-db-agent/templates/deployment.yaml
@@ -47,10 +47,14 @@ spec:
               {{- else }}
               value: "{{ required "target database port must be provided" .Values.database.port }}"
               {{- end }}
-              {{- if and .Values.cloudSqlProxy .Values.cloudSqlProxy.enabled }}
+            {{- if eq .Values.database.protocol "postgres" }}
             - name: DATABASE_SSL_MODE
+              {{- if and .Values.cloudSqlProxy .Values.cloudSqlProxy.enabled }}
               value: "disable"
+              {{- else }}
+              value: "{{ .Values.database.sslMode }}"
               {{- end }}
+            {{- end }}
             - name: DATABASE_USE_CLOUD_SQL_IAM_AUTH
               value: "{{ .Values.database.useCloudSQLIAMAuth }}"
             - name: DATABASE_USE_RDS_IAM_AUTH

--- a/charts/castai-db-agent/values.yaml
+++ b/charts/castai-db-agent/values.yaml
@@ -26,6 +26,8 @@ database:
   protocol: postgres
   # -- Database name to use for connecting to database instance for auto-discovering logical databases. This is only required for Postgres
   autoDiscoveryDatabase: "postgres"
+  # -- SSL mode for database connection (Postgres only). Forced to "disable" when cloudSqlProxy is enabled.
+  sslMode: "require"
 # -- URL to the CAST AI API gRPC endpoint.
 gRPCEndpoint: ""
 collectors:


### PR DESCRIPTION
### Summary
- Bumped `db-agent` image from `v0.18.1` to `v0.19.0`
- Added `database.sslMode` value (defaults to `require`, matching the `db-agent` image default).
- `DATABASE_SSL_MODE` is now always rendered for Postgres connections, not just Cloud SQL Proxy.
- Cloud SQL Proxy still forces `DATABASE_SSL_MODE=disable` regardless of the configured value.
- MySQL connections omit `DATABASE_SSL_MODE` entirely since this setting is Postgres-specific.

---
### Kimchi Summary
### What changed
Adds support for configuring the SSL mode for Postgres database connections and bumps the default DB agent version to `v0.19.0`.

### Why
Provides explicit control over database connection security settings and establishes a secure-by-default posture for Postgres deployments.

### Key changes
- `values.yaml`: Added `database.sslMode` parameter (default `"require"`)
- `templates/deployment.yaml`: Conditionally sets `DATABASE_SSL_MODE` for Postgres protocol; forces `"disable"` when Cloud SQL Proxy is enabled, otherwise uses `.Values.database.sslMode`
- `templates/_versions.tpl`: Updated default DB agent version from `v0.18.1` to `v0.19.0`
- `Chart.yaml` and `README.md`: Chart version bumped to `0.20.0`

### Impact
Postgres deployments without Cloud SQL Proxy will now have `DATABASE_SSL_MODE` explicitly set to `"require"` by default. Previously this environment variable was only injected (as `"disable"`) when Cloud SQL Proxy was enabled, so this may change the connection behavior for standalone Postgres configurations. Non-Postgres protocols are unaffected.