### PR TITLE
[castai-umbrella] update castai-agent to v0.155.5

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.35.15
+version: 0.35.16
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.lock
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.149.0
+  version: 0.155.5
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
-  version: 0.91.0
+  version: 0.92.4
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 0.1.191
+  version: 1.0.23
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 0.0.110
+  version: 1.0.23
 - name: castai-evictor
   repository: https://castai.github.io/helm-charts
-  version: 0.35.3
+  version: 0.35.60
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.5.0
-digest: sha256:71d8f5b36aed8447a5388fea0183cd30d1e09bf920a5391cbda4095950d63266
-generated: "2026-03-20T13:36:48.382399+01:00"
+  version: 0.13.4
+digest: sha256:f2fe91c8b47e6d6a781e1ef60aff522ac50b2b1ce2cab1730018c20ecbe38493
+generated: "2026-05-26T10:18:26.11521+02:00"

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.4.0
 dependencies:
   - name: castai-agent
-    version: "0.153.2"
+    version: "0.155.5"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
   - name: castai-cluster-controller

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -8,12 +8,12 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
+| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.59 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.22 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.22 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.60 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler-openshift/Chart.lock
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.149.0
-digest: sha256:0ba723fc81072430c73cae62bb612decab0c228cf6d79fcac59cf0c996ba83ad
-generated: "2026-03-20T13:37:08.29046+01:00"
+  version: 0.155.5
+digest: sha256:6a8574d766afd76496760744e58277724520f16f8331985b4d1c12be1e7e5094
+generated: "2026-05-26T10:18:50.142342+02:00"

--- a/charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml
@@ -5,6 +5,6 @@ type: application
 version: 0.1.0
 dependencies:
   - name: castai-agent
-    version: "0.153.2"
+    version: "0.155.5"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled

--- a/charts/castai-umbrella/charts/autoscaler-openshift/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/README.md
@@ -8,7 +8,7 @@ Wrapper chart for CAST AI Autoscaler OpenShift profile.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
+| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/Chart.lock
+++ b/charts/castai-umbrella/charts/autoscaler/Chart.lock
@@ -1,36 +1,36 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.151.0
+  version: 0.155.5
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
-  version: 0.32.0
+  version: 0.35.2
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.0.148
+  version: 1.160.3
 - name: gpu-metrics-exporter
   repository: https://castai.github.io/helm-charts
   version: 0.1.29
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
-  version: 0.91.1
+  version: 0.92.4
 - name: castai-evictor
   repository: https://castai.github.io/helm-charts
-  version: 0.35.25
+  version: 0.35.60
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.9.0
+  version: 0.13.4
 - name: castai-pod-pinner
   repository: https://castai.github.io/helm-charts
-  version: 1.11.0
+  version: 1.12.3
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.82.1
+  version: 0.98.0
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 0.1.204
+  version: 1.0.23
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 0.0.125
-digest: sha256:c2d401e2a3ff788999a6f2a77ec9e7679b6e1aa0250744167d5db20aa3b9c7e0
-generated: "2026-04-14T15:30:51.043569+03:00"
+  version: 1.0.23
+digest: sha256:48603d6091667d6b583819682774da7b6b84a1ef82cd4cc92a89ff4b05e2e897
+generated: "2026-05-26T10:17:38.235267+02:00"

--- a/charts/castai-umbrella/charts/autoscaler/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 dependencies:
   # ── readonly components ───────────────────────────────────────────────────────
   - name: castai-agent
-    version: "0.153.2"
+    version: "0.155.5"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
     tags:

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -8,16 +8,16 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
+| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.59 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.2 |
-| https://castai.github.io/helm-charts | castai-live | 0.97.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.60 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.3 |
+| https://castai.github.io/helm-charts | castai-live | 0.98.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.3 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.22 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.22 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
 | https://castai.github.io/helm-charts | gpu-metrics-exporter | 0.1.29 |
 
 ## Values

--- a/charts/castai-umbrella/charts/kent/Chart.lock
+++ b/charts/castai-umbrella/charts/kent/Chart.lock
@@ -1,25 +1,25 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.153.2
+  version: 0.155.5
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
-  version: 0.92.3
+  version: 0.92.4
 - name: castai-kentroller
   repository: https://castai.github.io/helm-charts
-  version: 0.1.145
+  version: 0.1.147
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 1.0.20
+  version: 1.0.23
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 1.0.20
+  version: 1.0.23
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.97.0
+  version: 0.98.0
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.13.3
+  version: 0.13.4
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
   version: 0.35.2
@@ -28,9 +28,9 @@ dependencies:
   version: 3.13.0
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.160.1
+  version: 1.160.3
 - name: castai-chart-upgrader
   repository: https://castai.github.io/helm-charts
   version: 0.1.0
-digest: sha256:68231fd8ddda3081edcbd4b0ab97bad28fdf32fd21771e0780566b9b69e9f1ee
-generated: "2026-05-22T16:34:45.627609+03:00"
+digest: sha256:e1bd4d933c7f2c3623e8453e85d7cb94451ef2c5403874e59f46761d2fdde51a
+generated: "2026-05-26T10:19:02.531196+02:00"

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.12.0
 dependencies:
   - name: castai-agent
-    version: "0.153.2"
+    version: "0.155.5"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
   - name: castai-cluster-controller

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -8,16 +8,16 @@ Wrapper chart for CAST AI Kent profile.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.153.2 |
+| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.145 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.2 |
-| https://castai.github.io/helm-charts | castai-live | 0.97.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.3 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.147 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.3 |
+| https://castai.github.io/helm-charts | castai-live | 0.98.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.22 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.22 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values


### PR DESCRIPTION
Update castai-agent dependency to v0.155.5 in all castai-umbrella subcharts:
- autoscaler
- autoscaler-anywhere
- autoscaler-openshift
- kent

This also regenerates helm documentation and updates Chart.lock files.

---
### Kimchi Summary
### What changed
Bumps the `castai-agent` dependency to `0.155.5` and refreshes lock files across the `castai-umbrella` chart and its subcharts (`autoscaler`, `autoscaler-anywhere`, `autoscaler-openshift`, and `kent`).

### Key changes
- `charts/castai-umbrella/Chart.yaml`: Bump umbrella chart version from `0.35.15` to `0.35.16`.
- `charts/castai-umbrella/charts/autoscaler/Chart.yaml`, `charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml`, `charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml`, `charts/castai-umbrella/charts/kent/Chart.yaml`: Update `castai-agent` dependency version to `0.155.5`.
- `charts/castai-umbrella/charts/autoscaler/Chart.lock`, `charts/castai-umbrella/charts/autoscaler-anywhere/Chart.lock`, `charts/castai-umbrella/charts/autoscaler-openshift/Chart.lock`, `charts/castai-umbrella/charts/kent/Chart.lock`: Regenerate lock files, updating `castai-agent`, `castai-cluster-controller`, `castai-evictor`, `castai-kvisor`, `castai-live`, `castai-pod-mutator`, `castai-workload-autoscaler`, and other component versions.
- `charts/castai-umbrella/charts/autoscaler/README.md`, `charts/castai-umbrella/charts/autoscaler-anywhere/README.md`, `charts/castai-umbrella/charts/autoscaler-openshift/README.md`, `charts/castai-umbrella/charts/kent/README.md`: Update dependency version tables to reflect the resolved chart versions.