### PR TITLE
[castai-cluster-controller] move apiKeySecretRef under castai to match umbrella

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.92.2
+version: 0.92.3
 appVersion: "v0.62.1"
 annotations:
   release-date: "2024-06-04T07:10:07"

--- a/charts/castai-cluster-controller/README.md
+++ b/charts/castai-cluster-controller/README.md
@@ -37,8 +37,8 @@ Cluster controller is responsible for handling certain Kubernetes actions such a
 | extraVolumeMounts | list | `[]` | Used to set additional volume mounts |
 | extraVolumes | list | `[]` | Used to set additional volumes |
 | fullnameOverride | string | `"castai-cluster-controller"` |  |
-| global | object | `{"apiKeySecretRef":"","commonAnnotations":{},"commonLabels":{},"registry":""}` | Global values that are propagated to child charts. |
-| global.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
+| global | object | `{"castai":{"apiKeySecretRef":""},"commonAnnotations":{},"commonLabels":{},"registry":""}` | Global values that are propagated to child charts. |
+| global.castai.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
 | global.commonAnnotations | object | `{}` | Annotations to add to all resources (including child charts). |
 | global.commonLabels | object | `{}` | Labels to add to all resources (including child charts). |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -187,7 +187,7 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.castai.apiKeySecretRef "castai-credentials" }}
           {{- if or .Values.apiKey .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if or .Values.apiKey .Values.castai.apiKey }}
@@ -303,7 +303,7 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.castai.apiKeySecretRef "castai-credentials" }}
           {{- if or .Values.apiKey .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if or .Values.apiKey .Values.castai.apiKey }}

--- a/charts/castai-cluster-controller/templates/deployment.yaml
+++ b/charts/castai-cluster-controller/templates/deployment.yaml
@@ -187,7 +187,7 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.castai.apiKeySecretRef "castai-credentials" }}
+          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.castai.apiKeySecretRef }}
           {{- if or .Values.apiKey .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if or .Values.apiKey .Values.castai.apiKey }}
@@ -303,7 +303,7 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.castai.apiKeySecretRef "castai-credentials" }}
+          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.castai.apiKeySecretRef }}
           {{- if or .Values.apiKey .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if or .Values.apiKey .Values.castai.apiKey }}

--- a/charts/castai-cluster-controller/values.yaml
+++ b/charts/castai-cluster-controller/values.yaml
@@ -11,9 +11,10 @@ global:
   # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
   # When set, it is prepended to all image repositories.
   registry: ""
-  # global.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
+  # global.castai.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
   # Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey.
-  apiKeySecretRef: ""
+  castai:
+    apiKeySecretRef: ""
 
 # replicas -- Number of replicas for castai-cluster-controller deployment.
 replicas: 2


### PR DESCRIPTION
…h umbrella

---
### Kimchi Summary
### What changed
Moves the global API key secret reference from `global.apiKeySecretRef` to `global.castai.apiKeySecretRef`, aligning the chart with umbrella chart value scoping conventions.

### Why
Allows the cluster-controller to correctly inherit a globally defined CAST AI API key secret when used as a subchart in an umbrella chart, avoiding top-level global value conflicts.

### Key changes
- `values.yaml`: Restructured `global.apiKeySecretRef` into nested `global.castai.apiKeySecretRef`.
- `templates/deployment.yaml`: Updated both container secret resolution expressions to fallback to `.Values.global.castai.apiKeySecretRef`.
- `README.md`: Updated documented global defaults and descriptions to reflect the new nested path.
- `Chart.yaml`: Bumped chart version from `0.92.2` to `0.92.3`.

### Impact
**Breaking change:** If you are currently setting `global.apiKeySecretRef`, migrate that value to `global.castai.apiKeySecretRef` before upgrading.