### PR TITLE
[castai-chart-upgrader] guard subchart installs

### DIFF
--- a/charts/castai-chart-upgrader/Chart.yaml
+++ b/charts/castai-chart-upgrader/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-chart-upgrader
 description: Auto-updates charts via CronJob
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "0.1.0"

--- a/charts/castai-chart-upgrader/README.md
+++ b/charts/castai-chart-upgrader/README.md
@@ -1,6 +1,6 @@
 # castai-chart-upgrader
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Auto-updates charts via CronJob
 
@@ -12,7 +12,7 @@ Auto-updates charts via CronJob
 | chart.auth.existingSecret | string | `""` |  |
 | chart.auth.password | string | `""` |  |
 | chart.auth.username | string | `""` |  |
-| chart.name | string | `"castai"` |  |
+| chart.name | string | `"castai"` | Chart name to upgrade (e.g., castai, kent). This must match the target release's top-level chart name. Use this chart only when the target chart is installed as a standalone Helm release. If CAST AI is installed as a dependency of another chart, use dependency automation such as Renovate, Argo CD Image Updater, or Flux Image Automation instead. |
 | chart.oci | bool | `false` |  |
 | chart.repository | string | `"https://castai.github.io/helm-charts"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -27,7 +27,7 @@ Auto-updates charts via CronJob
 | schedule | string | `"0 8 * * *"` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| targetRelease | string | `""` |  |
+| targetRelease | string | `""` | Target Helm release to upgrade. Defaults to the release this chart was installed under (.Release.Name). Set this when the chart-upgrader is installed as a standalone release that should upgrade a different release. |
 | tolerations | list | `[]` |  |
 | upgrade.atomic | bool | `true` |  |
 | upgrade.timeout | string | `"10m"` |  |

--- a/charts/castai-chart-upgrader/templates/cronjob.yaml
+++ b/charts/castai-chart-upgrader/templates/cronjob.yaml
@@ -102,8 +102,34 @@ spec:
               CHART_REF="castai/{{ .Values.chart.name }}"
               {{- end }}
 
-              echo "Upgrading release '{{ include "chart-upgrader.targetRelease" . }}' with chart '$CHART_REF'"
-              helm upgrade "{{ include "chart-upgrader.targetRelease" . }}" "$CHART_REF" \
+              TARGET_RELEASE="{{ include "chart-upgrader.targetRelease" . }}"
+              TARGET_CHART="{{ .Values.chart.name }}"
+
+              echo "Validating target release '$TARGET_RELEASE' before upgrade"
+              RELEASE_METADATA="$(helm get metadata "$TARGET_RELEASE" \
+                --namespace "{{ .Release.Namespace }}" \
+                --output json)"
+              CURRENT_CHART="$(printf '%s\n' "$RELEASE_METADATA" | jq -r '.chart // empty')"
+
+              if [ -z "$CURRENT_CHART" ]; then
+                echo "Failed to determine current top-level chart for release '$TARGET_RELEASE'" >&2
+                exit 1
+              fi
+
+              if [ "$CURRENT_CHART" != "$TARGET_CHART" ]; then
+                echo "Refusing to upgrade release '$TARGET_RELEASE': current top-level chart is '$CURRENT_CHART', expected '$TARGET_CHART'." >&2
+                echo "The chart-upgrader only supports releases installed directly from '$TARGET_CHART'. If '$TARGET_CHART' is installed as a dependency of a customer/wrapper chart, upgrade that parent chart instead." >&2
+                exit 1
+              fi
+
+              if printf '%s\n' "$RELEASE_METADATA" | jq -e --arg chart "$TARGET_CHART" '.dependencies[]? | select(.name == $chart)' >/dev/null; then
+                echo "Refusing to upgrade release '$TARGET_RELEASE': current top-level chart '$CURRENT_CHART' lists '$TARGET_CHART' as a dependency." >&2
+                echo "This indicates '$TARGET_CHART' is installed as a subchart. Upgrade the customer/wrapper chart that owns the release instead." >&2
+                exit 1
+              fi
+
+              echo "Upgrading release '$TARGET_RELEASE' with chart '$CHART_REF'"
+              helm upgrade "$TARGET_RELEASE" "$CHART_REF" \
                 --namespace "{{ .Release.Namespace }}" \
                 {{- if .Values.upgrade.atomic }}
                 --atomic \

--- a/charts/castai-chart-upgrader/values.yaml
+++ b/charts/castai-chart-upgrader/values.yaml
@@ -3,15 +3,22 @@
 # Cron schedule expression (default: daily at 8am UTC)
 schedule: "0 8 * * *"
 
-# Target Helm release to upgrade. Defaults to the release this chart was
-# installed under (.Release.Name). Set this when the chart-upgrader is installed
-# as a standalone release that should upgrade a *different* release.
+# targetRelease -- Target Helm release to upgrade. Defaults to the release this
+# chart was installed under (.Release.Name). Set this when the chart-upgrader is
+# installed as a standalone release that should upgrade a different release.
 targetRelease: ""
 
 # Target chart to upgrade. The updater always upgrades to the latest available
-# version in the configured repository.
+# version in the configured repository. Use this chart only when the target chart
+# is installed as a standalone Helm release. If CAST AI is installed as a
+# dependency of another chart, use dependency automation such as Renovate, Argo
+# CD Image Updater, or Flux Image Automation instead.
 chart:
-  # Chart name to upgrade (e.g., castai, kent).
+  # -- Chart name to upgrade (e.g., castai, kent). This must match the target
+  # release's top-level chart name. Use this chart only when the target chart is
+  # installed as a standalone Helm release. If CAST AI is installed as a
+  # dependency of another chart, use dependency automation such as Renovate,
+  # Argo CD Image Updater, or Flux Image Automation instead.
   name: "castai"
   # Helm repository to fetch the chart from. Override this if you mirror the
   # CAST AI charts behind a proxy or private registry.


### PR DESCRIPTION
## Summary
- add a default-on target release guard to castai-chart-upgrader before running helm upgrade
- fail safely when the target release is owned by a wrapper chart or when the target chart is installed as a dependency
- bump castai-chart-upgrader to 0.2.0 and wire it through Kent / umbrella
- document that the updater is only for standalone CAST AI umbrella installs

## Validation
- ct lint --config ct.yaml --charts charts/castai-chart-upgrader
- ct lint --config ct.yaml --charts charts/castai-umbrella
- git diff --check
- local kind: wrapped chart with non-castai top-level chart fails before upgrade and keeps deployment/castai-agent
- local kind: wrapped chart named castai with dependency castai fails before upgrade and keeps deployment/castai-agent
- local kind: direct public umbrella install upgrades successfully

## Context
This prevents the CSU-5400 failure mode where the updater runs helm upgrade castai castai/castai against a release installed from a customer wrapper chart, reuses wrapper-shaped values, and deletes CAST AI resources.

---
### Kimchi Summary
### What changed
Adds pre-upgrade validation to the `castai-chart-upgrader` CronJob to block upgrades when the target chart is not the top-level release or is listed as a dependency. Also updates documentation and bumps the chart version to `0.2.0`.

### Why
Upgrading a chart that is installed as a subchart can corrupt the parent release state and is not supported by standard Helm dependency management. This guard ensures the upgrader only acts on standalone installations.

### Key changes
- `templates/cronjob.yaml`: Added validation script before `helm upgrade`:
  - Fetches target release metadata with `helm get metadata`.
  - Verifies the release's top-level chart equals `.Values.chart.name`.
  - Uses `jq` to detect if the target chart appears in the release's `dependencies`.
  - Fails with a descriptive error if the chart is a dependency or the chart name mismatches.
- `values.yaml`: Updated comments for `targetRelease` and `chart.name` to warn against subchart use and recommend tools like Renovate, Argo CD Image Updater, or Flux Image Automation.
- `Chart.yaml`: Bumped version from `0.1.1` to `0.2.0`.
- `README.md`: Synchronized version badge and parameter descriptions with `values.yaml`.

### Impact
- Existing CronJob instances that target a subchart or misconfigured release will now exit with an error instead of attempting an upgrade.
- Users managing CAST AI as a dependency must switch to parent-chart automation before adopting this version.