### PR TITLE
[castai-pod-mutator] move apiKeySecretRef under castai to match umbrella

### DIFF
--- a/charts/castai-pod-mutator/Chart.yaml
+++ b/charts/castai-pod-mutator/Chart.yaml
@@ -3,5 +3,5 @@ name: castai-pod-mutator
 description: CAST AI Pod Mutator.
 type: application
 
-version: 0.13.2
+version: 0.13.3
 appVersion: "v0.3.1"

--- a/charts/castai-pod-mutator/README.md
+++ b/charts/castai-pod-mutator/README.md
@@ -1,6 +1,6 @@
 # castai-pod-mutator
 
-![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
+![Version: 0.13.3](https://img.shields.io/badge/Version-0.13.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 CAST AI Pod Mutator.
 
@@ -34,8 +34,8 @@ CAST AI Pod Mutator.
 | enforcer.scanInterval | string | `"10s"` |  |
 | envFrom | list | `[]` | Used to set additional environment variables for the pod-mutator container via configMaps or secrets. |
 | fullnameOverride | string | `"castai-pod-mutator"` |  |
-| global | object | `{"apiKeySecretRef":"","commonAnnotations":{},"commonLabels":{},"registry":""}` | Values to apply for the parent and child chart resources. |
-| global.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
+| global | object | `{"castai":{"apiKeySecretRef":""},"commonAnnotations":{},"commonLabels":{},"registry":""}` | Values to apply for the parent and child chart resources. |
+| global.castai.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey. |
 | global.commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | global.commonLabels | object | `{}` | Labels to add to all resources. |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |

--- a/charts/castai-pod-mutator/templates/deployment.yaml
+++ b/charts/castai-pod-mutator/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
             {{- end }}
           {{- end }}
           envFrom:
-          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.apiKeySecretRef }}
+          {{- $resolvedSecretRef := or .Values.castai.apiKeySecretRef .Values.global.castai.apiKeySecretRef }}
           {{- if or .Values.castai.apiKey $resolvedSecretRef }}
             - secretRef:
                 {{- if .Values.castai.apiKey }}

--- a/charts/castai-pod-mutator/values.yaml
+++ b/charts/castai-pod-mutator/values.yaml
@@ -131,9 +131,10 @@ global:
   # global.registry -- Container registry prefix for all images (e.g. "my-registry.example.com").
   # When set, it is prepended to all image repositories.
   registry: ""
-  # global.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
+  # global.castai.apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
   # Takes effect when castai.apiKeySecretRef is not set locally. Mutually exclusive with castai.apiKey.
-  apiKeySecretRef: ""
+  castai:
+    apiKeySecretRef: ""
 
 mutator:
   # processingDelay -- Delay in seconds before the pod-mutator processes the pod. Default is 30s


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Nests the umbrella-chart API key secret reference under `global.castai` so the pod-mutator can inherit `global.castai.apiKeySecretRef` from a parent CAST AI chart instead of the previous flat `global.apiKeySecretRef` key.

### Why
Umbrella charts typically share CAST AI configuration under the `global.castai` namespace. This aligns the pod-mutator with that convention so it correctly resolves the API key when deployed as a subchart.

### Key changes
- `values.yaml`: Moved `apiKeySecretRef` from `global` to the new `global.castai` object.
- `templates/deployment.yaml`: Updated `$resolvedSecretRef` logic to read `.Values.global.castai.apiKeySecretRef`.
- `README.md`: Regenerated docs to reflect the new `global.castai.apiKeySecretRef` default and description.
- `Chart.yaml`: Bumped chart version from `0.13.2` to `0.13.3`.

### Impact
**Breaking:** If you currently pass `global.apiKeySecretRef` in your custom values, you must rename it to `global.castai.apiKeySecretRef` when upgrading to this version.