### PR TITLE
[castai-umbrella] add capability to select the name for apiKeySecretRef

### DIFF
--- a/charts/castai-umbrella/Chart.lock
+++ b/charts/castai-umbrella/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: kent
   repository: file://charts/kent
-  version: 0.12.0
+  version: 0.13.0
 - name: autoscaler-anywhere
   repository: file://charts/autoscaler-anywhere
-  version: 0.4.0
+  version: 0.5.0
 - name: autoscaler-openshift
   repository: file://charts/autoscaler-openshift
-  version: 0.1.0
+  version: 0.2.0
 - name: autoscaler
   repository: file://charts/autoscaler
-  version: 0.1.0
-digest: sha256:e4cc3e13c1a87fa0f0ad9c326d5e9fcd3b603cb43cf406bab261230c4e20af02
-generated: "2026-05-22T16:34:51.050149+03:00"
+  version: 0.2.0
+digest: sha256:8c91422331b7c29dba1f4b24c9171396d50e17340cade67bf714bb2237cd545e
+generated: "2026-05-26T13:52:54.446747+02:00"

--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.35.16
+version: 0.36.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/README.md
+++ b/charts/castai-umbrella/README.md
@@ -270,7 +270,7 @@ helm upgrade castai castai-helm/castai \
 | autoscaler | object | `{}` |  |
 | extraObjects | list | `[]` | List of extra Kubernetes objects to render with the chart. Useful for deploying supporting resources such as ExternalSecrets alongside the umbrella. Each item must be a valid Kubernetes manifest (apiVersion, kind, metadata, spec). |
 | global.castai.apiKey | string | `""` |  |
-| global.castai.apiKeySecretRef | string | `""` |  |
+| global.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
 | global.castai.apiURL | string | `"https://api.cast.ai"` |  |
 | global.castai.grpcURL | string | `"grpc.cast.ai:443"` |  |
 | global.castai.provider | string | `""` |  |

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: autoscaler-anywhere
 description: Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 type: application
-version: 0.4.0
+version: 0.5.0
 dependencies:
   - name: castai-agent
     version: "0.155.5"

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -1,6 +1,6 @@
 # autoscaler-anywhere
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 
@@ -19,26 +19,25 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| castai-agent.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-agent.apiKeySecretRef | string | `""` |  |
 | castai-agent.createNamespace | bool | `false` |  |
 | castai-agent.enabled | bool | `true` |  |
 | castai-agent.metadataStore.createConfigMap | bool | `true` |  |
 | castai-agent.provider | string | `"anywhere"` |  |
 | castai-agent.replicaCount | int | `2` |  |
 | castai-cluster-controller.autoscaling.enabled | bool | `true` |  |
-| castai-cluster-controller.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-cluster-controller.castai.apiKeySecretRef | string | `""` |  |
 | castai-cluster-controller.enableTopologySpreadConstraints | bool | `true` |  |
 | castai-cluster-controller.enabled | bool | `true` |  |
 | castai-cluster-controller.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
 | castai-evictor.aggressiveMode | bool | `false` |  |
 | castai-evictor.enabled | bool | `true` |  |
-| castai-evictor.envFrom[0].secretRef.name | string | `"castai-credentials"` |  |
-| castai-evictor.envFrom[1].configMapRef.name | string | `"castai-agent-metadata"` |  |
-| castai-evictor.overrideEnvFrom | bool | `true` |  |
+| castai-evictor.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
+| castai-evictor.overrideEnvFrom | bool | `false` |  |
 | castai-evictor.replicaCount | int | `0` |  |
