### PR TITLE
[castai-db-optimizer] update query-processor image

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.77.1
+version: 0.77.2

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.77.1](https://img.shields.io/badge/Version-0.77.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.77.2](https://img.shields.io/badge/Version-0.77.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,5 +1,5 @@
 {{- define "defaultProxyVersion" -}}v4.84.1{{- end -}}
-{{- define "defaultQueryProcessorVersion" -}}v0.45.0{{- end -}}
+{{- define "defaultQueryProcessorVersion" -}}v0.46.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
 {{- define "defaultPgdogVersion" -}}v0.1.30{{- end -}}
 {{- define "defaultProxySqlVersion" -}}3.0.6{{- end -}}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the `castai-db-optimizer` Helm chart to `0.77.2` and updates the default query processor image version to `v0.46.0`.

### Key changes
- `Chart.yaml`: increments chart version from `0.77.1` to `0.77.2`
- `README.md`: updates version badge to `0.77.2`
- `templates/_versions.tpl`: bumps the `defaultQueryProcessorVersion` default from `v0.45.0` to `v0.46.0`