### PR TITLE
[castai-cluster-controller] Add support for global env var imagePullSecrets

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.92.3
+version: 0.92.4
 appVersion: "v0.62.1"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/templates/_helpers.tpl
+++ b/charts/castai-cluster-controller/templates/_helpers.tpl
@@ -84,6 +84,17 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Resolve imagePullSecrets: merge global.imagePullSecrets with local imagePullSecrets.
+*/}}
+{{- define "cluster-controller.imagePullSecrets" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $combined := concat ($global.imagePullSecrets | default list) (.Values.imagePullSecrets | default list) -}}
+{{- if $combined -}}
+{{ toYaml $combined }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve tolerations: merge .Values.global.tolerations with .Values.tolerations.
 */}}
 {{- define "cluster-controller.tolerations" -}}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -57,9 +57,9 @@ spec:
       priorityClassName: {{ .Values.priorityClass.name }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with include "cluster-controller.imagePullSecrets" . }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       tolerations:
         - operator: Exists


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for `global.imagePullSecrets` in the `castai-cluster-controller` Helm chart. The deployment now merges globally-defined image pull secrets with chart-local values when configuring pod `imagePullSecrets`.

### Why
Allows users to define `imagePullSecrets` once at a global level rather than repeating them in every sub-chart configuration.

### Key changes
- `templates/_helpers.tpl`: Added `cluster-controller.imagePullSecrets` helper template that concatenates `global.imagePullSecrets` and `.Values.imagePullSecrets`.
- `templates/deployment.yaml`: Updated `imagePullSecrets` to resolve via the new helper instead of reading `.Values.imagePullSecrets` directly.
- `Chart.yaml`: Bumped chart version from `0.92.3` to `0.92.4`.