-| castai-pod-mutator | object | `{"castai":{"apiKeySecretRef":"castai-credentials","configMapRef":"castai-agent-metadata"},"dependencyCheck":{"enabled":false},"enableTopologySpreadConstraints":true,"enabled":true,"envFrom":[{"configMapRef":{"name":"castai-agent-metadata"}}],"fullnameOverride":"castai-pod-mutator"}` | ------------------------------------------------------------------------- |
-| castai-workload-autoscaler | object | `{"castai":{"apiKeySecretRef":"castai-credentials","configMapRef":"castai-agent-metadata"},"enabled":true,"fullnameOverride":"castai-workload-autoscaler"}` | ------------------------------------------------------------------------- |
-| castai-workload-autoscaler-exporter.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-pod-mutator | object | `{"castai":{"apiKeySecretRef":"","configMapRef":"castai-agent-metadata"},"dependencyCheck":{"enabled":false},"enableTopologySpreadConstraints":true,"enabled":true,"envFrom":[{"configMapRef":{"name":"castai-agent-metadata"}}],"fullnameOverride":"castai-pod-mutator"}` | ------------------------------------------------------------------------- |
+| castai-workload-autoscaler | object | `{"castai":{"apiKeySecretRef":"","configMapRef":"castai-agent-metadata"},"enabled":true,"fullnameOverride":"castai-workload-autoscaler"}` | ------------------------------------------------------------------------- |
+| castai-workload-autoscaler-exporter.castai.apiKeySecretRef | string | `""` |  |
 | castai-workload-autoscaler-exporter.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-workload-autoscaler-exporter.enabled | bool | `true` |  |
 | castai-workload-autoscaler-exporter.fullnameOverride | string | `"castai-workload-autoscaler-exporter"` |  |

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/values.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/values.yaml
@@ -12,7 +12,7 @@ castai-agent:
   enabled: true
   replicaCount: 2
   provider: anywhere
-  apiKeySecretRef: castai-credentials
+  apiKeySecretRef: ""
   createNamespace: false
   metadataStore:
     createConfigMap: true
@@ -20,7 +20,7 @@ castai-agent:
 castai-cluster-controller:
   enabled: true
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
   envFrom:
     - configMapRef:
         name: castai-agent-metadata
@@ -36,24 +36,22 @@ castai-workload-autoscaler:
   enabled: true
   fullnameOverride: castai-workload-autoscaler
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
 
 castai-workload-autoscaler-exporter:
   enabled: true
   fullnameOverride: castai-workload-autoscaler-exporter
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
 
 castai-evictor:
   enabled: true
   replicaCount: 0
   aggressiveMode: false
-  overrideEnvFrom: true
+  overrideEnvFrom: false
   envFrom:
-    - secretRef:
-        name: castai-credentials
     - configMapRef:
         name: castai-agent-metadata
 
@@ -67,7 +65,7 @@ castai-pod-mutator:
   dependencyCheck:
     enabled: false
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
   enableTopologySpreadConstraints: true
   envFrom:

--- a/charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: autoscaler-openshift
 description: Wrapper chart for CAST AI Autoscaler OpenShift profile.
 type: application
-version: 0.1.0
+version: 0.2.0
 dependencies:
   - name: castai-agent
     version: "0.155.5"

--- a/charts/castai-umbrella/charts/autoscaler-openshift/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/README.md
@@ -1,6 +1,6 @@
 # autoscaler-openshift
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Autoscaler OpenShift profile.
 
@@ -14,7 +14,7 @@ Wrapper chart for CAST AI Autoscaler OpenShift profile.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| castai-agent.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-agent.apiKeySecretRef | string | `""` |  |
 | castai-agent.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | castai-agent.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | castai-agent.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/charts/castai-umbrella/charts/autoscaler-openshift/values.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/values.yaml
@@ -17,7 +17,7 @@ castai-agent:
   enabled: true
   replicaCount: 1
   provider: openshift
-  apiKeySecretRef: castai-credentials
+  apiKeySecretRef: ""
   createNamespace: false
   image:
     repository: us-docker.pkg.dev/castai-hub/library/agent-rh-ubi

--- a/charts/castai-umbrella/charts/autoscaler/Chart.lock
+++ b/charts/castai-umbrella/charts/autoscaler/Chart.lock
@@ -8,9 +8,6 @@ dependencies:
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
   version: 1.160.3
