### PR TITLE
[castai-umbrella] Update castai-agent to 0.158.0

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.36.43
+version: 0.36.44
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.5.0
 dependencies:
   - name: castai-agent
-    version: "0.155.5"
+    version: "0.158.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
   - name: castai-cluster-controller

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -8,12 +8,12 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
+| https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.60 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.76 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.1 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.1 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/Chart.yaml
@@ -5,6 +5,6 @@ type: application
 version: 0.2.0
 dependencies:
   - name: castai-agent
-    version: "0.155.5"
+    version: "0.158.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled

--- a/charts/castai-umbrella/charts/autoscaler-openshift/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-openshift/README.md
@@ -8,7 +8,7 @@ Wrapper chart for CAST AI Autoscaler OpenShift profile.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
+| https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/Chart.yaml
+++ b/charts/castai-umbrella/charts/autoscaler/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 dependencies:
   # ── readonly components ───────────────────────────────────────────────────────
   - name: castai-agent
-    version: "0.155.5"
+    version: "0.158.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
     tags:

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -8,16 +8,16 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
+| https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.60 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.3 |
-| https://castai.github.io/helm-charts | castai-live | 0.98.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.76 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.6 |
+| https://castai.github.io/helm-charts | castai-live | 0.103.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.1 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.1 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.13.0
 dependencies:
   - name: castai-agent
-    version: "0.155.5"
+    version: "0.158.0"
     repository: "https://castai.github.io/helm-charts"
     condition: castai-agent.enabled
   - name: castai-cluster-controller

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -8,16 +8,16 @@ Wrapper chart for CAST AI Kent profile.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://castai.github.io/helm-charts | castai-agent | 0.155.5 |
-| https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.0 |
+| https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
+| https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.1 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.147 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.3 |
-| https://castai.github.io/helm-charts | castai-live | 0.98.0 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.13.4 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.151 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.160.6 |
+| https://castai.github.io/helm-charts | castai-live | 0.103.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.0.23 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.0.23 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.1 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.1 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values


### PR DESCRIPTION
## Summary

Update `castai-agent` dependency to the latest version (`0.158.0`) across all umbrella profiles/subcharts:

- `autoscaler`
- `autoscaler-anywhere`
- `autoscaler-openshift`
- `kent`

Also regenerate helm-docs for updated dependency tables.

Co-Authored-By: Kimchi <noreply@kimchi.dev>

---
### Kimchi Summary
### What changed
Bumps `castai-agent` to `0.158.0` and updates several other CAST AI component dependencies across the `castai-umbrella` chart and its sub-charts.

### Key changes
- `charts/castai-umbrella/Chart.yaml`: chart version `0.36.43` → `0.36.44`
- `castai-agent`: `0.155.5` → `0.158.0` in `autoscaler`, `autoscaler-anywhere`, `autoscaler-openshift`, and `kent`
- `castai-evictor`: `0.35.60` → `0.35.76`
- `castai-kvisor`: `1.160.3` → `1.160.6`
- `castai-live`: `0.98.0` → `0.103.0`
- `castai-pod-mutator`: `0.13.4` → `0.14.0`
- `castai-kentroller`: `0.1.147` → `0.1.151` (kent profile only)
- `castai-chart-upgrader`: `0.1.0` → `0.1.1` (kent profile only)
- `castai-workload-autoscaler`: `1.0.23` → `1.2.1`
- `castai-workload-autoscaler-exporter`: `1.0.23` → `1.2.1`
- Updated `README.md` files in affected sub-charts to reflect the new dependency versions