### PR TITLE
[castai-chart-upgrader] Limit chart-upgrader to upgrading to chart of the same name

### DIFF
--- a/charts/castai-chart-upgrader/Chart.yaml
+++ b/charts/castai-chart-upgrader/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-chart-upgrader
 description: Auto-updates charts via CronJob
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"

--- a/charts/castai-chart-upgrader/README.md
+++ b/charts/castai-chart-upgrader/README.md
@@ -1,6 +1,6 @@
 # castai-chart-upgrader
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Auto-updates charts via CronJob
 
@@ -27,7 +27,8 @@ Auto-updates charts via CronJob
 | schedule | string | `"0 8 * * *"` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| targetRelease | string | `""` |  |
+| targetNamespace | string | `"castai-agent"` | Namespace where the target release lives. |
+| targetRelease | string | `"castai"` | Name of the Helm release to upgrade. |
 | tolerations | list | `[]` |  |
 | upgrade.atomic | bool | `true` |  |
 | upgrade.timeout | string | `"10m"` |  |

--- a/charts/castai-chart-upgrader/ci/test-values.yaml
+++ b/charts/castai-chart-upgrader/ci/test-values.yaml
@@ -1,3 +1,5 @@
 schedule: "0 8 * * *"
+targetRelease: castai
+targetNamespace: castai-agent
 chart:
   name: castai-agent

--- a/charts/castai-chart-upgrader/templates/_helpers.tpl
+++ b/charts/castai-chart-upgrader/templates/_helpers.tpl
@@ -60,9 +60,15 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Resolve the Helm release name to upgrade.
-Uses .Values.targetRelease when set, otherwise falls back to .Release.Name.
+Name of the Helm release to upgrade. Required.
 */}}
 {{- define "chart-upgrader.targetRelease" -}}
-{{- .Values.targetRelease | default .Release.Name -}}
+{{- required ".Values.targetRelease is required" .Values.targetRelease -}}
+{{- end }}
+
+{{/*
+Namespace where the target release lives. Required.
+*/}}
+{{- define "chart-upgrader.targetNamespace" -}}
+{{- required ".Values.targetNamespace is required" .Values.targetNamespace -}}
 {{- end }}

--- a/charts/castai-chart-upgrader/templates/cronjob.yaml
+++ b/charts/castai-chart-upgrader/templates/cronjob.yaml
@@ -102,9 +102,23 @@ spec:
               CHART_REF="castai/{{ .Values.chart.name }}"
               {{- end }}
 
+              echo "Verifying chart name for release '{{ include "chart-upgrader.targetRelease" . }}'..."
+              CURRENT_CHART_NAME=$(helm get metadata "{{ include "chart-upgrader.targetRelease" . }}" \
+                --namespace "{{ include "chart-upgrader.targetNamespace" . }}" -o json 2>/dev/null | jq -r '.chart // empty')
+              if [ -z "$CURRENT_CHART_NAME" ]; then
+                echo "ERROR: release '{{ include "chart-upgrader.targetRelease" . }}' not found in namespace '{{ include "chart-upgrader.targetNamespace" . }}'"
+                exit 1
+              fi
+              EXPECTED_CHART_NAME="{{ .Values.chart.name }}"
+              if [ "$CURRENT_CHART_NAME" != "$EXPECTED_CHART_NAME" ]; then
+                echo "ERROR: chart name mismatch - release '{{ include "chart-upgrader.targetRelease" . }}' is currently using chart '$CURRENT_CHART_NAME', but expected '$EXPECTED_CHART_NAME'"
+                exit 1
+              fi
+              echo "Chart name verified: '$CURRENT_CHART_NAME' matches expected '$EXPECTED_CHART_NAME'"
+
               echo "Upgrading release '{{ include "chart-upgrader.targetRelease" . }}' with chart '$CHART_REF'"
               helm upgrade "{{ include "chart-upgrader.targetRelease" . }}" "$CHART_REF" \
-                --namespace "{{ .Release.Namespace }}" \
+                --namespace "{{ include "chart-upgrader.targetNamespace" . }}" \
                 {{- if .Values.upgrade.atomic }}
                 --atomic \
                 {{- end }}

--- a/charts/castai-chart-upgrader/values.yaml
+++ b/charts/castai-chart-upgrader/values.yaml
@@ -3,10 +3,11 @@
 # Cron schedule expression (default: daily at 8am UTC)
 schedule: "0 8 * * *"
 
-# Target Helm release to upgrade. Defaults to the release this chart was
-# installed under (.Release.Name). Set this when the chart-upgrader is installed
-# as a standalone release that should upgrade a *different* release.
-targetRelease: ""
+# targetRelease -- Name of the Helm release to upgrade.
+targetRelease: "castai"
+
+# targetNamespace -- Namespace where the target release lives.
+targetNamespace: "castai-agent"
 
 # Target chart to upgrade. The updater always upgrades to the latest available
 # version in the configured repository.


### PR DESCRIPTION
If the release you're trying to upgrade has a different chart name in the metadata than the one you're upgrading to, the upgrade job will fail with an error message.

---
### Kimchi Summary
### What changed
Adds a pre-upgrade safeguard that verifies the target Helm release exists and matches the expected chart name before running `helm upgrade`. Also makes `targetRelease` and `targetNamespace` explicit, required configuration values with new defaults.

### Why
Prevents the CronJob from accidentally modifying the wrong release or failing silently when the target is missing or was installed with a different chart.

### Key changes
- `templates/cronjob.yaml`: Added `helm get metadata` verification step that validates the target release exists in `targetNamespace` and its chart name matches `.Values.chart.name` before invoking `helm upgrade`; changed the upgrade namespace from `.Release.Namespace` to the new `chart-upgrader.targetNamespace` helper.
- `templates/_helpers.tpl`: `chart-upgrader.targetRelease` is now required and no longer falls back to `.Release.Name`; added new required `chart-upgrader.targetNamespace` helper.
- `values.yaml`: Added `targetNamespace` with default `"castai-agent"` and changed `targetRelease` default from `""` to `"castai"`.
- `ci/test-values.yaml`: Added explicit `targetRelease` and `targetNamespace` values for CI testing.
- `Chart.yaml`: Bumped chart version to `0.1.2`.
- `README.md`: Updated version badge and parameter documentation.

### Impact
**Breaking change**: The upgrader no longer defaults to the installing release name and namespace. `targetRelease` defaults to `"castai"` instead of falling back to `.Release.Name`, and `targetNamespace` defaults to `"castai-agent"` instead of using `.Release.Namespace`. Update these values before upgrading to ensure the correct release is targeted.