-- name: gpu-metrics-exporter
-  repository: https://castai.github.io/helm-charts
-  version: 0.1.29
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
   version: 0.92.4
@@ -22,7 +19,7 @@ dependencies:
   version: 0.13.4
 - name: castai-pod-pinner
   repository: https://castai.github.io/helm-charts
-  version: 1.12.3
+  version: 1.12.5
 - name: castai-live
   repository: https://castai.github.io/helm-charts
   version: 0.98.0
@@ -32,5 +29,5 @@ dependencies:
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
   version: 1.0.23
-digest: sha256:48603d6091667d6b583819682774da7b6b84a1ef82cd4cc92a89ff4b05e2e897
-generated: "2026-05-26T10:17:38.235267+02:00"
+digest: sha256:4e92ef750974f90b5f188f14946770f82ab4bedf2d9926755b6173cc1c185d86
+generated: "2026-05-26T15:09:37.329384+02:00"

--- a/charts/castai-umbrella/charts/autoscaler/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: autoscaler
 description: CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, full.
 type: application
-version: 0.1.0
+version: 0.2.0
 dependencies:
   # ── readonly components ───────────────────────────────────────────────────────
   - name: castai-agent
@@ -27,15 +27,6 @@ dependencies:
     version: "1.160.3"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-kvisor.enabled
-    tags:
-      - readonly
-      - node-autoscaler
-      - workload-autoscaler
-      - full
-  - name: gpu-metrics-exporter
-    version: "0.1.29"
-    repository: "https://castai.github.io/helm-charts"
-    condition: gpu-metrics-exporter.enabled
     tags:
       - readonly
       - node-autoscaler
@@ -68,7 +59,7 @@ dependencies:
       - full
   # ── node-autoscaler + full ────────────────────────────────────────────────────
   - name: castai-pod-pinner
-    version: "1.12.3"
+    version: "1.12.5"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-pod-pinner.enabled
     tags:

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -1,6 +1,6 @@
 # autoscaler
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, full.
 
@@ -14,59 +14,55 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 | https://castai.github.io/helm-charts | castai-kvisor | 1.160.3 |
 | https://castai.github.io/helm-charts | castai-live | 0.98.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
-| https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.3 |
+| https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
-| https://castai.github.io/helm-charts | gpu-metrics-exporter | 0.1.29 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| castai-agent.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-agent.apiKeySecretRef | string | `""` |  |
 | castai-agent.createNamespace | bool | `false` |  |
 | castai-agent.metadataStore.createConfigMap | bool | `true` |  |
 | castai-agent.replicaCount | int | `1` |  |
 | castai-cluster-controller.aks.enabled | bool | `false` |  |
 | castai-cluster-controller.autoscaling.enabled | bool | `true` |  |
-| castai-cluster-controller.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-cluster-controller.castai.apiKeySecretRef | string | `""` |  |
 | castai-cluster-controller.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
 | castai-evictor.aggressiveMode | bool | `false` |  |
-| castai-evictor.envFrom[0].secretRef.name | string | `"castai-credentials"` |  |
-| castai-evictor.envFrom[1].configMapRef.name | string | `"castai-agent-metadata"` |  |
-| castai-evictor.overrideEnvFrom | bool | `true` |  |
+| castai-evictor.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
+| castai-evictor.overrideEnvFrom | bool | `false` |  |
 | castai-evictor.replicaCount | int | `1` |  |
-| castai-kvisor.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-kvisor.agent.gpu.enabled | bool | `true` |  |
+| castai-kvisor.castai.apiKeySecretRef | string | `""` |  |
 | castai-kvisor.castai.clusterIdConfigMapKeyRef.key | string | `"CLUSTER_ID"` |  |
 | castai-kvisor.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-live.castai-aws-vpc-cni.enabled | bool | `false` |  |
-| castai-live.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-live.castai.apiKeySecretRef | string | `""` |  |
 | castai-live.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-live.controller.replicaCount | int | `2` |  |
 | castai-live.daemon.labelNodeSubnet | bool | `false` |  |
