### PR TITLE
[castai-db-proxy] add chart version env variable

### DIFF
--- a/charts/castai-db-proxy/Chart.yaml
+++ b/charts/castai-db-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-proxy
 description: CAST AI database proxy cache deployment.
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/charts/castai-db-proxy/README.md
+++ b/charts/castai-db-proxy/README.md
@@ -1,6 +1,6 @@
 # castai-db-proxy
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database proxy cache deployment.
 

--- a/charts/castai-db-proxy/templates/deployment.yaml
+++ b/charts/castai-db-proxy/templates/deployment.yaml
@@ -80,6 +80,9 @@ spec:
               {{- else }}
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.apiKeySecretRef }}
               {{- end }}
+          env:
+            - name: CHART_VERSION
+              value: {{ .Chart.Version }}
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
### Summary
This PR ensures the chart version string is available to `castai-db-proxy` pods through the `CHART_VERSION` environment variable. This allows the pods to report which chart version they are running.

### Key Changes
- Added `CHART_VERSION` env var to `deployment.yaml`, set from the built-in `{{ .Chart.Version }}` Helm variable
- Bumped chart version `0.1.0` → `0.1.1`

---
### Kimchi Summary
### What changed
Exposes the deployed Helm chart version to the `castai-db-proxy` container via a new `CHART_VERSION` environment variable, and bumps the chart version to `0.1.1`.

### Why
Allows the application to report or log the currently running chart version for observability and troubleshooting.

### Key changes
- `charts/castai-db-proxy/templates/deployment.yaml`: Adds `env` block injecting `CHART_VERSION` set to `{{ .Chart.Version }}`
- `charts/castai-db-proxy/Chart.yaml`: Bumps chart version from `0.1.0` to `0.1.1`
- `charts/castai-db-proxy/README.md`: Updates version badge to `0.1.1`