### PR TITLE
[castai-db-agent] bump db agent image version

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.21.1
+version: 0.22.0

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -1,6 +1,6 @@
 # castai-db-agent
 
-![Version: 0.21.1](https://img.shields.io/badge/Version-0.21.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI DB agent deployment.
 

--- a/charts/castai-db-agent/templates/_versions.tpl
+++ b/charts/castai-db-agent/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultDbAgentVersion" -}}v0.20.1{{- end -}}
+{{- define "defaultDbAgentVersion" -}}v0.21.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}


### PR DESCRIPTION
## What changed
Bumps the CAST AI DB agent Helm chart to `0.22.0` and updates the default DB agent application version to `v0.21.0`.

## Why
Delivers the latest patch release of the DB agent.

## Key changes
- **`charts/castai-db-agent/Chart.yaml`** — bumps chart version from `0.21.1` → `0.22.0`
- **`charts/castai-db-agent/templates/_versions.tpl`** — updates `defaultDbAgentVersion` from `v0.20.1` → `v0.21.0`
- **`charts/castai-db-agent/README.md`** — updates the version badge to `0.22.0`

---
### Kimchi Summary
### What changed
Bumps the default CAST AI DB agent image to `v0.21.0` and updates the Helm chart version to `0.22.0`.

### Why
To distribute the latest DB agent release.

### Key changes
- `charts/castai-db-agent/templates/_versions.tpl`: Updates `defaultDbAgentVersion` from `v0.20.1` to `v0.21.0`.
- `charts/castai-db-agent/Chart.yaml`: Increments chart version from `0.21.1` to `0.22.0`.
- `charts/castai-db-agent/README.md`: Updates the version badge to `0.22.0`.