-| castai-pod-mutator.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-pod-mutator.castai.apiKeySecretRef | string | `""` |  |
 | castai-pod-mutator.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-pod-mutator.dependencyCheck.enabled | bool | `false` |  |
 | castai-pod-mutator.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
 | castai-pod-mutator.fullnameOverride | string | `"castai-pod-mutator"` |  |
-| castai-pod-pinner.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-pod-pinner.castai.apiKeySecretRef | string | `""` |  |
 | castai-pod-pinner.castai.clusterIdConfigMapKeyRef.key | string | `"CLUSTER_ID"` |  |
 | castai-pod-pinner.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-pod-pinner.replicaCount | int | `0` |  |
-| castai-spot-handler.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-spot-handler.apiKeySecretRef | string | `""` |  |
 | castai-spot-handler.castai.clusterIdConfigMapKeyRef.key | string | `"CLUSTER_ID"` |  |
 | castai-spot-handler.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-spot-handler.castai.provider | string | `""` |  |
-| castai-workload-autoscaler-exporter.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-workload-autoscaler-exporter.castai.apiKeySecretRef | string | `""` |  |
 | castai-workload-autoscaler-exporter.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-workload-autoscaler-exporter.fullnameOverride | string | `"castai-workload-autoscaler-exporter"` |  |
-| castai-workload-autoscaler.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-workload-autoscaler.castai.apiKeySecretRef | string | `""` |  |
 | castai-workload-autoscaler.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-workload-autoscaler.fullnameOverride | string | `"castai-workload-autoscaler"` |  |
-| gpu-metrics-exporter.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
-| gpu-metrics-exporter.castai.clusterIdConfigMapKeyRef.key | string | `"CLUSTER_ID"` |  |
-| gpu-metrics-exporter.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/castai-umbrella/charts/autoscaler/values.yaml
+++ b/charts/castai-umbrella/charts/autoscaler/values.yaml
@@ -26,7 +26,7 @@
 
 castai-agent:
   replicaCount: 1
-  apiKeySecretRef: castai-credentials
+  apiKeySecretRef: ""
   createNamespace: false
   metadataStore:
     createConfigMap: true
@@ -37,25 +37,21 @@ castai-spot-handler:
     clusterIdConfigMapKeyRef:
       name: castai-agent-metadata
       key: CLUSTER_ID
-  apiKeySecretRef: castai-credentials
+  apiKeySecretRef: ""
 
 castai-kvisor:
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     clusterIdConfigMapKeyRef:
       name: castai-agent-metadata
       key: CLUSTER_ID
-
-gpu-metrics-exporter:
-  castai:
-    apiKeySecretRef: castai-credentials
-    clusterIdConfigMapKeyRef:
-      name: castai-agent-metadata
-      key: CLUSTER_ID
+  agent:
+    gpu:
+      enabled: true
 
 castai-cluster-controller:
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
   envFrom:
     - configMapRef:
         name: castai-agent-metadata
@@ -67,10 +63,8 @@ castai-cluster-controller:
 castai-evictor:
   replicaCount: 1
   aggressiveMode: false
-  overrideEnvFrom: true
+  overrideEnvFrom: false
   envFrom:
-    - secretRef:
-        name: castai-credentials
     - configMapRef:
         name: castai-agent-metadata
 
@@ -79,7 +73,7 @@ castai-pod-mutator:
   dependencyCheck:
     enabled: false
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
   envFrom:
     - configMapRef:
@@ -87,7 +81,7 @@ castai-pod-mutator:
 
 castai-pod-pinner:
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     clusterIdConfigMapKeyRef:
       name: castai-agent-metadata
       key: CLUSTER_ID
@@ -95,7 +89,7 @@ castai-pod-pinner:
 
 castai-live:
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
   castai-aws-vpc-cni:
     enabled: false
