### PR TITLE
[castai-umbrella] Add support for imagePullSecrets global var

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.35.7
+version: 0.35.8
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/README.md
+++ b/charts/castai-umbrella/README.md
@@ -274,6 +274,7 @@ helm upgrade castai castai-helm/castai \
 | global.castai.apiURL | string | `"https://api.cast.ai"` |  |
 | global.castai.grpcURL | string | `"grpc.cast.ai:443"` |  |
 | global.castai.provider | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
 | global.registry | string | `""` |  |
 | global.tolerations | list | `[]` |  |
 | kent.enabled | bool | `false` |  |

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -9,11 +9,11 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 | Repository | Name | Version |
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.3 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.58 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.59 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.20 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.20 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.22 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.22 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -9,15 +9,15 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 | Repository | Name | Version |
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.3 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.58 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.1 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.59 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.2 |
 | https://castai.github.io/helm-charts | castai-live | 0.97.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.3 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.20 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.20 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.22 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.22 |
 | https://castai.github.io/helm-charts | gpu-metrics-exporter | 0.1.29 |
 
 ## Values

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -10,14 +10,14 @@ Wrapper chart for CAST AI Kent profile.
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.0 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.3 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
 | https://castai.github.io/helm-charts | castai-kentroller | 0.1.145 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.1 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.2 |
 | https://castai.github.io/helm-charts | castai-live | 0.97.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.20 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.20 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.22 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.22 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values

--- a/charts/castai-umbrella/values.yaml
+++ b/charts/castai-umbrella/values.yaml
@@ -8,6 +8,8 @@ global:
     grpcURL: "grpc.cast.ai:443"
     # provider -- Kubernetes service provider: eks, aks, gke, kops, anywhere.
     provider: ""
+  # imagePullSecrets -- Image pull secrets applied to all sub-chart pods (merged with per-chart imagePullSecrets).
+  imagePullSecrets: []
   # tolerations -- Global tolerations applied to all sub-chart pods (can be overridden per sub-chart).
   tolerations: []
   # registry -- Container registry prefix for all sub-chart images (e.g. "my-registry.example.com").


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds a `global.imagePullSecrets` value to the CAST AI umbrella chart, allowing users to configure image pull secrets once for all sub-chart pods. Bumps the umbrella chart version to `0.35.8` and refreshes documented dependency versions for multiple profile sub-charts.

### Why
Reduces repetition when deploying CAST AI components from a private registry that requires authentication.

### Key changes
- `charts/castai-umbrella/values.yaml`: introduces `global.imagePullSecrets` list (default `[]`) to be merged with per-chart image pull secrets.
- `charts/castai-umbrella/Chart.yaml`: bumps chart version from `0.35.7` to `0.35.8`.
- `charts/castai-umbrella/README.md`: documents the new `global.imagePullSecrets` parameter.
- `charts/castai-umbrella/charts/autoscaler-anywhere/README.md`, `autoscaler/README.md`, and `kent/README.md`: updates dependency version references for `castai-cluster-controller`, `castai-evictor`, `castai-kvisor`, `castai-workload-autoscaler`, and `castai-workload-autoscaler-exporter`.