### PR TITLE
Add bump versions pipeline for new umbrella repo

### DIFF
--- a/.github/scripts/check-umbrella-drift.sh
+++ b/.github/scripts/check-umbrella-drift.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Compares env vars defined in a component's Helm templates against the
+# corresponding folded templates in the kubecast umbrella chart.
+#
+# Required env vars:
+#   CHART_NAME     — e.g. castai-agent, castai-workload-autoscaler, castai-live
+#   CHART_VERSION  — required only for castai-live (pulled from registry)
+#
+# Paths expected to exist at call time (set up by release-umbrella-rc.yml):
+#   kubecast/      — clone of the kubecast repo (contains both services/ and castai-umbrella/)
+#
+# Writes markdown to stdout and, when GITHUB_OUTPUT is set, appends
+#   drift_report<<DELIMITER / ... / DELIMITER
+# to that file.
+
+set -euo pipefail
+
+CHART_NAME="${CHART_NAME:?CHART_NAME env var required}"
+CHART_VERSION="${CHART_VERSION:-}"
+
+COMP_TEMPLATES=""
+
+if [ "$CHART_NAME" = "castai-live" ]; then
+  if [ -z "$CHART_VERSION" ]; then
+    echo "CHART_VERSION is required for castai-live" >&2
+    exit 1
+  fi
+  # castai-live lives in a separate repo; pull its chart from the public registry.
+  LIVE_UNTAR_DIR="/tmp/castai-live-chart"
+  rm -rf "$LIVE_UNTAR_DIR"
+  helm repo add castai-helm https://castai.github.io/helm-charts --force-update >/dev/null 2>&1
+  helm pull castai-helm/castai-live \
+    --version "$CHART_VERSION" \
+    --untar \
+    --untardir "$LIVE_UNTAR_DIR"
+  COMP_TEMPLATES="${LIVE_UNTAR_DIR}/castai-live/templates"
+else
+  # Locate the chart inside kubecast/services/ by matching the chart name in Chart.yaml.
+  CHART_YAML_PATH=$(find kubecast/services -name "Chart.yaml" -exec grep -l "^name: ${CHART_NAME}$" {} \; 2>/dev/null | head -1 || true)
+  if [ -z "$CHART_YAML_PATH" ]; then
+    cat <<MD
+## Env-var drift: \`${CHART_NAME}\`
+
+> Chart not found under \`kubecast/services/\` — skipping drift check.
+> This component may be a subchart dependency only (e.g. castai-kentroller, castai-chart-upgrader).
+MD
+    exit 0
+  fi
+  COMP_TEMPLATES="$(dirname "$CHART_YAML_PATH")/templates"
+fi
+
+UMB_TEMPLATES="kubecast/castai-umbrella/chart/templates/${CHART_NAME}"
+
+if [ ! -d "$COMP_TEMPLATES" ]; then
+  cat <<MD
+## Env-var drift: \`${CHART_NAME}\`
+
+> Component templates not found at \`${COMP_TEMPLATES}\` — skipping drift check.
+MD
+  exit 0
+fi
+
+if [ ! -d "$UMB_TEMPLATES" ]; then
+  cat <<MD
+## Env-var drift: \`${CHART_NAME}\`
+
+> Umbrella templates not found at \`${UMB_TEMPLATES}\` — skipping drift check.
+> The umbrella may use a subchart for this component rather than flat templates.
+MD
+  exit 0
+fi
+
+extract_env_vars() {
+  local dir="$1"
+  grep -rh '^\s*- name:\s*[A-Z_]' "$dir" \
+    | sed 's/.*- name:[[:space:]]*//' \
+    | sed 's/[[:space:]]*$//' \
+    | sort -u
+}
+
+COMP_VARS=$(extract_env_vars "$COMP_TEMPLATES")
+UMB_VARS=$(extract_env_vars "$UMB_TEMPLATES")
+
+COMP_ONLY=$(comm -23 \
+  <(echo "$COMP_VARS") \
+  <(echo "$UMB_VARS") \
+  || true)
+
+UMB_ONLY=$(comm -13 \
+  <(echo "$COMP_VARS") \
+  <(echo "$UMB_VARS") \
+  || true)
+
+build_report() {
+  echo "## Env-var drift: \`${CHART_NAME}\`"
+  echo ""
+  if [ -z "$COMP_ONLY" ] && [ -z "$UMB_ONLY" ]; then
+    echo "No drift detected — umbrella env vars match the component chart."
+    return
+  fi
+  if [ -n "$COMP_ONLY" ]; then
+    echo "### In component, missing from umbrella (need porting)"
+    echo ""
+    echo "| Env var |"
+    echo "|---------|"
+    while IFS= read -r var; do
+      [ -z "$var" ] && continue
+      echo "| \`${var}\` |"
+    done <<< "$COMP_ONLY"
+    echo ""
+  else
+    echo "No env vars missing from umbrella."
+    echo ""
+  fi
+  if [ -n "$UMB_ONLY" ]; then
+    echo "### In umbrella only (umbrella additions — informational)"
+    echo ""
+    echo "| Env var |"
+    echo "|---------|"
+    while IFS= read -r var; do
+      [ -z "$var" ] && continue
+      echo "| \`${var}\` |"
+    done <<< "$UMB_ONLY"
+  else
+    echo "No umbrella-only env vars."
+  fi
+}
+
+REPORT=$(build_report)
+echo "$REPORT"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  DELIMITER="DRIFT_EOF_$(date +%s%N)"
+  {
+    echo "drift_report<<${DELIMITER}"
+    echo "$REPORT"
+    echo "${DELIMITER}"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -100,11 +100,11 @@ jobs:
           echo "skip=true" >> $GITHUB_OUTPUT
 
       - name: Install yq
-        if: steps.check.outputs.skip != 'true'
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         uses: mikefarah/yq@v4.44.3
 
       - name: Checkout helm-charts at release tag
-        if: steps.check.outputs.skip != 'true'
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag_name }}
@@ -113,10 +113,21 @@ jobs:
 
       - name: Read appVersion (image tag) from released chart
         id: image
-        if: steps.check.outputs.skip != 'true'
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
           CHART_NAME: ${{ steps.parse.outputs.chart_name }}
+          CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
         run: |
+          # Components that have no chart in this repo; use the release chart_version
+          # directly as the image tag (images are versioned alongside the chart).
+          USES_CHART_VERSION=(castai-live)
+          for name in "${USES_CHART_VERSION[@]}"; do
+            if [ "$name" = "$CHART_NAME" ]; then
+              echo "image_tag=${CHART_VERSION}" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+
           CHART_FILE="helm-charts/charts/${CHART_NAME}/Chart.yaml"
           if [ ! -f "$CHART_FILE" ]; then
             echo "Chart file '${CHART_FILE}' not found — image tag update will be skipped."
@@ -132,7 +143,7 @@ jobs:
           echo "image_tag=${APP_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Clone kubecast
-        if: steps.check.outputs.skip != 'true'
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
           GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
         run: |
@@ -146,46 +157,58 @@ jobs:
 
       - name: Update image tag in values.yaml
         id: bump_image
-        if: steps.check.outputs.skip != 'true' && steps.image.outputs.image_tag != ''
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true' && steps.image.outputs.image_tag != ''
         env:
           COMPONENT: ${{ steps.check.outputs.component }}
           IMAGE_TAG: ${{ steps.image.outputs.image_tag }}
         run: |
           VALUES="kubecast/castai-umbrella/chart/values.yaml"
 
-          # Components whose image tag lives at a non-standard path in values.yaml.
-          # All others use .autoscaler."<component>".image.tag.
-          declare -A IMAGE_TAG_PATH=(
+          # Space-separated yq paths per component.
+          # Components with multiple images (e.g. castai-live) list all paths here.
+          # All others default to .autoscaler."<component>".image.tag.
+          declare -A IMAGE_TAG_PATHS=(
             [castai-workload-autoscaler-exporter]='.autoscaler."castai-workload-autoscaler-exporter".exporter.image.tag'
+            [castai-live]='.autoscaler."castai-live".daemon.image.tag .autoscaler."castai-live".controller.image.tag .autoscaler."castai-live".tc.image.tag'
           )
-          YQ_PATH="${IMAGE_TAG_PATH[$COMPONENT]:-".autoscaler.\"${COMPONENT}\".image.tag"}"
+          YQ_PATHS_STR="${IMAGE_TAG_PATHS[$COMPONENT]:-".autoscaler.\"${COMPONENT}\".image.tag"}"
+          read -ra YQ_PATHS <<< "$YQ_PATHS_STR"
 
-          CURRENT=$(yq "$YQ_PATH" "$VALUES")
-          if [ "$CURRENT" = "null" ] || [ -z "$CURRENT" ]; then
-            echo "${COMPONENT} has no image tag at ${YQ_PATH} — skipping image bump."
+          CHANGED=false
+          OLD_TAGS=""
+          for YQ_PATH in "${YQ_PATHS[@]}"; do
+            CURRENT=$(yq "$YQ_PATH" "$VALUES")
+            if [ "$CURRENT" = "null" ] || [ -z "$CURRENT" ]; then
+              echo "${COMPONENT}: no value at ${YQ_PATH} — skipping."
+              continue
+            fi
+            if [ "$CURRENT" = "$IMAGE_TAG" ]; then
+              echo "${COMPONENT}: ${YQ_PATH} already at ${IMAGE_TAG} — no change."
+              continue
+            fi
+            yq -i "${YQ_PATH} = \"${IMAGE_TAG}\"" "$VALUES"
+            echo "Bumped ${COMPONENT} ${YQ_PATH}: ${CURRENT} -> ${IMAGE_TAG}"
+            CHANGED=true
+            OLD_TAGS="${OLD_TAGS:+$OLD_TAGS, }${CURRENT}"
+          done
+
+          if [ "$CHANGED" = "false" ]; then
             echo "changed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          if [ "$CURRENT" = "$IMAGE_TAG" ]; then
-            echo "Image tag is already ${IMAGE_TAG} — nothing to do."
-            echo "changed=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          yq -i "${YQ_PATH} = \"${IMAGE_TAG}\"" "$VALUES"
-          echo "Bumped ${COMPONENT} image: ${CURRENT} -> ${IMAGE_TAG}"
           echo "changed=true" >> $GITHUB_OUTPUT
-          echo "old_tag=${CURRENT}" >> $GITHUB_OUTPUT
+          echo "old_tag=${OLD_TAGS}" >> $GITHUB_OUTPUT
 
       # ── Update 2: subchart dependency versions (kent / anywhere / openshift) ──
 
       - name: Update subchart dependency versions
         id: bump_deps
-        if: steps.check.outputs.skip != 'true'
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
           CHART_NAME: ${{ steps.parse.outputs.chart_name }}
           CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
         run: |
+          set -euo pipefail
           SUBCHART_FILES=(
             "kubecast/castai-umbrella/chart/charts/kent/Chart.yaml"
             "kubecast/castai-umbrella/chart/charts/autoscaler-anywhere/Chart.yaml"
@@ -219,7 +242,7 @@ jobs:
 
       - name: Check if anything changed
         id: changed
-        if: steps.check.outputs.skip != 'true'
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         run: |
           IMAGE_CHANGED="${{ steps.bump_image.outputs.changed }}"
           DEPS_CHANGED="${{ steps.bump_deps.outputs.changed }}"
@@ -246,6 +269,15 @@ jobs:
           echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "tag=castai-${NEW_VERSION}" >> $GITHUB_OUTPUT
 
+      - name: Check env-var drift between component and umbrella
+        id: drift
+        if: steps.changed.outputs.any == 'true'
+        env:
+          CHART_NAME: ${{ steps.parse.outputs.chart_name }}
+          CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
+        run: |
+          bash helm-charts/.github/scripts/check-umbrella-drift.sh
+
       - name: Commit to kubecast and open GitLab MR
         if: steps.changed.outputs.any == 'true'
         env:
@@ -258,6 +290,7 @@ jobs:
           GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
           IMAGE_OLD_TAG: ${{ steps.bump_image.outputs.old_tag }}
           DEPS_SUMMARY: ${{ steps.bump_deps.outputs.summary }}
+          DRIFT_REPORT: ${{ steps.drift.outputs.drift_report }}
         run: |
           BRANCH="bump/castai-umbrella-${COMPONENT}-${CHART_VERSION}"
           cd kubecast
@@ -281,6 +314,12 @@ jobs:
             DESC_ROWS="${DESC_ROWS}\n| **Subchart deps updated** | ${DEPS_SUMMARY} |"
           fi
 
+          if [ -n "$RELEASE_TAG" ] && [ -n "$RELEASE_URL" ]; then
+            TRIGGER_LINE="Automated bump triggered by [helm-charts release ${RELEASE_TAG}](${RELEASE_URL})."
+          else
+            TRIGGER_LINE="Automated bump triggered by manual workflow_dispatch."
+          fi
+
           RESPONSE=$(curl -s -w "\n%{http_code}" \
             -X POST \
             -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
@@ -289,11 +328,11 @@ jobs:
             -d "$(jq -n \
               --arg source "$BRANCH" \
               --arg title "[castai-umbrella] Bump ${COMPONENT} to ${CHART_VERSION} (${RC_VERSION})" \
-              --arg release_tag "$RELEASE_TAG" \
-              --arg release_url "$RELEASE_URL" \
+              --arg trigger_line "$TRIGGER_LINE" \
               --arg rows "$DESC_ROWS" \
+              --arg drift "$DRIFT_REPORT" \
               '{ source_branch: $source, target_branch: "master", title: $title, labels: "team::identity",
-                 description: ("Automated bump triggered by [helm-charts release \($release_tag)](\($release_url)).\n\n| | |\n|---|---|\n" + $rows) }')")
+                 description: ($trigger_line + "\n\n| | |\n|---|---|\n" + $rows + if ($drift | length) > 0 then "\n\n---\n\n" + $drift else "" end) }')")
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
           BODY=$(echo "$RESPONSE" | head -n -1)
           if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -1,0 +1,306 @@
+name: Release umbrella RC
+
+# Fires when a tracked component chart is released in this repo.
+# Performs two complementary updates in the kubecast umbrella chart:
+#
+#  1. Image tag in values.yaml (autoscaler.<component>.image.tag)
+#     — for flat-template autoscaler/workload-autoscaler modes.
+#     Uses the chart's appVersion as the image tag.
+#
+#  2. Subchart dependency version in charts/kent/Chart.yaml,
+#     charts/autoscaler-anywhere/Chart.yaml, and
+#     charts/autoscaler-openshift/Chart.yaml
+#     — for kent / autoscaler-anywhere / autoscaler-openshift modes.
+#     Uses the chart version from the release tag.
+#
+# After either update, increments the RC counter in Chart.yaml and
+# publishes a GitHub prerelease tagged castai-0.0.0-rc<N>.
+#
+# Versioning: always publishes as 0.0.0-rc<N>. These are semver
+# prereleases that castctl's GetLatestChartVersion skips by default;
+# install a specific RC via `castctl cluster connect --umbrella-version 0.0.0-rcN`.
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Component release tag to simulate (e.g. castai-agent-0.158.0)'
+        required: true
+
+jobs:
+  release-umbrella-rc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse release tag
+        id: parse
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
+        run: |
+          VERSION=$(echo "$TAG" | grep -oP '\d+\.\d+\.\d+$' || true)
+          if [ -z "$VERSION" ]; then
+            echo "Tag '${TAG}' does not match <chart-name>-x.y.z — skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          CHART_NAME="${TAG%-${VERSION}}"
+
+          if ! echo "$CHART_NAME" | grep -qP '^[a-z0-9-]+$'; then
+            echo "Chart name '${CHART_NAME}' contains unexpected characters — skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Skip umbrella self-releases to avoid infinite loops.
+          if [ "$CHART_NAME" = "castai" ]; then
+            echo "Tag '${TAG}' is the umbrella itself — skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "chart_name=${CHART_NAME}" >> $GITHUB_OUTPUT
+          echo "chart_version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Check if component is tracked in umbrella
+        id: check
+        if: steps.parse.outputs.skip != 'true'
+        env:
+          CHART_NAME: ${{ steps.parse.outputs.chart_name }}
+        run: |
+          # Explicit allowlist — components that trigger an umbrella RC release.
+          # Covers both flat-template mode (image tag in values.yaml) and
+          # subchart deps (kent / autoscaler-anywhere / autoscaler-openshift).
+          TRACKED=(
+            castai-agent
+            castai-cluster-controller
+            castai-spot-handler
+            castai-kvisor
+            castai-evictor
+            castai-pod-pinner
+            castai-pod-mutator
+            castai-workload-autoscaler
+            castai-workload-autoscaler-exporter
+            castai-kentroller
+            castai-chart-upgrader
+            castai-live
+          )
+
+          for name in "${TRACKED[@]}"; do
+            if [ "$name" = "$CHART_NAME" ]; then
+              echo "component=${CHART_NAME}" >> $GITHUB_OUTPUT
+              echo "skip=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+
+          echo "Chart '${CHART_NAME}' is not tracked in the umbrella — skipping."
+          echo "skip=true" >> $GITHUB_OUTPUT
+
+      - name: Install yq
+        if: steps.check.outputs.skip != 'true'
+        uses: mikefarah/yq@v4.44.3
+
+      - name: Checkout helm-charts at release tag
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag_name }}
+          fetch-depth: 1
+          path: helm-charts
+
+      - name: Read appVersion (image tag) from released chart
+        id: image
+        if: steps.check.outputs.skip != 'true'
+        env:
+          CHART_NAME: ${{ steps.parse.outputs.chart_name }}
+        run: |
+          CHART_FILE="helm-charts/charts/${CHART_NAME}/Chart.yaml"
+          if [ ! -f "$CHART_FILE" ]; then
+            echo "Chart file '${CHART_FILE}' not found — image tag update will be skipped."
+            echo "image_tag=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          APP_VERSION=$(yq e '.appVersion' "$CHART_FILE")
+          if [ -z "$APP_VERSION" ] || [ "$APP_VERSION" = "null" ]; then
+            echo "No appVersion in ${CHART_FILE} — image tag update will be skipped."
+            echo "image_tag=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "image_tag=${APP_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Clone kubecast
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
+        run: |
+          git config --global credential.helper '!f() { echo "username=oauth2"; echo "password='"${GITLAB_TOKEN}"'"; }; f'
+          git clone https://gitlab.com/castai/kubecast.git kubecast
+          cd kubecast
+          git config user.email "ci@cast.ai"
+          git config user.name "GitHub Actions"
+
+      # ── Update 1: image tag in flat-template umbrella values.yaml ─────────────
+
+      - name: Update image tag in values.yaml
+        id: bump_image
+        if: steps.check.outputs.skip != 'true' && steps.image.outputs.image_tag != ''
+        env:
+          COMPONENT: ${{ steps.check.outputs.component }}
+          IMAGE_TAG: ${{ steps.image.outputs.image_tag }}
+        run: |
+          VALUES="kubecast/castai-umbrella/chart/values.yaml"
+
+          # Components whose image tag lives at a non-standard path in values.yaml.
+          # All others use .autoscaler."<component>".image.tag.
+          declare -A IMAGE_TAG_PATH=(
+            [castai-workload-autoscaler-exporter]='.autoscaler."castai-workload-autoscaler-exporter".exporter.image.tag'
+          )
+          YQ_PATH="${IMAGE_TAG_PATH[$COMPONENT]:-".autoscaler.\"${COMPONENT}\".image.tag"}"
+
+          CURRENT=$(yq "$YQ_PATH" "$VALUES")
+          if [ "$CURRENT" = "null" ] || [ -z "$CURRENT" ]; then
+            echo "${COMPONENT} has no image tag at ${YQ_PATH} — skipping image bump."
+            echo "changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [ "$CURRENT" = "$IMAGE_TAG" ]; then
+            echo "Image tag is already ${IMAGE_TAG} — nothing to do."
+            echo "changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          yq -i "${YQ_PATH} = \"${IMAGE_TAG}\"" "$VALUES"
+          echo "Bumped ${COMPONENT} image: ${CURRENT} -> ${IMAGE_TAG}"
+          echo "changed=true" >> $GITHUB_OUTPUT
+          echo "old_tag=${CURRENT}" >> $GITHUB_OUTPUT
+
+      # ── Update 2: subchart dependency versions (kent / anywhere / openshift) ──
+
+      - name: Update subchart dependency versions
+        id: bump_deps
+        if: steps.check.outputs.skip != 'true'
+        env:
+          CHART_NAME: ${{ steps.parse.outputs.chart_name }}
+          CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
+        run: |
+          SUBCHART_FILES=(
+            "kubecast/castai-umbrella/chart/charts/kent/Chart.yaml"
+            "kubecast/castai-umbrella/chart/charts/autoscaler-anywhere/Chart.yaml"
+            "kubecast/castai-umbrella/chart/charts/autoscaler-openshift/Chart.yaml"
+          )
+
+          CHANGED=false
+          BUMP_SUMMARY=""
+
+          for SUBCHART_FILE in "${SUBCHART_FILES[@]}"; do
+            [ -f "$SUBCHART_FILE" ] || continue
+
+            if yq ".dependencies[].name" "$SUBCHART_FILE" | grep -qx "$CHART_NAME"; then
+              CURRENT=$(yq ".dependencies[] | select(.name == \"$CHART_NAME\") | .version" "$SUBCHART_FILE")
+              if [ "$CURRENT" != "$CHART_VERSION" ]; then
+                yq -i "(.dependencies[] | select(.name == \"$CHART_NAME\") | .version) = \"${CHART_VERSION}\"" "$SUBCHART_FILE"
+                echo "Updated ${CHART_NAME} in ${SUBCHART_FILE}: ${CURRENT} -> ${CHART_VERSION}"
+                CHANGED=true
+                SUBCHART_NAME=$(yq '.name' "$SUBCHART_FILE")
+                BUMP_SUMMARY="${BUMP_SUMMARY:+$BUMP_SUMMARY, }${SUBCHART_NAME}"
+              else
+                echo "${CHART_NAME} in ${SUBCHART_FILE} already at ${CHART_VERSION} — skipping."
+              fi
+            fi
+          done
+
+          echo "changed=${CHANGED}" >> $GITHUB_OUTPUT
+          echo "summary=${BUMP_SUMMARY}" >> $GITHUB_OUTPUT
+
+      # ── Gate the rest on at least one change ──────────────────────────────────
+
+      - name: Check if anything changed
+        id: changed
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          IMAGE_CHANGED="${{ steps.bump_image.outputs.changed }}"
+          DEPS_CHANGED="${{ steps.bump_deps.outputs.changed }}"
+          if [ "$IMAGE_CHANGED" = "true" ] || [ "$DEPS_CHANGED" = "true" ]; then
+            echo "any=true" >> $GITHUB_OUTPUT
+          else
+            echo "any=false" >> $GITHUB_OUTPUT
+            echo "No changes — skipping RC release."
+          fi
+
+      - name: Increment RC version in Chart.yaml
+        id: rc
+        if: steps.changed.outputs.any == 'true'
+        run: |
+          CHART_YAML="kubecast/castai-umbrella/chart/Chart.yaml"
+          CURRENT=$(yq '.version' "$CHART_YAML")
+
+          RC_NUM=$(echo "$CURRENT" | grep -oP 'rc\K\d+$' || echo "0")
+          NEXT_RC=$((RC_NUM + 1))
+          NEW_VERSION="0.0.0-rc${NEXT_RC}"
+
+          yq -i ".version = \"${NEW_VERSION}\"" "$CHART_YAML"
+          echo "Bumped umbrella version: ${CURRENT} -> ${NEW_VERSION}"
+          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=castai-${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Commit to kubecast and open GitLab MR
+        if: steps.changed.outputs.any == 'true'
+        env:
+          COMPONENT: ${{ steps.check.outputs.component }}
+          IMAGE_TAG: ${{ steps.image.outputs.image_tag }}
+          CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
+          RC_VERSION: ${{ steps.rc.outputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
+          IMAGE_OLD_TAG: ${{ steps.bump_image.outputs.old_tag }}
+          DEPS_SUMMARY: ${{ steps.bump_deps.outputs.summary }}
+        run: |
+          BRANCH="bump/castai-umbrella-${COMPONENT}-${CHART_VERSION}"
+          cd kubecast
+
+          if git fetch origin "$BRANCH" 2>/dev/null; then
+            echo "Branch '${BRANCH}' already exists — skipping."
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH"
+          git add castai-umbrella/chart/
+          git commit -m "Bump ${COMPONENT} to ${CHART_VERSION} in umbrella (${RC_VERSION})"
+          git push origin HEAD:"$BRANCH"
+
+          # Build MR description rows dynamically.
+          DESC_ROWS="| **Component** | \`${COMPONENT}\` |\n| **Chart version** | \`${CHART_VERSION}\` |\n| **Umbrella RC** | \`${RC_VERSION}\` |"
+          if [ -n "$IMAGE_TAG" ] && [ -n "$IMAGE_OLD_TAG" ]; then
+            DESC_ROWS="${DESC_ROWS}\n| **Image tag** | \`${IMAGE_OLD_TAG}\` → \`${IMAGE_TAG}\` |"
+          fi
+          if [ -n "$DEPS_SUMMARY" ]; then
+            DESC_ROWS="${DESC_ROWS}\n| **Subchart deps updated** | ${DEPS_SUMMARY} |"
+          fi
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST \
+            -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "https://gitlab.com/api/v4/projects/castai%2Fkubecast/merge_requests" \
+            -d "$(jq -n \
+              --arg source "$BRANCH" \
+              --arg title "[castai-umbrella] Bump ${COMPONENT} to ${CHART_VERSION} (${RC_VERSION})" \
+              --arg release_tag "$RELEASE_TAG" \
+              --arg release_url "$RELEASE_URL" \
+              --arg rows "$DESC_ROWS" \
+              '{ source_branch: $source, target_branch: "master", title: $title, labels: "team::identity",
+                 description: ("Automated bump triggered by [helm-charts release \($release_tag)](\($release_url)).\n\n| | |\n|---|---|\n" + $rows) }')")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "GitLab MR creation failed (HTTP ${HTTP_CODE}): ${BODY}"
+            exit 1
+          fi
+          echo "MR created: $(echo "$BODY" | jq -r '.web_url')"
+
+      # Packaging and publishing happen in the kubecast GitLab CI pipeline
+      # (castai-umbrella/pipeline.yml) after the MR above is merged to master.


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Introduces a `release-umbrella-rc` GitHub Actions workflow that automatically prepares a kubecast umbrella chart RC when a tracked component chart is released. It bumps image tags in `values.yaml`, updates subchart dependency versions, increments the umbrella RC version, and opens a GitLab MR. Also adds a `check-umbrella-drift.sh` script to detect environment variable drift between component and umbrella Helm templates.

### Why
Eliminates manual steps required to propagate component chart releases into the kubecast umbrella chart, and adds automated env-var drift detection to catch mismatches between flat component templates and their folded umbrella equivalents.

### Key changes
- `.github/workflows/release-umbrella-rc.yml`: Workflow triggered on release publish or `workflow_dispatch`. Parses the tag to extract chart name and version, validates against an explicit allowlist (`TRACKED`), reads `appVersion` from `Chart.yaml` as the image tag (with special handling for `castai-live`), clones the kubecast repo, updates `autoscaler.<component>.image.tag` paths in `castai-umbrella/chart/values.yaml`, bumps matching dependency versions in `charts/kent/Chart.yaml`, `charts/autoscaler-anywhere/Chart.yaml`, and `charts/autoscaler-openshift/Chart.yaml`, increments the umbrella `version` to `0.0.0-rc<N>`, and creates a GitLab MR via API including a drift report.
- `.github/scripts/check-umbrella-drift.sh`: Bash script that extracts environment variable definitions from component Helm templates and the corresponding folded umbrella templates, computes symmetric differences with `comm`, and emits a markdown table report. Special-cases `castai-live` by pulling the chart from the public `castai-helm` registry. Writes the report to `GITHUB_OUTPUT` when available.

### Impact
- Umbrella RC versions follow the `0.0.0-rc<N>` prerelease scheme, which `castctl` skips by default unless a specific version is requested.
- Requires the `KUBECAST_GITLAB_TOKEN` repository secret for GitLab branch push and MR creation.
- Chart packaging and publishing still occur in the kubecast GitLab CI pipeline after the MR merges.