@@ -107,11 +101,11 @@ castai-live:
 castai-workload-autoscaler:
   fullnameOverride: castai-workload-autoscaler
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
 
 castai-workload-autoscaler-exporter:
   fullnameOverride: castai-workload-autoscaler-exporter
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kent
 description: Wrapper chart for CAST AI Kent profile.
 type: application
-version: 0.12.0
+version: 0.13.0
 dependencies:
   - name: castai-agent
     version: "0.155.5"

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -1,6 +1,6 @@
 # kent
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Kent profile.
 
@@ -24,7 +24,7 @@ Wrapper chart for CAST AI Kent profile.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| castai-agent.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-agent.apiKeySecretRef | string | `""` |  |
 | castai-agent.createNamespace | bool | `false` |  |
 | castai-agent.enabled | bool | `true` |  |
 | castai-agent.metadataStore.createConfigMap | bool | `true` |  |
@@ -34,14 +34,14 @@ Wrapper chart for CAST AI Kent profile.
 | castai-chart-upgrader.chart.repository | string | `"https://castai.github.io/helm-charts"` |  |
 | castai-chart-upgrader.enabled | bool | `false` |  |
 | castai-cluster-controller.autoscaling.enabled | bool | `false` |  |
-| castai-cluster-controller.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-cluster-controller.castai.apiKeySecretRef | string | `""` |  |
 | castai-cluster-controller.enabled | bool | `true` |  |
 | castai-cluster-controller.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
-| castai-kentroller.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-kentroller.castai.apiKeySecretRef | string | `""` |  |
 | castai-kentroller.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-kentroller.enabled | bool | `true` |  |
 | castai-kvisor.agent.enabled | bool | `false` |  |
-| castai-kvisor.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-kvisor.castai.apiKeySecretRef | string | `""` |  |
 | castai-kvisor.castai.clusterIdConfigMapKeyRef.key | string | `"CLUSTER_ID"` |  |
 | castai-kvisor.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-kvisor.controller.enabled | bool | `true` |  |
@@ -49,25 +49,25 @@ Wrapper chart for CAST AI Kent profile.
 | castai-kvisor.controller.extraArgs.log-level | string | `"info"` |  |
 | castai-kvisor.enabled | bool | `true` |  |
 | castai-live.castai-aws-vpc-cni.enabled | bool | `true` |  |
-| castai-live.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-live.castai.apiKeySecretRef | string | `""` |  |
 | castai-live.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-live.controller.replicaCount | int | `0` |  |
 | castai-live.daemon.labelNodeSubnet | bool | `true` |  |
 | castai-live.enabled | bool | `true` |  |
-| castai-pod-mutator.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-pod-mutator.castai.apiKeySecretRef | string | `""` |  |
 | castai-pod-mutator.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-pod-mutator.dependencyCheck.enabled | bool | `false` |  |
 | castai-pod-mutator.enabled | bool | `true` |  |
 | castai-pod-mutator.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
-| castai-spot-handler.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-spot-handler.apiKeySecretRef | string | `""` |  |
 | castai-spot-handler.castai.clusterIdConfigMapKeyRef.key | string | `"CLUSTER_ID"` |  |
 | castai-spot-handler.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-spot-handler.castai.provider | string | `"eks"` |  |
 | castai-spot-handler.enabled | bool | `true` |  |
-| castai-workload-autoscaler-exporter.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-workload-autoscaler-exporter.castai.apiKeySecretRef | string | `""` |  |
 | castai-workload-autoscaler-exporter.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-workload-autoscaler-exporter.enabled | bool | `true` |  |
-| castai-workload-autoscaler.castai.apiKeySecretRef | string | `"castai-credentials"` |  |
+| castai-workload-autoscaler.castai.apiKeySecretRef | string | `""` |  |
 | castai-workload-autoscaler.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-workload-autoscaler.enabled | bool | `true` |  |
 | metrics-server.enabled | bool | `false` |  |

--- a/charts/castai-umbrella/charts/kent/values.yaml
+++ b/charts/castai-umbrella/charts/kent/values.yaml
@@ -1,7 +1,7 @@
 castai-agent:
   enabled: true
   replicaCount: 1
