### PR TITLE
[castai-spot-handler] move apiKeySecretRef under castai to match umbrella

### DIFF
--- a/charts/castai-spot-handler/Chart.yaml
+++ b/charts/castai-spot-handler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-spot-handler
 description: Spot Handler is the component responsible for scheduled events monitoring and delivering them to the central platform.
 type: application
-version: 0.35.1
+version: 0.35.2
 appVersion: "v0.23.0"

--- a/charts/castai-spot-handler/README.md
+++ b/charts/castai-spot-handler/README.md
@@ -78,8 +78,8 @@ Spot Handler is the component responsible for scheduled events monitoring and de
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | envFrom | list | `[]` | Used to set additional environment variables for the spot handler container via configMaps or secrets. |
-| global | object | `{"apiKeySecretRef":"","registry":""}` | Global values propagated from parent charts. |
-| global.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
+| global | object | `{"castai":{"apiKeySecretRef":""},"registry":""}` | Global values propagated from parent charts. |
+| global.castai.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/spot-handler"` |  |

--- a/charts/castai-spot-handler/templates/daemonset.yaml
+++ b/charts/castai-spot-handler/templates/daemonset.yaml
@@ -106,7 +106,7 @@ spec:
             - secretRef:
                 name: {{ .Values.trustedCACertSecretRef -}}
           {{- end }}
-          {{- $resolvedSecretRef := or .Values.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.apiKeySecretRef .Values.global.castai.apiKeySecretRef }}
           {{- if and .Values.castai.apiKey $resolvedSecretRef }}
             {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
           {{- end }}

--- a/charts/castai-spot-handler/values.yaml
+++ b/charts/castai-spot-handler/values.yaml
@@ -13,9 +13,10 @@ global:
   # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
   # When set, it is prepended to all image repositories.
   registry: ""
-  # global.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
+  # global.castai.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
   # Takes effect when apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey.
-  apiKeySecretRef: ""
+  castai:
+    apiKeySecretRef: ""
 
 image:
   repository: us-docker.pkg.dev/castai-hub/library/spot-handler


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Moves the global `apiKeySecretRef` configuration under the `castai` key in the spot-handler chart to align with umbrella chart patterns.

### Why
Enables parent/umbrella charts to propagate the CAST AI API key secret reference through a namespaced `global.castai` values path, consistent with conventions used across the CAST AI chart suite.

### Key changes
- `values.yaml`: Restructured `apiKeySecretRef` from `global` to `global.castai`
- `templates/daemonset.yaml`: Updated secret resolution to read from `.Values.global.castai.apiKeySecretRef`
- `README.md`: Updated parameter table to document `global.castai.apiKeySecretRef`
- `Chart.yaml`: Bumped chart version from `0.35.1` to `0.35.2`

### Impact
**Breaking change**: Users or parent charts currently setting `global.apiKeySecretRef` must migrate the value to `global.castai.apiKeySecretRef`.