### PR TITLE
[castai-umbrella] add castai-kvisor name override to autoscaler

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.36.45
+version: 0.36.46
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -10,7 +10,7 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.76 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.77 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.1 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.1 |

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -10,7 +10,7 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.76 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.77 |
 | https://castai.github.io/helm-charts | castai-kvisor | 1.160.6 |
 | https://castai.github.io/helm-charts | castai-live | 0.103.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |
@@ -39,6 +39,7 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 | castai-kvisor.castai.apiKeySecretRef | string | `""` |  |
 | castai-kvisor.castai.clusterIdConfigMapKeyRef.key | string | `"CLUSTER_ID"` |  |
 | castai-kvisor.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
+| castai-kvisor.fullnameOverride | string | `"castai-kvisor"` |  |
 | castai-live.castai-aws-vpc-cni.enabled | bool | `false` |  |
 | castai-live.castai.apiKeySecretRef | string | `""` |  |
 | castai-live.castai.configMapRef | string | `"castai-agent-metadata"` |  |

--- a/charts/castai-umbrella/charts/autoscaler/values.yaml
+++ b/charts/castai-umbrella/charts/autoscaler/values.yaml
@@ -40,6 +40,7 @@ castai-spot-handler:
   apiKeySecretRef: ""
 
 castai-kvisor:
+  fullnameOverride: castai-kvisor
   castai:
     apiKeySecretRef: ""
     clusterIdConfigMapKeyRef:

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -11,7 +11,7 @@ Wrapper chart for CAST AI Kent profile.
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.1 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.151 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.152 |
 | https://castai.github.io/helm-charts | castai-kvisor | 1.160.6 |
 | https://castai.github.io/helm-charts | castai-live | 0.103.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |

--- a/test/e2e/umbrella_test.go
+++ b/test/e2e/umbrella_test.go
@@ -5,6 +5,9 @@ import (
 	"os/exec"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/castai/helm-charts/test/e2e/utils"
 )
 

--- a/test/e2e/umbrella_test.go
+++ b/test/e2e/umbrella_test.go
@@ -5,9 +5,6 @@ import (
 	"os/exec"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"github.com/castai/helm-charts/test/e2e/utils"
 )
 
@@ -219,7 +216,7 @@ var _ = Describe("castai-umbrella helm chart", Ordered, func() {
 
 		It("should create the kvisor-controller deployment", func() {
 			Eventually(func(g Gomega) {
-				podHelper.VerifyDeploymentExists(g, releaseName+"-castai-kvisor-controller")
+				podHelper.VerifyDeploymentExists(g, "castai-kvisor-controller")
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
@@ -351,7 +348,7 @@ var _ = Describe("castai-umbrella helm chart", Ordered, func() {
 
 		It("should create the kvisor-controller deployment", func() {
 			Eventually(func(g Gomega) {
-				podHelper.VerifyDeploymentExists(g, releaseName+"-castai-kvisor-controller")
+				podHelper.VerifyDeploymentExists(g, "castai-kvisor-controller")
 			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 		})
 


### PR DESCRIPTION
Fixes `castai-castai-kvisor-*` resource names when installing castai-kvisor with umbrella, as part of autoscaler.

---
### Kimchi Summary
### What changed
Sets `fullnameOverride: castai-kvisor` on the `castai-kvisor` dependency in the `autoscaler` subchart so that kvisor resources use fixed names instead of being prefixed with the Helm release name. Also bumps the umbrella chart version and minor dependency versions for `castai-evictor` and `castai-kentroller`.

### Why
Ensures stable, predictable resource naming for kvisor components regardless of the Helm release name used during deployment.

### Key changes
- `charts/castai-umbrella/charts/autoscaler/values.yaml`: Added `fullnameOverride: castai-kvisor` under the `castai-kvisor` key.
- `charts/castai-umbrella/charts/autoscaler/README.md`: Documented the new `castai-kvisor.fullnameOverride` value and updated the `castai-evictor` version reference to `0.35.77`.
- `test/e2e/umbrella_test.go`: Updated kvisor deployment assertions to expect the fixed name `castai-kvisor-controller` instead of a release-prefixed name.
- `charts/castai-umbrella/Chart.yaml`: Bumped umbrella chart version from `0.36.45` to `0.36.46`.
- `charts/castai-umbrella/charts/autoscaler-anywhere/README.md`: Updated `castai-evictor` version reference to `0.35.77`.
- `charts/castai-umbrella/charts/kent/README.md`: Updated `castai-kentroller` version reference to `0.1.152`.

### Impact
Kvisor resources deployed via the `autoscaler` profile will be recreated with the new fixed names (`castai-kvisor-*` instead of `<release-name>-castai-kvisor-*`). Upgrades may require manual cleanup of the old kvisor deployment if Helm does not seamlessly handle the rename.