### PR TITLE
[castai-umbrella] Update kent chart dependencies, add castai-chart-upgrader

### DIFF
--- a/charts/castai-umbrella/Chart.lock
+++ b/charts/castai-umbrella/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kent
   repository: file://charts/kent
-  version: 0.11.0
+  version: 0.12.0
 - name: autoscaler-anywhere
   repository: file://charts/autoscaler-anywhere
   version: 0.4.0
@@ -11,5 +11,5 @@ dependencies:
 - name: autoscaler
   repository: file://charts/autoscaler
   version: 0.1.0
-digest: sha256:60538f7222399f986741c9766df2c648e4d767dc35f73ecb3567cb8b6cd26c66
-generated: "2026-04-14T16:13:44.080811+03:00"
+digest: sha256:e4cc3e13c1a87fa0f0ad9c326d5e9fcd3b603cb43cf406bab261230c4e20af02
+generated: "2026-05-22T16:34:51.050149+03:00"

--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.34.73
+version: 0.35.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -9,11 +9,11 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 | Repository | Name | Version |
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.0 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.37 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.10 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.10 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.3 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.58 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.20 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.20 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -9,15 +9,15 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 | Repository | Name | Version |
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.0 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.37 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.0.155 |
-| https://castai.github.io/helm-charts | castai-live | 0.91.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.0 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.3 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.58 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.1 |
+| https://castai.github.io/helm-charts | castai-live | 0.97.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.3 |
-| https://castai.github.io/helm-charts | castai-spot-handler | 0.34.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.10 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.10 |
+| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.20 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.20 |
 | https://castai.github.io/helm-charts | gpu-metrics-exporter | 0.1.29 |
 
 ## Values

--- a/charts/castai-umbrella/charts/kent/Chart.lock
+++ b/charts/castai-umbrella/charts/kent/Chart.lock
@@ -1,33 +1,36 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.152.0
+  version: 0.153.2
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
-  version: 0.92.0
+  version: 0.92.3
 - name: castai-kentroller
   repository: https://castai.github.io/helm-charts
-  version: 0.1.117
+  version: 0.1.145
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 1.0.0
+  version: 1.0.20
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 0.0.117
+  version: 1.0.20
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.83.0
+  version: 0.97.0
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.10.0
+  version: 0.13.3
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
-  version: 0.33.0
+  version: 0.35.2
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
   version: 3.13.0
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.0.150
-digest: sha256:845d2b32483d9789ab941946a97a83e838e88e6b85cea8f1993c336c63b68d49
-generated: "2026-04-16T13:57:35.136908+03:00"
+  version: 1.160.1
+- name: castai-chart-upgrader
+  repository: https://castai.github.io/helm-charts
+  version: 0.1.0
+digest: sha256:68231fd8ddda3081edcbd4b0ab97bad28fdf32fd21771e0780566b9b69e9f1ee
+generated: "2026-05-22T16:34:45.627609+03:00"

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kent
 description: Wrapper chart for CAST AI Kent profile.
 type: application
-version: 0.11.0
+version: 0.12.0
 dependencies:
   - name: castai-agent
     version: "0.153.2"
@@ -44,3 +44,7 @@ dependencies:
     version: "1.160.1"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-kvisor.enabled
+  - name: castai-chart-upgrader
+    version: "0.1.0"
+    repository: "https://castai.github.io/helm-charts"
+    condition: castai-chart-upgrader.enabled

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -1,6 +1,6 @@
 # kent
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Kent profile.
 
@@ -9,14 +9,15 @@ Wrapper chart for CAST AI Kent profile.
 | Repository | Name | Version |
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.0 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.135 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.0.156 |
-| https://castai.github.io/helm-charts | castai-live | 0.91.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.0 |
-| https://castai.github.io/helm-charts | castai-spot-handler | 0.34.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.10 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.10 |
+| https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.0 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.3 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.145 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.1 |
+| https://castai.github.io/helm-charts | castai-live | 0.97.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
+| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.20 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.20 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values
@@ -29,6 +30,9 @@ Wrapper chart for CAST AI Kent profile.
 | castai-agent.metadataStore.createConfigMap | bool | `true` |  |
 | castai-agent.provider | string | `"eks"` |  |
 | castai-agent.replicaCount | int | `1` |  |
+| castai-chart-upgrader.chart.name | string | `"castai"` |  |
+| castai-chart-upgrader.chart.repository | string | `"https://castai.github.io/helm-charts"` |  |
+| castai-chart-upgrader.enabled | bool | `false` |  |
 | castai-cluster-controller.autoscaling.enabled | bool | `false` |  |
 | castai-cluster-controller.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
 | castai-cluster-controller.enabled | bool | `true` |  |

--- a/charts/castai-umbrella/charts/kent/values.yaml
+++ b/charts/castai-umbrella/charts/kent/values.yaml
@@ -90,3 +90,9 @@ castai-kvisor:
     extraArgs:
       log-level: info
       cluster-proxy-enabled: "true"
+
+castai-chart-upgrader:
+  enabled: false
+  chart:
+    name: castai
+    repository: "https://castai.github.io/helm-charts"


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the CAST AI umbrella chart to `0.35.0` and the `kent` profile to `0.12.0`, adding `castai-chart-upgrader` as an optional dependency. Also refreshes documented sub-chart dependency versions across the `kent`, `autoscaler`, and `autoscaler-anywhere` profiles.

### Why
Adds the chart upgrader component to the Kent profile so clusters can optionally auto-update their CAST AI Helm releases.

### Key changes
- `charts/castai-umbrella/Chart.yaml`: Bumped umbrella chart version to `0.35.0` and `kent` dependency version to `0.12.0`.
- `charts/castai-umbrella/charts/kent/Chart.yaml`: Bumped `kent` version to `0.12.0` and added optional dependency `castai-chart-upgrader` (`0.1.0`) guarded by `castai-chart-upgrader.enabled`.
- `charts/castai-umbrella/charts/kent/values.yaml`: Introduced `castai-chart-upgrader` values block with `enabled: false`, `chart.name`, and `chart.repository`.
- `charts/castai-umbrella/charts/kent/Chart.lock`: Regenerated lock file; updated resolved versions for `castai-agent`, `castai-cluster-controller`, `castai-kentroller`, `castai-kvisor`, `castai-live`, `castai-pod-mutator`, `castai-spot-handler`, `castai-workload-autoscaler`, and `castai-workload-autoscaler-exporter`.
- `charts/castai-umbrella/charts/autoscaler/README.md` and `charts/castai-umbrella/charts/autoscaler-anywhere/README.md`: Updated documented dependency versions to reflect latest sub-chart releases.

### Impact
- `castai-chart-upgrader` is disabled by default; existing installations are unaffected unless explicitly enabled.
- To opt in, set `castai-chart-upgrader.enabled=true` in your values.