### PR TITLE
[castai-evictor] move apiKeySecretRef under castai to match umbrella

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.56
+version: 0.35.57
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -37,8 +37,8 @@ Cluster utilization defragmentation tool
 | extraVolumeMounts | list | `[]` | Used to set additional volume mounts. |
 | extraVolumes | list | `[]` | Used to set additional volumes. |
 | fullnameOverride | string | `"castai-evictor"` |  |
-| global | object | `{"apiKeySecretRef":"","registry":""}` | Global values propagated from parent charts. |
-| global.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when apiKeySecretRef is not set locally. |
+| global | object | `{"castai":{"apiKeySecretRef":""},"registry":""}` | Global values propagated from parent charts. |
+| global.castai.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when apiKeySecretRef is not set locally. |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | hostNetwork.enabled | bool | `false` | Enable host networking. |
 | ignorePodDisruptionBudgets | bool | `false` | Specifies whether the Evictor should ignore Pod Disruption Budgets (PDBs). If true, evictor will attempt to evict pods even if it would violate a PDB. Use with caution as this may disrupt application availability guarantees. |

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if not .Values.overrideEnvFrom}}
-          {{- $resolvedSecretRef := or .Values.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.apiKeySecretRef .Values.global.castai.apiKeySecretRef }}
             - secretRef:
                 name: {{ or $resolvedSecretRef "castai-cluster-controller" }}
                 optional: false

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -15,9 +15,10 @@ global:
   # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
   # When set, it is prepended to all image repositories.
   registry: ""
-  # global.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
+  # global.castai.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
   # Takes effect when apiKeySecretRef is not set locally.
-  apiKeySecretRef: ""
+  castai:
+    apiKeySecretRef: ""
 
 # dryRyn -- Specifies whether the Evictor should run in dryRun mode (Read-Only).
 # if true, evictor will just log action(s) it would perform


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Moves the global API key secret reference in the evictor Helm chart from `global.apiKeySecretRef` to `global.castai.apiKeySecretRef`, grouping CAST AI-specific configuration under the `castai` key to align with umbrella chart conventions.

### Why
Supports umbrella chart deployments by scoping global CAST AI credentials under a dedicated `castai` object, avoiding key collisions with other subcharts and maintaining consistency across the CAST AI Helm chart ecosystem.

### Key changes
- `values.yaml`: Moved `apiKeySecretRef` under the `global.castai` object (previously `global.apiKeySecretRef`)
- `templates/deployment.yaml`: Updated secret resolution logic to read from `.Values.global.castai.apiKeySecretRef`
- `README.md`: Updated parameter documentation to reflect the new `global.castai.apiKeySecretRef` path
- `Chart.yaml`: Incremented chart version to `0.35.57`

### Impact
**Breaking change:** Users who currently set `global.apiKeySecretRef` must update their values to use `global.castai.apiKeySecretRef`. The previous global key is no longer read by the deployment template.