### PR TITLE
[castai-db-optimizer] generate ProxySQL users dynamically

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.77.3
+version: 0.78.0

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.77.3](https://img.shields.io/badge/Version-0.77.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.78.0](https://img.shields.io/badge/Version-0.78.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 
@@ -100,11 +100,12 @@ CAST AI database cache deployment.
 | proxySql.config.stacksize | int | `1048576` | Stacksize for ProxySQL threads |
 | proxySql.config.threads | int | `4` | Number of ProxySQL threads |
 | proxySql.enabled | bool | `false` | Enable ProxySQL pooler sidecar (MySQL only) |
-| proxySql.password | string | `""` | ProxySQL upstream DB password (plain string). Mutually exclusive with usersSecretRef |
+| proxySql.password | string | `""` | Single ProxySQL upstream DB password (plain string). Mutually exclusive with users/usersSecretRef. |
 | proxySql.resources.cpu | string | `"500m"` |  |
 | proxySql.resources.memory | string | `"256Mi"` |  |
-| proxySql.user | string | `""` | ProxySQL upstream DB user (plain string). Mutually exclusive with usersSecretRef |
-| proxySql.usersSecretRef | string | `""` | Reference to existing secret containing username and password. Mutually exclusive with user/password. The secret must contain keys "PROXY_SQL_USERNAME" and "PROXY_SQL_PASSWORD". |
+| proxySql.user | string | `""` | Single ProxySQL upstream DB user (plain string). Mutually exclusive with users/usersSecretRef. |
+| proxySql.users | list | `[]` | Multiple ProxySQL upstream DB users (inline list). Mutually exclusive with user/usersSecretRef. Example: [{username: "u1", password: "p1"}, {username: "u2", password: "p2"}] |
+| proxySql.usersSecretRef | string | `""` | Reference to existing secret containing a users.json key with a JSON array of {username, password} objects. Mutually exclusive with user/users. |
 | proxySqlImage.pullPolicy | string | `"IfNotPresent"` |  |
 | proxySqlImage.repository | string | `"docker.io/proxysql/proxysql"` |  |
 | proxySqlImage.tag | string | `""` |  |

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,5 +1,5 @@
 {{- define "defaultProxyVersion" -}}v4.84.1{{- end -}}
-{{- define "defaultQueryProcessorVersion" -}}v0.46.0{{- end -}}
+{{- define "defaultQueryProcessorVersion" -}}v0.47.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
 {{- define "defaultPgdogVersion" -}}v0.1.30{{- end -}}
 {{- define "defaultProxySqlVersion" -}}3.0.6{{- end -}}

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
             name: {{ include "name" . }}-proxysql-config
         - name: proxysql-config-output
           emptyDir: {}
+        - name: proxysql-users-secret-volume
+          secret:
+            secretName: {{ ternary .Values.proxySql.usersSecretRef (printf "%s-proxysql-users" (include "name" .)) (ne .Values.proxySql.usersSecretRef "") }}
         {{- end }}
       {{- if or (and .Values.pgdog .Values.pgdog.enabled) (and .Values.proxySql .Values.proxySql.enabled) }}
       initContainers:
@@ -131,29 +134,35 @@ spec:
             - /bin/sh
             - -c
             - |
-              sed \
-                -e "s|\${PROXY_SQL_USERNAME}|$PROXY_SQL_USERNAME|g" \
-                -e "s|\${PROXY_SQL_PASSWORD}|$PROXY_SQL_PASSWORD|g" \
-                /etc/proxysql-template/proxysql.cnf > /etc/proxysql/proxysql.cnf
+              cp /etc/proxysql-template/proxysql.cnf /etc/proxysql/proxysql.cnf
               openssl req -x509 -newkey rsa:2048 \
                 -keyout /etc/proxysql/proxysql.key \
                 -out /etc/proxysql/proxysql.crt \
                 -days 3650 -nodes -subj "/CN=proxysql"
-          env:
-            {{- $proxySqlSecretName := ternary .Values.proxySql.usersSecretRef (printf "%s-proxysql-users" (include "name" .)) (ne .Values.proxySql.usersSecretRef "") }}
-            - name: PROXY_SQL_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $proxySqlSecretName }}
-                  key: PROXY_SQL_USERNAME
-            - name: PROXY_SQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $proxySqlSecretName }}
-                  key: PROXY_SQL_PASSWORD
           volumeMounts:
             - name: proxysql-config-template
               mountPath: /etc/proxysql-template
+              readOnly: true
+            - name: proxysql-config-output
+              mountPath: /etc/proxysql
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 999
+        - name: proxysql-users-init
+          image: "{{.Values.queryProcessorImage.repository}}:{{ include "queryProcessorImage" . }}"
+          imagePullPolicy: {{.Values.queryProcessorImage.pullPolicy}}
+          command:
+            - query-processor
+            - init-proxysql-users
+            - --users-json=/etc/proxysql-users-secret/users.json
+            - --config-output=/etc/proxysql/proxysql.cnf
+          volumeMounts:
+            - name: proxysql-users-secret-volume
+              mountPath: /etc/proxysql-users-secret
               readOnly: true
             - name: proxysql-config-output
               mountPath: /etc/proxysql
@@ -530,18 +539,6 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: true
             runAsUser: 999
