### PR TITLE
[castai-db-agent] update db-agent image

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.21.0
+version: 0.21.1

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -1,6 +1,6 @@
 # castai-db-agent
 
-![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.21.1](https://img.shields.io/badge/Version-0.21.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI DB agent deployment.
 

--- a/charts/castai-db-agent/templates/_versions.tpl
+++ b/charts/castai-db-agent/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultDbAgentVersion" -}}v0.20.0{{- end -}}
+{{- define "defaultDbAgentVersion" -}}v0.20.1{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the CAST AI DB agent Helm chart to `0.21.1` and updates the default DB agent application version to `v0.20.1`.

### Why
Delivers the latest patch release of the DB agent.

### Key changes
- `charts/castai-db-agent/Chart.yaml` — bumps chart version from `0.21.0` to `0.21.1`.
- `charts/castai-db-agent/templates/_versions.tpl` — updates `defaultDbAgentVersion` from `v0.20.0` to `v0.20.1`.
- `charts/castai-db-agent/README.md` — updates the version badge to `0.21.1`.