### PR TITLE
[castai-umbrella] bump castai-agent to v.0.157.0

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.36.23
+version: 0.36.24
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.lock
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.155.5
+  version: 0.157.0
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
   version: 0.92.4
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 1.0.23
+  version: 1.1.1
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 1.0.23
+  version: 1.1.1
 - name: castai-evictor
   repository: https://castai.github.io/helm-charts
-  version: 0.35.60
+  version: 0.35.67
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.13.4
-digest: sha256:f2fe91c8b47e6d6a781e1ef60aff522ac50b2b1ce2cab1730018c20ecbe38493
-generated: "2026-05-26T10:18:26.11521+02:00"
+  version: 0.13.5
+digest: sha256:f5504c59ab0ef5b5bfd88fc4bb8e718a48e41c4387923552c6a0976b3d36f0f5
+generated: "2026-06-02T17:18:04.465331+02:00"

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.5.0
 dependencies:
   - name: castai-agent
-    version: "0.155.5"
+    version: "0.157.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
   - name: castai-cluster-controller

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -8,12 +8,12 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
+| https://castai.github.io/helm-charts | castai-agent | 0.157.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.60 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.67 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.5 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.1.1 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.1.1 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler-openshift/Chart.lock
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.155.5
-digest: sha256:6a8574d766afd76496760744e58277724520f16f8331985b4d1c12be1e7e5094
-generated: "2026-05-26T10:18:50.142342+02:00"
+  version: 0.157.0
+digest: sha256:4327eb8440a2dfeeedf46959b33d6898fd4cd58d51c20b9bd6dc6e33e8bda9d6
+generated: "2026-06-02T17:18:24.101214+02:00"

--- a/charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml
@@ -5,6 +5,6 @@ type: application
 version: 0.2.0
 dependencies:
   - name: castai-agent
-    version: "0.155.5"
+    version: "0.157.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled

--- a/charts/castai-umbrella/charts/autoscaler-openshift/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/README.md
@@ -8,7 +8,7 @@ Wrapper chart for CAST AI Autoscaler OpenShift profile.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
+| https://castai.github.io/helm-charts | castai-agent | 0.157.0 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/Chart.lock
+++ b/charts/castai-umbrella/charts/autoscaler/Chart.lock
@@ -1,33 +1,33 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.155.5
+  version: 0.157.0
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
   version: 0.35.2
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.160.3
+  version: 1.160.6
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
   version: 0.92.4
 - name: castai-evictor
   repository: https://castai.github.io/helm-charts
-  version: 0.35.60
+  version: 0.35.67
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.13.4
+  version: 0.13.5
 - name: castai-pod-pinner
   repository: https://castai.github.io/helm-charts
   version: 1.12.5
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.98.0
+  version: 0.100.0
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 1.0.23
+  version: 1.1.1
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 1.0.23
-digest: sha256:4e92ef750974f90b5f188f14946770f82ab4bedf2d9926755b6173cc1c185d86
-generated: "2026-05-26T15:09:37.329384+02:00"
+  version: 1.1.1
+digest: sha256:23db346e793e27724c8fdee674d316d6cb7087485ce9d8dd82e6a0496b0a1343
+generated: "2026-06-02T17:18:31.735537+02:00"

--- a/charts/castai-umbrella/charts/autoscaler/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 dependencies:
   # ── readonly components ───────────────────────────────────────────────────────
   - name: castai-agent
-    version: "0.155.5"
+    version: "0.157.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
     tags:

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -8,16 +8,16 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
+| https://castai.github.io/helm-charts | castai-agent | 0.157.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.60 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.3 |
-| https://castai.github.io/helm-charts | castai-live | 0.98.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.67 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.6 |
+| https://castai.github.io/helm-charts | castai-live | 0.100.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.5 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.1.1 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.1.1 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/kent/Chart.lock
+++ b/charts/castai-umbrella/charts/kent/Chart.lock
@@ -1,25 +1,25 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.155.5
+  version: 0.157.0
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
   version: 0.92.4
 - name: castai-kentroller
   repository: https://castai.github.io/helm-charts
-  version: 0.1.147
+  version: 0.1.149
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 1.0.23
+  version: 1.1.1
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 1.0.23
+  version: 1.1.1
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.98.0
+  version: 0.100.0
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.13.4
+  version: 0.13.5
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
   version: 0.35.2
@@ -28,9 +28,9 @@ dependencies:
   version: 3.13.0
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.160.3
+  version: 1.160.6
 - name: castai-chart-upgrader
   repository: https://castai.github.io/helm-charts
   version: 0.1.0
-digest: sha256:e1bd4d933c7f2c3623e8453e85d7cb94451ef2c5403874e59f46761d2fdde51a
-generated: "2026-05-26T10:19:02.531196+02:00"
+digest: sha256:2653e065840939e655bdd2b828026b925c0bf0a33bdaef848fa88bbf1c257906
+generated: "2026-06-02T17:17:28.814623+02:00"

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.13.0
 dependencies:
   - name: castai-agent
-    version: "0.155.5"
+    version: "0.157.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
   - name: castai-cluster-controller

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -8,16 +8,16 @@ Wrapper chart for CAST AI Kent profile.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
+| https://castai.github.io/helm-charts | castai-agent | 0.157.0 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.147 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.3 |
-| https://castai.github.io/helm-charts | castai-live | 0.98.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.149 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.6 |
+| https://castai.github.io/helm-charts | castai-live | 0.100.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.5 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.1.1 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.1.1 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the CAST AI umbrella chart version and updates dependency versions across all profile sub-charts (`autoscaler`, `autoscaler-anywhere`, `autoscaler-openshift`, `kent`) to their latest releases.

### Key changes
- `charts/castai-umbrella/Chart.yaml`: bumped umbrella chart version to `0.36.24`.
- `castai-agent`: bumped to `0.157.0` in `autoscaler`, `autoscaler-anywhere`, `autoscaler-openshift`, and `kent` profiles.
- `castai-workload-autoscaler` and `castai-workload-autoscaler-exporter`: bumped to `1.1.1` in `autoscaler`, `autoscaler-anywhere`, and `kent`.
- `castai-evictor`: bumped to `0.35.67` in `autoscaler` and `autoscaler-anywhere`.
- `castai-pod-mutator`: bumped to `0.13.5` in `autoscaler`, `autoscaler-anywhere`, and `kent`.
- `castai-kvisor`: bumped to `1.160.6` in `autoscaler` and `kent`.
- `castai-live`: bumped to `0.100.0` in `autoscaler` and `kent`.
- `castai-kentroller`: bumped to `0.1.149` in the `kent` profile.
- Regenerated `Chart.lock` digests and updated README dependency tables for all affected profiles.