### PR TITLE
[castai-spot-handler] Add support for global env var imagePullSecrets

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.35.2
+version: 0.35.3
 appVersion: "v0.23.0"

--- a/charts/castai-spot-handler/templates/_helpers.tpl
+++ b/charts/castai-spot-handler/templates/_helpers.tpl
@@ -78,6 +78,17 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Resolve imagePullSecrets: merge global.imagePullSecrets with local imagePullSecrets.
+*/}}
+{{- define "spot-handler.imagePullSecrets" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $combined := concat ($global.imagePullSecrets | default list) (.Values.imagePullSecrets | default list) -}}
+{{- if $combined -}}
+{{ toYaml $combined }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve tolerations: merge .Values.global.tolerations with .Values.tolerations.
 */}}
 {{- define "spot-handler.tolerations" -}}

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -43,9 +43,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.useHostNetwork }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with include "spot-handler.imagePullSecrets" . }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       securityContext:
       {{- toYaml .Values.securityContext | nindent 8 }}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
The `castai-spot-handler` Helm chart now supports global `imagePullSecrets`. The DaemonSet merges any secrets defined in `.Values.global.imagePullSecrets` with chart-local `.Values.imagePullSecrets` when pulling images.

### Why
This allows users to define `imagePullSecrets` once at a global level instead of repeating them in every subchart.

### Key changes
- `templates/_helpers.tpl`: Added `spot-handler.imagePullSecrets` helper template to concatenate `.Values.global.imagePullSecrets` and `.Values.imagePullSecrets`.
- `templates/daemonset.yaml`: Replaced direct `.Values.imagePullSecrets` usage with the new `spot-handler.imagePullSecrets` helper.
- `Chart.yaml`: Bumped chart version from `0.35.2` to `0.35.3`.