-  apiKeySecretRef: castai-credentials
+  apiKeySecretRef: ""
   # Currently only EKS is supported
   provider: eks
   # executed for helm to create the namespace `helm --create-namespace`
@@ -12,7 +12,7 @@ castai-agent:
 castai-cluster-controller:
   enabled: true
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
   envFrom:
     - configMapRef:
         name: castai-agent-metadata
@@ -22,27 +22,27 @@ castai-cluster-controller:
 castai-kentroller:
   enabled: true
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     clusterIdConfigMapKeyRef:
       name: castai-agent-metadata
 
 castai-workload-autoscaler:
   enabled: true
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
 
 castai-workload-autoscaler-exporter:
   enabled: true
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
 
 # controller.replicaCount: 0 = CLM disabled, 2 = CLM enabled.
 castai-live:
   enabled: true
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
   castai-aws-vpc-cni:
     enabled: true
@@ -56,7 +56,7 @@ castai-pod-mutator:
   dependencyCheck:
     enabled: false
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
   envFrom:
     - configMapRef:
@@ -64,7 +64,7 @@ castai-pod-mutator:
 
 castai-spot-handler:
   enabled: true
-  apiKeySecretRef: castai-credentials
+  apiKeySecretRef: ""
   castai:
     provider: eks
     clusterIdConfigMapKeyRef:
@@ -79,7 +79,7 @@ metrics-server:
 castai-kvisor:
   enabled: true
   castai:
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: ""
     clusterIdConfigMapKeyRef:
       name: castai-agent-metadata
       key: CLUSTER_ID

--- a/charts/castai-umbrella/templates/validate-values.yaml
+++ b/charts/castai-umbrella/templates/validate-values.yaml
@@ -13,10 +13,12 @@
 
 {{/* ── Required values when a mode tag is set ─────────────────────────────── */}}
 {{- if $enabledTags }}
-{{- if and (not .Values.global.castai.apiKey) (not .Values.global.castai.apiKeySecretRef) }}
+{{- $hasApiKey := .Values.global.castai.apiKey }}
+{{- $hasCustomSecretRef := and .Values.global.castai.apiKeySecretRef (ne .Values.global.castai.apiKeySecretRef "castai-credentials") }}
+{{- if and (not $hasApiKey) (not $hasCustomSecretRef) }}
 {{ fail "Either global.castai.apiKey or global.castai.apiKeySecretRef is required when enabling a mode tag" }}
 {{- end }}
-{{- if and .Values.global.castai.apiKey .Values.global.castai.apiKeySecretRef }}
+{{- if and $hasApiKey $hasCustomSecretRef }}
 {{ fail "global.castai.apiKey and global.castai.apiKeySecretRef are mutually exclusive" }}
 {{- end }}
 {{- $modeTag := index $enabledTags 0 }}

--- a/charts/castai-umbrella/values.yaml
+++ b/charts/castai-umbrella/values.yaml
@@ -3,7 +3,9 @@ global:
     apiKey: ""
     # apiKeySecretRef -- Name of a pre-existing Secret containing the CAST AI API key.
     # The secret must have a key named API_KEY. Mutually exclusive with apiKey.
-    apiKeySecretRef: ""
+    # Defaults to "castai-credentials" — the secret created by this chart when apiKey is set.
+    # Set to a custom name to use a pre-existing secret instead of providing apiKey.
+    apiKeySecretRef: "castai-credentials"
     apiURL: "https://api.cast.ai"
     grpcURL: "grpc.cast.ai:443"
     # provider -- Kubernetes service provider: eks, aks, gke, kops, anywhere.

--- a/test/e2e/umbrella_test.go
+++ b/test/e2e/umbrella_test.go
@@ -252,12 +252,6 @@ var _ = Describe("castai-umbrella helm chart", Ordered, func() {
 			podHelper.VerifyDeploymentAbsent(Default, "castai-kentroller")
 		})
 
