### PR TITLE
[castai-evictor] Use castai forked cluster-proportional VPA

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.64
+version: 0.35.65
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -22,7 +22,7 @@ Cluster utilization defragmentation tool
 | clusterIdConfigMapKeyRef.name | string | `""` | name and of the config map with cluster id |
 | clusterIdSecretKeyRef.key | string | `"CLUSTER_ID"` |  |
 | clusterIdSecretKeyRef.name | string | `""` |  |
-| clusterVPA | object | `{"enabled":true,"pollPeriodSeconds":300,"repository":"registry.k8s.io/cpa/cpvpa","resources":{},"version":"v0.8.4"}` | Cluster proportional vertical autoscaler for the evictor deployment https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler. |
+| clusterVPA | object | `{"enabled":true,"pollPeriodSeconds":300,"repository":"registry.k8s.io/cpa/cpvpa","resources":{},"version":"v0.8.11"}` | Cluster proportional vertical autoscaler for the evictor deployment https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler. |
 | commonAnnotations | object | `{}` |  |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | configMapLabels | object | `{}` |  |

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -22,7 +22,7 @@ Cluster utilization defragmentation tool
 | clusterIdConfigMapKeyRef.name | string | `""` | name and of the config map with cluster id |
 | clusterIdSecretKeyRef.key | string | `"CLUSTER_ID"` |  |
 | clusterIdSecretKeyRef.name | string | `""` |  |
-| clusterVPA | object | `{"enabled":true,"pollPeriodSeconds":300,"repository":"registry.k8s.io/cpa/cpvpa","resources":{},"version":"v0.8.11"}` | Cluster proportional vertical autoscaler for the evictor deployment https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler. |
+| clusterVPA | object | `{"enabled":true,"pollPeriodSeconds":300,"repository":"us-docker.pkg.dev/castai-hub/library/cpa/cpvpa","resources":{},"version":"v0.8.11"}` | Cluster proportional vertical autoscaler for the evictor deployment https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler. |
 | commonAnnotations | object | `{}` |  |
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | configMapLabels | object | `{}` |  |

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -214,9 +214,9 @@ apiKeySecretRef: ""
 # clusterVPA -- Cluster proportional vertical autoscaler for the evictor deployment
 # https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler.
 clusterVPA:
-  repository: "registry.k8s.io/cpa/cpvpa"
+  repository: "us-docker.pkg.dev/castai-hub/library/cpa/cpvpa"
   enabled: true
-  version: v0.8.4
+  version: v0.8.11
   pollPeriodSeconds: 300
   resources: {}
   # configOverride -- Override the default ClusterVPA calculation configuration.


### PR DESCRIPTION
Forked image is built with golang 1.26.3 from [v0.8.11](https://github.com/castai/cluster-proportional-vertical-autoscaler/tree/v0.8.11) mitigating a bunch of vulnerabilities
Trivy Report Summary
```
┌──────────────────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                                Target                                │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ us-docker.pkg.dev/castai-hub/library/cpa/cpvpa:v0.8.11 (debian 13.5) │  debian  │        0        │    -    │
├──────────────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ cpvpa                                                                │ gobinary │        0        │    -    │
└──────────────────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
```

---
### Kimchi Summary
### What changed
Switches the `castai-evictor` chart to use the CAST AI fork of the cluster-proportional-vertical-autoscaler image and bumps the chart patch version.

### Why
To adopt the CAST AI maintained `cpvpa` image for improved supply chain control and to consume a newer patched version.

### Key changes
- `charts/castai-evictor/values.yaml`: Updated `clusterVPA.repository` to `us-docker.pkg.dev/castai-hub/library/cpa/cpvpa` and `clusterVPA.version` from `v0.8.4` to `v0.8.11`.
- `charts/castai-evictor/README.md`: Synced the documented default values for `clusterVPA` to reflect the new repository and version.
- `charts/castai-evictor/Chart.yaml`: Bumped chart version from `0.35.64` to `0.35.65`.

### Impact
Clusters with `clusterVPA.enabled` will now pull the `cpvpa` image from the CAST AI artifact registry instead of `registry.k8s.io`.