### PR TITLE
[castai-chart-upgrader] Preserve RBAC for upgrader job

### DIFF
--- a/charts/castai-chart-upgrader/Chart.yaml
+++ b/charts/castai-chart-upgrader/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-chart-upgrader
 description: Auto-updates charts via CronJob
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/charts/castai-chart-upgrader/README.md
+++ b/charts/castai-chart-upgrader/README.md
@@ -1,6 +1,6 @@
 # castai-chart-upgrader
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Auto-updates charts via CronJob
 

--- a/charts/castai-chart-upgrader/templates/rbac.yaml
+++ b/charts/castai-chart-upgrader/templates/rbac.yaml
@@ -5,6 +5,8 @@ kind: ServiceAccount
 metadata:
   name: {{ include "chart-upgrader.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     {{- include "chart-upgrader.labels" . | nindent 4 }}
 {{- end }}
@@ -18,6 +20,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "chart-upgrader.serviceAccountName" . }}
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     {{- include "chart-upgrader.labels" . | nindent 4 }}
 rules:
@@ -29,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "chart-upgrader.serviceAccountName" . }}
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     {{- include "chart-upgrader.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds the `helm.sh/resource-policy: keep` annotation to the RBAC resources in the `castai-chart-upgrader` Helm chart so they are retained during Helm uninstalls and upgrades. Bumps the chart version to `0.1.1`.

### Why
Prevents the updater job's `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` from being deleted, ensuring required permissions remain available if the job executes during a chart uninstall or upgrade.

### Key changes
- `charts/castai-chart-upgrader/templates/rbac.yaml`: Added `helm.sh/resource-policy: keep` annotation to the `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding`.
- `charts/castai-chart-upgrader/Chart.yaml`: Bumped chart version from `0.1.0` to `0.1.1`.
- `charts/castai-chart-upgrader/README.md`: Updated version badge to `0.1.1`.

### Impact
RBAC resources will now persist in the cluster after `helm uninstall`; manual cleanup is required if complete removal is desired.