-		It("should create the gpu-metrics-exporter daemonset (enabled by default)", func() {
-			Eventually(func(g Gomega) {
-				podHelper.VerifyDaemonSetExists(g, releaseName+"-gpu-metrics-exporter")
-			}, 2*time.Minute, 5*time.Second).Should(Succeed())
-		})
-
 		It("should have autoscaler config in release values", func() {
 			values, err := helmHelper.GetReleaseValues()
 			Expect(err).NotTo(HaveOccurred())
@@ -358,12 +352,6 @@ var _ = Describe("castai-umbrella helm chart", Ordered, func() {
 		It("should create the kvisor-controller deployment", func() {
 			Eventually(func(g Gomega) {
 				podHelper.VerifyDeploymentExists(g, releaseName+"-castai-kvisor-controller")
-			}, 2*time.Minute, 5*time.Second).Should(Succeed())
-		})
-
-		It("should create the gpu-metrics-exporter daemonset", func() {
-			Eventually(func(g Gomega) {
-				podHelper.VerifyDaemonSetExists(g, releaseName+"-gpu-metrics-exporter")
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
@@ -649,9 +637,6 @@ var _ = Describe("castai-umbrella helm chart", Ordered, func() {
 		It("should create readonly-only components", func() {
 			Eventually(func(g Gomega) {
 				podHelper.VerifyDeploymentExists(g, "castai-agent")
-			}, 2*time.Minute, 5*time.Second).Should(Succeed())
-			Eventually(func(g Gomega) {
-				podHelper.VerifyDaemonSetExists(g, releaseName+"-gpu-metrics-exporter")
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 		})
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for bringing a custom Kubernetes secret for the CAST AI API key via `global.castai.apiKeySecretRef` in the umbrella chart. Removes the `gpu-metrics-exporter` subchart from the `autoscaler` profile and centralizes all subchart API key secret references to inherit from the global configuration.

### Why
Allows users to manage the CAST AI API key outside of Helm values— for example, with an external secrets operator—without hardcoding secret names in individual subcharts.

### Key changes
- `charts/castai-umbrella/values.yaml`: Changed default of `global.castai.apiKeySecretRef` from `""` to `"castai-credentials"` and added documentation comments.
- `charts/castai-umbrella/templates/validate-values.yaml`: Updated validation to require either `global.castai.apiKey` (which creates the default secret) or a *custom* `global.castai.apiKeySecretRef` when a mode tag is enabled.
- `charts/castai-umbrella/charts/autoscaler/Chart.yaml` & `Chart.lock`: Removed the `gpu-metrics-exporter` dependency; bumped `castai-pod-pinner` to `1.12.5`.
- `charts/castai-umbrella/charts/autoscaler/values.yaml`: Cleared hardcoded `apiKeySecretRef` defaults for all components; enabled `castai-kvisor.agent.gpu.enabled`; removed `gpu-metrics-exporter` configuration.
- `charts/castai-umbrella/charts/autoscaler-anywhere/values.yaml` & `autoscaler/values.yaml`: Removed the `secretRef` mount from `castai-evictor.envFrom` and set `castai-evictor.overrideEnvFrom` to `false`.
- `charts/castai-umbrella/charts/autoscaler-anywhere`, `autoscaler-openshift`, `kent`: Bumped chart versions and reset local `apiKeySecretRef` defaults to `""` so they defer to the umbrella global value.
- `test/e2e/umbrella_test.go`: Removed e2e assertions expecting the `gpu-metrics-exporter` DaemonSet.

### Impact
- **Breaking**: The `autoscaler` profile no longer installs `gpu-metrics-exporter`; GPU metrics collection is now handled by `castai-kvisor`. If you rely on the standalone exporter, you must install it separately.
- Subcharts that previously hardcoded `castai-credentials` for `apiKeySecretRef` now inherit the global umbrella value. Ensure that either `global.castai.apiKey` or a custom `global.castai.apiKeySecretRef` is configured.