### PR TITLE
[castai-umbrella] Add tolerations support for kent preflight job

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.36.50
+version: 0.37.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -11,7 +11,7 @@ Wrapper chart for CAST AI Kent profile.
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.1.1 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.4 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.152 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.153 |
 | https://castai.github.io/helm-charts | castai-kvisor | 1.161.2 |
 | https://castai.github.io/helm-charts | castai-live | 0.103.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.14.0 |

--- a/charts/castai-umbrella/templates/kent-preflight.yaml
+++ b/charts/castai-umbrella/templates/kent-preflight.yaml
@@ -58,6 +58,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ .Release.Name }}-kent-preflight
+      {{- with .Values.global.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: preflight
           image: bitnami/kubectl:latest


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for `global.tolerations` in the `kent-preflight` Job so the preflight pod can be scheduled on tainted nodes. Also updates the `castai-kentroller` dependency and bumps the umbrella chart version.

### Why
Clusters that use taints on all nodes previously could fail to schedule the kent preflight pod; propagating the configured tolerations ensures the Job runs successfully.

### Key changes
- `charts/castai-umbrella/templates/kent-preflight.yaml`: Injected a `tolerations` block under the pod spec, sourced from `.Values.global.tolerations`.
- `charts/castai-umbrella/Chart.yaml`: Bumped umbrella chart version from `0.36.50` to `0.37.0`.
- `charts/castai-umbrella/charts/kent/README.md`: Updated `castai-kentroller` dependency to `0.1.153`.

### Impact
No breaking changes. The `tolerations` block is omitted when `.Values.global.tolerations` is unset.