### PR TITLE
[castai-evictor] Add support for global env var imagePullSecrets

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.58
+version: 0.35.59
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -37,8 +37,9 @@ Cluster utilization defragmentation tool
 | extraVolumeMounts | list | `[]` | Used to set additional volume mounts. |
 | extraVolumes | list | `[]` | Used to set additional volumes. |
 | fullnameOverride | string | `"castai-evictor"` |  |
-| global | object | `{"castai":{"apiKeySecretRef":""},"registry":""}` | Global values propagated from parent charts. |
+| global | object | `{"castai":{"apiKeySecretRef":""},"imagePullSecrets":[],"registry":""}` | Global values propagated from parent charts. |
 | global.castai.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when apiKeySecretRef is not set locally. |
+| global.imagePullSecrets | list | `[]` | Image pull secrets applied to all pods. Merged with local imagePullSecrets. |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | hostNetwork.enabled | bool | `false` | Enable host networking. |
 | ignorePodDisruptionBudgets | bool | `false` | Specifies whether the Evictor should ignore Pod Disruption Budgets (PDBs). If true, evictor will attempt to evict pods even if it would violate a PDB. Use with caution as this may disrupt application availability guarantees. |

--- a/charts/castai-evictor/templates/_helpers.tpl
+++ b/charts/castai-evictor/templates/_helpers.tpl
@@ -100,6 +100,17 @@ Resolve image repository: prepend global.registry if set.
 {{- end }}
 
 {{/*
+Resolve imagePullSecrets: merge global.imagePullSecrets with local imagePullSecrets.
+*/}}
+{{- define "evictor.imagePullSecrets" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $combined := concat ($global.imagePullSecrets | default list) (.Values.imagePullSecrets | default list) -}}
+{{- if $combined -}}
+{{ toYaml $combined }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Pass the customConfig to the configMap
 */}}
 {{- define "evictor.configMap.customConfig" -}}

--- a/charts/castai-evictor/templates/clustervpa-deployment.yaml
+++ b/charts/castai-evictor/templates/clustervpa-deployment.yaml
@@ -46,9 +46,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with include "evictor.imagePullSecrets" . }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- with .Values.securityContext }}
       securityContext:

--- a/charts/castai-evictor/templates/deployment.yaml
+++ b/charts/castai-evictor/templates/deployment.yaml
@@ -39,9 +39,9 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with include "evictor.imagePullSecrets" . }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "evictor.serviceAccountName" . }}
       {{- if .Values.securityContext }}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -19,6 +19,8 @@ global:
   # Takes effect when apiKeySecretRef is not set locally.
   castai:
     apiKeySecretRef: ""
+  # global.imagePullSecrets -- Image pull secrets applied to all pods. Merged with local imagePullSecrets.
+  imagePullSecrets: []
 
 # dryRyn -- Specifies whether the Evictor should run in dryRun mode (Read-Only).
 # if true, evictor will just log action(s) it would perform


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for `global.imagePullSecrets` to the CAST AI Evictor Helm chart. The main `Deployment` and `ClusterVPA` deployment now merge globally-defined image pull secrets with local `imagePullSecrets` when generating pod specs.

### Why
Allows parent charts or unified deployments to configure image pull secrets once at the global level, rather than repeating them in every subchart.

### Key changes
- `values.yaml`: Introduced `global.imagePullSecrets` list (defaults to `[]`).
- `README.md`: Documented the new `global.imagePullSecrets` value and its merge behavior with local secrets.
- `templates/_helpers.tpl`: Added `evictor.imagePullSecrets` helper template that concatenates `global.imagePullSecrets` with `.Values.imagePullSecrets`.
- `templates/deployment.yaml` and `templates/clustervpa-deployment.yaml`: Replaced direct `.Values.imagePullSecrets` usage with the `evictor.imagePullSecrets` helper.
- `Chart.yaml`: Incremented chart version to `0.35.59`.

### Impact
- Fully additive with no breaking changes. Existing local `imagePullSecrets` configurations continue to function as before; when global secrets are also provided, both lists are merged in the generated pod spec.