### PR TITLE
[castai-db-optimizer] update proxy image

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.79.0
+version: 0.79.1

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.79.0](https://img.shields.io/badge/Version-0.79.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.79.1](https://img.shields.io/badge/Version-0.79.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,4 +1,4 @@
-{{- define "defaultProxyVersion" -}}v4.84.1{{- end -}}
+{{- define "defaultProxyVersion" -}}v4.84.2{{- end -}}
 {{- define "defaultQueryProcessorVersion" -}}v0.48.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
 {{- define "defaultPgdogVersion" -}}v0.1.30{{- end -}}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the `castai-db-optimizer` Helm chart to `0.79.1` and updates the default proxy image version to `v4.84.2`.

### Why
Pulls in the latest proxy patch release to include recent bug fixes.

### Key changes
- `Chart.yaml`: Bumps chart version from `0.79.0` to `0.79.1`.
- `README.md`: Updates the version badge to `0.79.1`.
- `templates/_versions.tpl`: Updates `defaultProxyVersion` from `v4.84.1` to `v4.84.2`.