### PR TITLE
[castai-evictor] add serviceAccount.rbac toggle for cluster-scoped RBAC

### DIFF
--- a/charts/castai-evictor/Chart.lock
+++ b/charts/castai-evictor/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://child-charts/castai-evictor-ext
   version: 0.5.0
 digest: sha256:6b104203eb2f32cea8879803a479d4df6e91bf4b014a25208566b253eb6bdb80
-generated: "2026-03-09T20:53:30.464703+01:00"
+generated: "2026-06-04T12:44:22.675839-04:00"

--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,21 +14,19 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.68
+version: 0.35.69
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: 37fcd39afdad8bce7b442a16d7add9988d8c09e8
 annotations:
-  release-date: "2026-06-02T05:51:07"
+  release-date: "2026-06-04"
   artifacthub.io/changes: |
-    - kind: removed
+    - kind: added
       description: |
-        Removed 'karpenterMode' values block and the KARPENTER_MODE_ENABLED env var.
-        This was a legacy code path intended for KENT integration; it caused Evictor
-        to label Karpenter-managed nodes in a way that prevented Karpenter consolidation.
-        See UPGRADING.md for required manual node cleanup steps.
+        Added global.rbac.clusterScoped.enabled toggle for cluster-scoped RBAC resources.
+        Set to false to disable ClusterRole and ClusterRoleBinding creation.
 # GitHub actions fails when 'chart' directory is used for dependencies.
 dependencies:
   - name: castai-evictor-ext

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -37,9 +37,10 @@ Cluster utilization defragmentation tool
 | extraVolumeMounts | list | `[]` | Used to set additional volume mounts. |
 | extraVolumes | list | `[]` | Used to set additional volumes. |
 | fullnameOverride | string | `"castai-evictor"` |  |
-| global | object | `{"castai":{"apiKeySecretRef":""},"imagePullSecrets":[],"registry":""}` | Global values propagated from parent charts. |
+| global | object | `{"castai":{"apiKeySecretRef":""},"imagePullSecrets":[],"rbac":{"clusterScoped":{"enabled":true}},"registry":""}` | Global values propagated from parent charts. |
 | global.castai.apiKeySecretRef | string | `""` | Name of a pre-existing Secret containing the CAST AI API key. Takes effect when apiKeySecretRef is not set locally. |
 | global.imagePullSecrets | list | `[]` | Image pull secrets applied to all pods. Merged with local imagePullSecrets. |
+| global.rbac.clusterScoped.enabled | bool | `true` | Enable cluster-scoped RBAC resources (ClusterRole, ClusterRoleBinding). Set to false to disable cluster-scoped RBAC if using namespace-scoped permissions. |
 | global.registry | string | `""` | Container registry prefix for all images (e.g. "my-registry.example.com"). When set, it is prepended to all image repositories. |
 | hostNetwork.enabled | bool | `false` | Enable host networking. |
 | ignorePodDisruptionBudgets | bool | `false` | Specifies whether the Evictor should ignore Pod Disruption Budgets (PDBs). If true, evictor will attempt to evict pods even if it would violate a PDB. Use with caution as this may disrupt application availability guarantees. |

--- a/charts/castai-evictor/child-charts/castai-evictor-ext/README.md
+++ b/charts/castai-evictor/child-charts/castai-evictor-ext/README.md
@@ -11,6 +11,8 @@ castai-evictor-ext.
 | commonAnnotations | object | `{}` |  |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | fullnameOverride | string | `"castai-evictor-ext"` |  |
+| global | object | `{"rbac":{"clusterScoped":{"enabled":true}}}` | Global values propagated from parent charts. |
+| global.rbac.clusterScoped.enabled | bool | `true` | Enable cluster-scoped RBAC resources (ClusterRole, ClusterRoleBinding). Set to false to disable cluster-scoped RBAC if using namespace-scoped permissions. |
 | nameOverride | string | `""` |  |
 | serviceAccount.name | string | `"castai-evictor"` |  |
 

--- a/charts/castai-evictor/child-charts/castai-evictor-ext/templates/clusterrole.yaml
+++ b/charts/castai-evictor/child-charts/castai-evictor-ext/templates/clusterrole.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if (dig "rbac" "clusterScoped" "enabled" true (.Values.global | default dict)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -150,3 +151,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}

