### PR TITLE
[castai-cluster-controller] bump to v0.62.2

### DIFF
--- a/charts/castai-cluster-controller/Chart.yaml
+++ b/charts/castai-cluster-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castai-cluster-controller
 description: Cluster controller is responsible for handling certain Kubernetes actions such as draining and deleting nodes, adding labels, approving CSR requests.
 type: application
-version: 0.92.4
-appVersion: "v0.62.1"
+version: 0.92.5
+appVersion: "v0.62.2"
 annotations:
   release-date: "2024-06-04T07:10:07"
 dependencies:


### PR DESCRIPTION
Bumps appVersion to v0.62.2 (CSU-5412: golang.org/x CVE fixes + Go 1.26.4). Chart version: 0.92.4 → 0.92.5.

---
### Kimchi Summary
### What changed
Bumps the `castai-cluster-controller` Helm chart to app version `v0.62.2` and chart version `0.92.5`.

### Key changes
- `charts/castai-cluster-controller/Chart.yaml`: updated `appVersion` from `v0.62.1` to `v0.62.2` and `version` from `0.92.4` to `0.92.5`.