### PR TITLE
[castai-umbrella] Add ORGANIZATION_ID env to kentroller

### DIFF
--- a/charts/castai-umbrella/Chart.lock
+++ b/charts/castai-umbrella/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kent
   repository: file://charts/kent
-  version: 0.13.0
+  version: 0.13.1
 - name: autoscaler-anywhere
   repository: file://charts/autoscaler-anywhere
   version: 0.5.0
@@ -11,5 +11,5 @@ dependencies:
 - name: autoscaler
   repository: file://charts/autoscaler
   version: 0.2.0
-digest: sha256:8c91422331b7c29dba1f4b24c9171396d50e17340cade67bf714bb2237cd545e
-generated: "2026-05-26T13:52:54.446747+02:00"
+digest: sha256:9b14cb853ec07a941d467bee43c4488bc2160281c1e2cc0c8ff9bf556388c31c
+generated: "2026-06-10T13:50:36.768015+02:00"

--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.36.48
+version: 0.36.49
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -11,7 +11,7 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
 | https://castai.github.io/helm-charts | castai-evictor | 0.35.77 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.6 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.161.2 |
 | https://castai.github.io/helm-charts | castai-live | 0.103.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |

--- a/charts/castai-umbrella/charts/kent/Chart.lock
+++ b/charts/castai-umbrella/charts/kent/Chart.lock
@@ -1,25 +1,25 @@
 dependencies:
 - name: castai-agent
   repository: https://castai.github.io/helm-charts
-  version: 0.155.5
+  version: 0.158.0
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
   version: 0.92.4
 - name: castai-kentroller
   repository: https://castai.github.io/helm-charts
-  version: 0.1.147
+  version: 0.1.152
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 1.0.23
+  version: 1.2.1
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 1.0.23
+  version: 1.2.1
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.98.0
+  version: 0.103.0
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.13.4
+  version: 0.14.0
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
   version: 0.35.2
@@ -28,9 +28,9 @@ dependencies:
   version: 3.13.0
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.160.3
+  version: 1.161.2
 - name: castai-chart-upgrader
   repository: https://castai.github.io/helm-charts
-  version: 0.1.0
-digest: sha256:e1bd4d933c7f2c3623e8453e85d7cb94451ef2c5403874e59f46761d2fdde51a
-generated: "2026-05-26T10:19:02.531196+02:00"
+  version: 0.1.1
+digest: sha256:ad3b4050b38c5fd8ddcd84e5dd6e952cced5d584dfe71c0bf8f4d1d778cb4f93
+generated: "2026-06-10T13:49:44.639428+02:00"

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kent
 description: Wrapper chart for CAST AI Kent profile.
 type: application
-version: 0.13.0
+version: 0.13.1
 dependencies:
   - name: castai-agent
     version: "0.158.0"

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -1,6 +1,6 @@
 # kent
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Kent profile.
 
@@ -12,7 +12,7 @@ Wrapper chart for CAST AI Kent profile.
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.1 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
 | https://castai.github.io/helm-charts | castai-kentroller | 0.1.152 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.160.6 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.161.2 |
 | https://castai.github.io/helm-charts | castai-live | 0.103.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
@@ -39,6 +39,7 @@ Wrapper chart for CAST AI Kent profile.
 | castai-cluster-controller.envFrom[0].configMapRef.name | string | `"castai-agent-metadata"` |  |
 | castai-kentroller.castai.apiKeySecretRef | string | `""` |  |
 | castai-kentroller.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
+| castai-kentroller.castai.organizationIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-kentroller.enabled | bool | `true` |  |
 | castai-kvisor.agent.enabled | bool | `false` |  |
 | castai-kvisor.castai.apiKeySecretRef | string | `""` |  |

--- a/charts/castai-umbrella/charts/kent/values.yaml
+++ b/charts/castai-umbrella/charts/kent/values.yaml
@@ -25,6 +25,8 @@ castai-kentroller:
     apiKeySecretRef: ""
     clusterIdConfigMapKeyRef:
       name: castai-agent-metadata
+    organizationIdConfigMapKeyRef:
+      name: castai-agent-metadata
 
 castai-workload-autoscaler:
   enabled: true


### PR DESCRIPTION
## Summary

Pass ORGANIZATION_ID to `castai-kentroller` via `organizationIdConfigMapKeyRef`, reading from the `castai-agent-metadata` ConfigMap (same pattern as CLUSTER_ID).

## Changes

- Add `organizationIdConfigMapKeyRef` to `kent/values.yaml` for `castai-kentroller`
- Bump kent subchart version `0.13.0` → `0.13.1`
- Bump umbrella chart version `0.36.48` → `0.36.49`
- Regenerate `helm-docs` and update `Chart.lock` files

Co-Authored-By: Kimchi <noreply@kimchi.dev>

---
### Kimchi Summary
### What changed
Bumps the `kent` subchart to `0.13.1` and the umbrella chart to `0.36.49`. Adds `organizationIdConfigMapKeyRef` for `castai-kentroller` and updates multiple CAST AI component dependencies to their latest patch/minor versions.

### Why
Provides `castai-kentroller` with the organization ID from the `castai-agent-metadata` ConfigMap so it can correctly associate the cluster with its organization.

<img width="1243" height="419" alt="image" src="https://github.com/user-attachments/assets/636bedd7-9271-40b9-bd1b-85b8cf0d99df" />


### Key changes
- `charts/castai-umbrella/charts/kent/values.yaml`: Adds `organizationIdConfigMapKeyRef.name: castai-agent-metadata` under `castai-kentroller.castai`.
- `charts/castai-umbrella/charts/kent/Chart.yaml`: Bumps `kent` chart version to `0.13.1`.
- `charts/castai-umbrella/Chart.yaml` / `Chart.lock`: Bumps umbrella chart version to `0.36.49` and updates the locked `kent` dependency digest.
- `charts/castai-umbrella/charts/kent/Chart.lock`: Updates dependency versions:
  - `castai-agent` `0.155.5` → `0.158.0`
  - `castai-kentroller` `0.1.147` → `0.1.152`
  - `castai-workload-autoscaler` and `castai-workload-autoscaler-exporter` `1.0.23` → `1.2.1`
  - `castai-live` `0.98.0` → `0.103.0`
  - `castai-pod-mutator` `0.13.4` → `0.14.0`
  - `castai-kvisor` `1.160.3` → `1.161.2`
  - `castai-chart-upgrader` `0.1.0` → `0.1.1`

### Impact
Deploying this chart will upgrade several CAST AI components in the Kent profile. Review upstream component changelogs before applying to production clusters.