### PR TITLE
[castai-db-proxy] Added fallback endpoints

### DIFF
--- a/charts/castai-db-proxy/README.md
+++ b/charts/castai-db-proxy/README.md
@@ -18,6 +18,7 @@ CAST AI database proxy cache deployment.
 | commonLabels | object | `{}` | Labels to add to all resources. |
 | dnsConfig | object | `{}` | Pod DNS configuration. |
 | dnsPolicy | string | `""` | Pod DNS policy. |
+| endpoints | list | `[]` | Upstream database endpoints. Each entry needs `address` (host:port) and `readonly` (bool). |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/castai-hub/library/db-proxy"` |  |
 | image.tag | string | `""` | Overrides the image tag. Defaults to Chart.appVersion. |

--- a/charts/castai-db-proxy/ci/test-values.yaml
+++ b/charts/castai-db-proxy/ci/test-values.yaml
@@ -2,6 +2,10 @@ organizationID: "123"
 proxyID: "proxy-20"
 apiKey: "456"
 
+endpoints:
+  - address: "db-primary:1521"
+    readonly: false
+
 podLabels:
   podLabel: label
 

--- a/charts/castai-db-proxy/templates/configmap.yaml
+++ b/charts/castai-db-proxy/templates/configmap.yaml
@@ -13,6 +13,13 @@ data:
     ro_listen_port = {{ .Values.ports.readOnly }}
     metrics_port = {{ .Values.ports.metrics }}
 
+    {{- if not .Values.endpoints }}{{ fail "endpoints must contain at least one endpoint" }}{{ end }}
+    {{- range .Values.endpoints }}
+    [[fallback_endpoints]]
+    address = {{ .address | quote }}
+    readonly = {{ .readonly }}
+    {{- end }}
+
     [api]
     url = {{ printf "https://%s" (required "apiURL must be provided" .Values.apiURL) | quote }}
     organization_id = {{ required "organizationID must be provided" .Values.organizationID | quote }}

--- a/charts/castai-db-proxy/values.yaml
+++ b/charts/castai-db-proxy/values.yaml
@@ -27,6 +27,9 @@ proxyID: ""
 # protocol -- Database protocol.
 protocol: "Oracle"
 
+# endpoints -- Upstream database endpoints. Each entry needs `address` (host:port) and `readonly` (bool).
+endpoints: []
+
 ports:
   # -- Listening port for read-write connections.
   readWrite: 6141


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for configuring upstream database fallback endpoints in the `castai-db-proxy` Helm chart. The proxy now accepts a list of endpoints that define the upstream database address and read-only mode.

### Why
Enables the database proxy to discover and connect to upstream database instances when operating as a caching layer.

### Key changes
- `values.yaml`: Added new `endpoints` list parameter; each entry requires `address` (`host:port`) and `readonly` (bool).
- `templates/configmap.yaml`: Renders `[[fallback_endpoints]]` stanzas from `.Values.endpoints` and enforces that at least one endpoint is provided.
- `README.md`: Documented the new `endpoints` value.
- `ci/test-values.yaml`: Added sample endpoint configuration for CI testing.

### Impact
**Breaking change**: `.Values.endpoints` is now required. Helm installs or upgrades will fail template rendering unless `endpoints` contains at least one entry.