-          env:
-            {{- $proxySqlSecretName := ternary .Values.proxySql.usersSecretRef (printf "%s-proxysql-users" (include "name" .)) (ne .Values.proxySql.usersSecretRef "") }}
-            - name: PROXY_SQL_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $proxySqlSecretName }}
-                  key: PROXY_SQL_USERNAME
-            - name: PROXY_SQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $proxySqlSecretName }}
-                  key: PROXY_SQL_PASSWORD
           readinessProbe:
             tcpSocket:
               port: {{ .Values.proxySql.basePort }}

--- a/charts/castai-db-optimizer/templates/proxysql-config.yaml
+++ b/charts/castai-db-optimizer/templates/proxysql-config.yaml
@@ -90,13 +90,4 @@ data:
     {{- end }}
     )
 
-    mysql_users=
-    (
-      {
-        username = "${PROXY_SQL_USERNAME}"
-        password = "${PROXY_SQL_PASSWORD}"
-        default_hostgroup = 0
-        active = 1
-      }
-    )
 {{- end }}

--- a/charts/castai-db-optimizer/templates/proxysql-users-secret.yaml
+++ b/charts/castai-db-optimizer/templates/proxysql-users-secret.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.proxySql .Values.proxySql.enabled .Values.proxySql.user .Values.proxySql.password }}
+{{- if and .Values.proxySql .Values.proxySql.enabled (not .Values.proxySql.usersSecretRef) }}
+{{- if or .Values.proxySql.user .Values.proxySql.users }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +10,11 @@ metadata:
     {{- include "annotations" . | nindent 4 }}
 type: Opaque
 stringData:
-  PROXY_SQL_USERNAME: {{ .Values.proxySql.user | quote }}
-  PROXY_SQL_PASSWORD: {{ .Values.proxySql.password | quote }}
+  users.json: |
+    {{- if .Values.proxySql.users }}
+    {{ .Values.proxySql.users | toJson }}
+    {{- else }}
+    [{"username":{{ .Values.proxySql.user | quote }},"password":{{ .Values.proxySql.password | quote }}}]
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/castai-db-optimizer/values.yaml
+++ b/charts/castai-db-optimizer/values.yaml
@@ -235,12 +235,15 @@ proxySql:
   # -- Starting port from which ProxySQL internal listening ports are sequentially assigned per endpoint.
   # These ports are pod-internal (Envoy → ProxySQL) and must not conflict with endpoint.port values.
   basePort: 6033
-  # -- ProxySQL upstream DB user (plain string). Mutually exclusive with usersSecretRef
+  # -- Single ProxySQL upstream DB user (plain string). Mutually exclusive with users/usersSecretRef.
   user: ""
-  # -- ProxySQL upstream DB password (plain string). Mutually exclusive with usersSecretRef
+  # -- Single ProxySQL upstream DB password (plain string). Mutually exclusive with users/usersSecretRef.
   password: ""
-  # -- Reference to existing secret containing username and password. Mutually exclusive with user/password.
-  # The secret must contain keys "PROXY_SQL_USERNAME" and "PROXY_SQL_PASSWORD".
+  # -- Multiple ProxySQL upstream DB users (inline list). Mutually exclusive with user/usersSecretRef.
+  # Example: [{username: "u1", password: "p1"}, {username: "u2", password: "p2"}]
+  users: []
+  # -- Reference to existing secret containing a users.json key with a JSON array of {username, password} objects.
+  # Mutually exclusive with user/users.
   usersSecretRef: ""
   resources:
     cpu: "500m"


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for configuring multiple upstream users for the ProxySQL sidecar via a new `proxySql.users` list. The chart now generates a `users.json` credential file consumed by a new `query-processor` init container to build the ProxySQL runtime configuration.

### Why
Required to support MySQL workloads that need more than one database credential for the ProxySQL connection pooler.

### Key changes
- `values.yaml`: Added `proxySql.users` parameter (inline list of `{username, password}` maps). Updated `user`, `password`, and `usersSecretRef` descriptions to clarify mutual exclusivity.
- `templates/proxysql-users-secret.yaml`: Changed generated secret to store a `users.json` key containing a JSON user array instead of separate `PROXY_SQL_USERNAME` and `PROXY_SQL_PASSWORD` keys.
- `templates/deployment.yaml`: Replaced shell-based env substitution in the `proxysql-init` container with a new `proxysql-users-init` init container running `query-processor init-proxysql-users`. Added `proxysql-users-secret-volume` to mount the credentials secret into the init container pipeline.
- `templates/proxysql-config.yaml`: Removed the static `mysql_users` configuration block; user definitions are now injected by the init container.
- `templates/_versions.tpl`: Bumped default Query Processor image to `v0.47.0`.
- `Chart.yaml`: Bumped chart version to `0.78.0`.

### Impact
- **Breaking change**: External secrets referenced by `proxySql.usersSecretRef` must now contain a `users.json` key with a JSON array of `{username, password}` objects. The previous `PROXY_SQL_USERNAME` and `PROXY_SQL_PASSWORD` keys are no longer supported. Migration requires re-creating or updating the referenced secret.
- Only one of `proxySql.user`/`proxySql.password`, `proxySql.users`, or `proxySql.usersSecretRef` can be configured at a time.