--- a/charts/castai-evictor/child-charts/castai-evictor-ext/templates/clusterrolebinding.yaml
+++ b/charts/castai-evictor/child-charts/castai-evictor-ext/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if (dig "rbac" "clusterScoped" "enabled" true (.Values.global | default dict)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,3 +18,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/castai-evictor/child-charts/castai-evictor-ext/values.yaml
+++ b/charts/castai-evictor/child-charts/castai-evictor-ext/values.yaml
@@ -8,6 +8,14 @@ commonAnnotations: {}
 nameOverride: ""
 fullnameOverride: castai-evictor-ext
 
+# global -- Global values propagated from parent charts.
+global:
+  # global.rbac.clusterScoped.enabled -- Enable cluster-scoped RBAC resources (ClusterRole, ClusterRoleBinding).
+  # Set to false to disable cluster-scoped RBAC if using namespace-scoped permissions.
+  rbac:
+    clusterScoped:
+      enabled: true
+
 # This chart is meant to provide possibility for granting permissions mostly. Permissions are granted by creating
 # new role bindings to the SA created in the parent Chart. This SA name is used for creating role bindings.
 serviceAccount:

--- a/charts/castai-evictor/templates/clusterrole.yaml
+++ b/charts/castai-evictor/templates/clusterrole.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if (dig "rbac" "clusterScoped" "enabled" true (.Values.global | default dict)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -75,3 +76,4 @@ rules:
       - list
       - watch
       - update
+{{- end }}

--- a/charts/castai-evictor/templates/clusterrolebinding.yaml
+++ b/charts/castai-evictor/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if (dig "rbac" "clusterScoped" "enabled" true (.Values.global | default dict)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,3 +18,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "evictor.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -21,6 +21,11 @@ global:
     apiKeySecretRef: ""
   # global.imagePullSecrets -- Image pull secrets applied to all pods. Merged with local imagePullSecrets.
   imagePullSecrets: []
+  # global.rbac.clusterScoped.enabled -- Enable cluster-scoped RBAC resources (ClusterRole, ClusterRoleBinding).
+  # Set to false to disable cluster-scoped RBAC if using namespace-scoped permissions.
+  rbac:
+    clusterScoped:
+      enabled: true
 
 # dryRyn -- Specifies whether the Evictor should run in dryRun mode (Read-Only).
 # if true, evictor will just log action(s) it would perform


### PR DESCRIPTION
Add a `serviceAccount.rbac` boolean toggle (default: `true`) that conditionally creates ClusterRole and ClusterRoleBinding resources in both the parent castai-evictor chart and the castai-evictor-ext child chart.

When set to `false`, SecOps teams can manage cluster-scoped RBAC independently while the chart continues to render namespace-scoped Role/RoleBinding resources.

**Files changed:**
- `values.yaml`: add `serviceAccount.rbac` field
- `templates/clusterrole.yaml`: guard with `serviceAccount.rbac`
- `templates/clusterrolebinding.yaml`: guard with `serviceAccount.rbac`
- `Chart.yaml`: update dependency condition + bump chart version

---
### Kimchi Summary
### What changed
Adds a `global.rbac.clusterScoped.enabled` toggle (defaulting to `true`) to the Evictor Helm chart and its `castai-evictor-ext` dependency. When set to `false`, the chart skips creating ClusterRole and ClusterRoleBinding resources.

### Why
Supports deployments in clusters where cluster-scoped RBAC is restricted, externally managed, or replaced by namespace-scoped permissions.

### Key changes
- `values.yaml` (main chart and child chart): Introduced `global.rbac.clusterScoped.enabled` (defaults to `true`).
- `templates/clusterrole.yaml` and `templates/clusterrolebinding.yaml`: Wrapped resource creation in a conditional `dig "rbac" "clusterScoped" "enabled"` check.
- `child-charts/castai-evictor-ext/templates/clusterrole.yaml` and `clusterrolebinding.yaml`: Applied the same conditional guards.
- `README.md` (both charts): Documented the new `global.rbac.clusterScoped.enabled` parameter.
- `Chart.yaml`: Bumped chart version to `0.35.70` and updated release annotations.

### Impact
Default behavior is unchanged. If `global.rbac.clusterScoped.enabled` is set to `false`, equivalent permissions must be provided through other means or Evictor will lack required cluster access.