### PR TITLE
[castai-db-optimizer] bump pgdog to latest version

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.79.2
+version: 0.80.0

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.79.2](https://img.shields.io/badge/Version-0.79.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.80.0](https://img.shields.io/badge/Version-0.80.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,5 +1,5 @@
 {{- define "defaultProxyVersion" -}}v4.84.2{{- end -}}
 {{- define "defaultQueryProcessorVersion" -}}v0.48.0{{- end -}}
 {{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
-{{- define "defaultPgdogVersion" -}}v0.1.30{{- end -}}
+{{- define "defaultPgdogVersion" -}}v0.1.43{{- end -}}
 {{- define "defaultProxySqlVersion" -}}3.0.6{{- end -}}


### PR DESCRIPTION
This PR bumps the `castai-db-optimizer` chart to bring in the latest `pgdog` version as a default.

---
### Kimchi Summary
### What changed
Bumps the `castai-db-optimizer` Helm chart version to `0.80.0` and updates the default `pgdog` image tag to `v0.1.43`.

### Why
Updates the database optimizer to use the latest `pgdog` release.

### Key changes
- `Chart.yaml` — incremented chart version from `0.79.2` to `0.80.0`.
- `README.md` — updated version badge to `0.80.0`.
- `templates/_versions.tpl` — bumped `defaultPgdogVersion` from `v0.1.30` to `v0.1.43`.

### Impact
Deployments that rely on the default `pgdog` version will automatically pull `v0.1.43` after the next `helm upgrade`.