### PR TITLE
[castai-umbrella] Update apiKeySecretRef validatiom and docs

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.37.0
+version: 0.38.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/README.md
+++ b/charts/castai-umbrella/README.md
@@ -54,33 +54,33 @@ Replace `tags.readonly` with the desired mode tag (`node-autoscaler`, `workload-
 
 #### Using an external secret (Sealed Secrets / ESO / Vault)
 
-If you manage secrets externally, pre-create the `castai-credentials` Secret and pass `apiKeySecretRef` instead of `apiKey`:
+If you manage secrets externally, pre-create a Secret and pass its name as `apiKeySecretRef` instead of `apiKey`:
 
 ```shell
 kubectl create namespace castai-agent
-kubectl create secret generic castai-credentials \
+kubectl create secret generic my-castai-credentials \
   --namespace castai-agent \
   --from-literal=API_KEY=<YOUR_API_KEY>
 
 helm upgrade --install castai castai-helm/castai \
   --namespace castai-agent --create-namespace \
-  --set global.castai.apiKeySecretRef=castai-credentials \
+  --set global.castai.apiKeySecretRef=my-castai-credentials \
   --set global.castai.apiURL=https://api.cast.ai \
   --set global.castai.provider=<eks|aks|gke> \
   --set tags.readonly=true
 ```
 
-The Secret must contain a key named `API_KEY` and be in the same namespace as the release. `apiKey` and `apiKeySecretRef` are mutually exclusive.
+The Secret must contain a key named `API_KEY` and be in the same namespace as the release. `apiKey` and `apiKeySecretRef` are mutually exclusive. The default value for `apiKeySecretRef` is `castai-credentials`, but any Secret name is accepted.
 
 #### Using ExternalSecret (External Secrets Operator)
 
-If you use the [External Secrets Operator](https://external-secrets.io), you can provision the `castai-credentials` secret directly from your secret store using `extraObjects` — no manual `kubectl create secret` step required.
+If you use the [External Secrets Operator](https://external-secrets.io), you can provision a credentials secret directly from your secret store using `extraObjects` — no manual `kubectl create secret` step required.
 
 ```yaml
 global:
   castai:
     apiKey: ""                          # leave empty — ExternalSecret creates the secret
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: castai-credentials # any name — must match target.name below
     apiURL: "https://api.cast.ai"
     provider: eks
 
@@ -98,7 +98,7 @@ extraObjects:
         name: my-secret-store           # your SecretStore or ClusterSecretStore name
         kind: SecretStore
       target:
-        name: castai-credentials        # must be exactly this
+        name: castai-credentials        # must match global.castai.apiKeySecretRef
         creationPolicy: Owner
       data:
         - secretKey: API_KEY            # must be exactly this
@@ -106,7 +106,7 @@ extraObjects:
             key: castai/api-key         # path in your secret store
 ```
 
-The `ExternalSecret` is rendered into the same namespace as the release. All subcharts, including `castai-evictor` which reads credentials via `envFrom`, will find the `castai-credentials` secret automatically.
+The `ExternalSecret` is rendered into the same namespace as the release. All subcharts will find the secret named by `global.castai.apiKeySecretRef` automatically.
 
 ### Accepted mode upgrade paths
 
@@ -188,11 +188,11 @@ helm upgrade castai castai-helm/castai \
 
 ## Autoscaler Anywhere
 
-For non-managed Kubernetes clusters (bare metal, on-prem, edge). Authentication uses a pre-created `castai-credentials` Secret instead of inline API key flags.
+For non-managed Kubernetes clusters (bare metal, on-prem, edge). Authentication uses a pre-created credentials Secret instead of inline API key flags.
 
 ### Prerequisites
 
-Create the credentials secret before installing:
+Create the credentials secret before installing (name must match `global.castai.apiKeySecretRef`, default: `castai-credentials`):
 
 ```shell
 kubectl create namespace castai-agent
@@ -227,11 +227,11 @@ helm upgrade castai castai-helm/castai \
 
 ## Kent
 
-CAST AI Kent profile for EKS clusters. Like Autoscaler Anywhere, authentication uses a pre-created `castai-credentials` Secret.
+CAST AI Kent profile for EKS clusters. Like Autoscaler Anywhere, authentication uses a pre-created credentials Secret.
 
 ### Prerequisites
 
-Create the credentials secret before installing:
+Create the credentials secret before installing (name must match `global.castai.apiKeySecretRef`, default: `castai-credentials`):
 
 ```shell
 kubectl create namespace castai-agent

--- a/charts/castai-umbrella/README.md.gotmpl
+++ b/charts/castai-umbrella/README.md.gotmpl
@@ -47,33 +47,33 @@ Replace `tags.readonly` with the desired mode tag (`node-autoscaler`, `workload-
 
 #### Using an external secret (Sealed Secrets / ESO / Vault)
 
-If you manage secrets externally, pre-create the `castai-credentials` Secret and pass `apiKeySecretRef` instead of `apiKey`:
+If you manage secrets externally, pre-create a Secret and pass its name as `apiKeySecretRef` instead of `apiKey`:
 
 ```shell
 kubectl create namespace castai-agent
-kubectl create secret generic castai-credentials \
+kubectl create secret generic my-castai-credentials \
   --namespace castai-agent \
   --from-literal=API_KEY=<YOUR_API_KEY>
 
 helm upgrade --install castai castai-helm/castai \
   --namespace castai-agent --create-namespace \
-  --set global.castai.apiKeySecretRef=castai-credentials \
+  --set global.castai.apiKeySecretRef=my-castai-credentials \
   --set global.castai.apiURL=https://api.cast.ai \
   --set global.castai.provider=<eks|aks|gke> \
   --set tags.readonly=true
 ```
 
-The Secret must contain a key named `API_KEY` and be in the same namespace as the release. `apiKey` and `apiKeySecretRef` are mutually exclusive.
+The Secret must contain a key named `API_KEY` and be in the same namespace as the release. `apiKey` and `apiKeySecretRef` are mutually exclusive. The default value for `apiKeySecretRef` is `castai-credentials`, but any Secret name is accepted.
 
 #### Using ExternalSecret (External Secrets Operator)
 
-If you use the [External Secrets Operator](https://external-secrets.io), you can provision the `castai-credentials` secret directly from your secret store using `extraObjects` — no manual `kubectl create secret` step required.
+If you use the [External Secrets Operator](https://external-secrets.io), you can provision a credentials secret directly from your secret store using `extraObjects` — no manual `kubectl create secret` step required.
 
 ```yaml
 global:
   castai:
     apiKey: ""                          # leave empty — ExternalSecret creates the secret
-    apiKeySecretRef: castai-credentials
+    apiKeySecretRef: castai-credentials # any name — must match target.name below
     apiURL: "https://api.cast.ai"
     provider: eks
 
@@ -91,7 +91,7 @@ extraObjects:
         name: my-secret-store           # your SecretStore or ClusterSecretStore name
         kind: SecretStore
       target:
-        name: castai-credentials        # must be exactly this
+        name: castai-credentials        # must match global.castai.apiKeySecretRef
         creationPolicy: Owner
       data:
         - secretKey: API_KEY            # must be exactly this
@@ -99,7 +99,7 @@ extraObjects:
             key: castai/api-key         # path in your secret store
 ```
 
-The `ExternalSecret` is rendered into the same namespace as the release. All subcharts, including `castai-evictor` which reads credentials via `envFrom`, will find the `castai-credentials` secret automatically.
+The `ExternalSecret` is rendered into the same namespace as the release. All subcharts will find the secret named by `global.castai.apiKeySecretRef` automatically.
 
 ### Accepted mode upgrade paths
 
@@ -181,11 +181,11 @@ helm upgrade castai castai-helm/castai \
 
 ## Autoscaler Anywhere
 
-For non-managed Kubernetes clusters (bare metal, on-prem, edge). Authentication uses a pre-created `castai-credentials` Secret instead of inline API key flags.
+For non-managed Kubernetes clusters (bare metal, on-prem, edge). Authentication uses a pre-created credentials Secret instead of inline API key flags.
 
 ### Prerequisites
 
-Create the credentials secret before installing:
+Create the credentials secret before installing (name must match `global.castai.apiKeySecretRef`, default: `castai-credentials`):
 
 ```shell
 kubectl create namespace castai-agent
@@ -220,11 +220,11 @@ helm upgrade castai castai-helm/castai \
 
 ## Kent
 
-CAST AI Kent profile for EKS clusters. Like Autoscaler Anywhere, authentication uses a pre-created `castai-credentials` Secret.
+CAST AI Kent profile for EKS clusters. Like Autoscaler Anywhere, authentication uses a pre-created credentials Secret.
 
 ### Prerequisites
 
-Create the credentials secret before installing:
+Create the credentials secret before installing (name must match `global.castai.apiKeySecretRef`, default: `castai-credentials`):
 
 ```shell
 kubectl create namespace castai-agent

--- a/charts/castai-umbrella/templates/validate-values.yaml
+++ b/charts/castai-umbrella/templates/validate-values.yaml
@@ -14,8 +14,11 @@
 {{/* ── Required values when a mode tag is set ─────────────────────────────── */}}
 {{- if $enabledTags }}
 {{- $hasApiKey := .Values.global.castai.apiKey }}
-{{- $hasCustomSecretRef := and .Values.global.castai.apiKeySecretRef (ne .Values.global.castai.apiKeySecretRef "castai-credentials") }}
-{{- if and (not $hasApiKey) (not $hasCustomSecretRef) }}
+{{- $hasSecretRef := not (empty .Values.global.castai.apiKeySecretRef) }}
+{{/* apiKey + the default "castai-credentials" is fine — apiKey creates that secret.
+     Only a custom ref name conflicts with apiKey. */}}
+{{- $hasCustomSecretRef := and $hasSecretRef (ne .Values.global.castai.apiKeySecretRef "castai-credentials") }}
+{{- if and (not $hasApiKey) (not $hasSecretRef) }}
 {{ fail "Either global.castai.apiKey or global.castai.apiKeySecretRef is required when enabling a mode tag" }}
 {{- end }}
 {{- if and $hasApiKey $hasCustomSecretRef }}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Relaxes validation and updates documentation for the `global.castai.apiKeySecretRef` field so that any Secret name is accepted. The default remains `castai-credentials`.

### Why
The previous Helm validation incorrectly required `apiKey` even when `apiKeySecretRef` was set to its default value of `castai-credentials`, and the README implied the secret name was fixed. This change supports externally managed secrets with arbitrary names.

### Key changes
- `templates/validate-values.yaml`: Fixes credential validation so that either `apiKey` or any non-empty `apiKeySecretRef` satisfies the requirement. The mutually-exclusive check now only errors when a *custom* (non-default) `apiKeySecretRef` is used alongside `apiKey`.
- `README.md` and `README.md.gotmpl`: Clarifies that `apiKeySecretRef` can reference any Secret name. Updates shell and YAML examples to use a placeholder name and notes the default value.
- `Chart.yaml`: Bumps umbrella chart version to `0.38.0`.

### Impact
Low-risk fix. Removes an overly strict validation case, allowing installations that supply only the default `apiKeySecretRef` without `apiKey`. No migration steps required.