### PR TITLE
[castai-db-agent] bump db-agent image to latest version

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.20.0
+version: 0.21.0

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -1,6 +1,6 @@
 # castai-db-agent
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI DB agent deployment.
 

--- a/charts/castai-db-agent/templates/_versions.tpl
+++ b/charts/castai-db-agent/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultDbAgentVersion" -}}v0.19.0{{- end -}}
+{{- define "defaultDbAgentVersion" -}}v0.20.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}


### PR DESCRIPTION
Bumps `db-agent` image to `v0.20.0` for collecting MySQL index size statistics.

---
### Kimchi Summary
### What changed
Bumps the `castai-db-agent` Helm chart version to `0.21.0` and updates the default DB agent application version to `v0.20.0`.

### Key changes
- `Chart.yaml` — incremented chart version from `0.20.0` to `0.21.0`.
- `README.md` — updated version badge to `0.21.0`.
- `templates/_versions.tpl` — bumped `defaultDbAgentVersion` from `v0.19.0` to `v0.20.0`.