### PR TITLE
[castai-db-optimizer] update query-processor image

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.78.0
+version: 0.79.0

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.78.0](https://img.shields.io/badge/Version-0.78.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.79.0](https://img.shields.io/badge/Version-0.79.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,5 +1,5 @@
 {{- define "defaultProxyVersion" -}}v4.84.1{{- end -}}
-{{- define "defaultQueryProcessorVersion" -}}v0.47.0{{- end -}}
+{{- define "defaultQueryProcessorVersion" -}}v0.48.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
 {{- define "defaultPgdogVersion" -}}v0.1.30{{- end -}}
 {{- define "defaultProxySqlVersion" -}}3.0.6{{- end -}}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Update the default Query Processor image to `v0.48.0` and bump the `castai-db-optimizer` Helm chart version to `0.79.0`.

### Key changes
- `charts/castai-db-optimizer/templates/_versions.tpl`: Updated `defaultQueryProcessorVersion` from `v0.47.0` to `v0.48.0`.
- `charts/castai-db-optimizer/Chart.yaml`: Bumped chart version from `0.78.0` to `0.79.0`.
- `charts/castai-db-optimizer/README.md`: Updated the version badge to `0.79.0`.