### PR TITLE
[castai-db-optimizer] trigger db-optimizer proxy release

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.79.1
+version: 0.79.2

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.79.1](https://img.shields.io/badge/Version-0.79.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.79.2](https://img.shields.io/badge/Version-0.79.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumped the `castai-db-optimizer` Helm chart version from `0.79.1` to `0.79.2`.

### Key changes
- `charts/castai-db-optimizer/Chart.yaml`: bumped `version` from `0.79.1` to `0.79.2`
- `charts/castai-db-optimizer/README.md`: updated the version badge to `0.79.2`