### PR TITLE
Remove non-existent castai-omni-agent chart

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -46042,17 +46042,6 @@ entries:
     urls:
     - https://github.com/castai/helm-charts/releases/download/castai-node-storage-agent-0.1.0/castai-node-storage-agent-0.1.0.tgz
     version: 0.1.0
-  castai-omni-agent:
-  - apiVersion: v2
-    appVersion: 0.1.1
-    created: "2025-11-04T09:53:54.596718949Z"
-    description: A Helm chart for OMNI agent
-    digest: b5e8a25b43c35176dc0faf112d55d42289a715813a5c1d33748321cefbbb96fc
-    name: castai-omni-agent
-    type: application
-    urls:
-    - https://github.com/castai/helm-charts/releases/download/castai-omni-agent-0.1.1/castai-omni-agent-0.1.1.tgz
-    version: 0.1.1
   castai-pod-mutator:
   - apiVersion: v2
     appVersion: v0.15.1


### PR DESCRIPTION
Remove non-existent castai-omni-agent chart, because:
- The single `castai-omni-agent` Helm chart points to a URL that returns 404: https://github.com/castai/helm-charts/releases/download/castai-omni-agent-0.1.1/castai-omni-agent-0.1.1.tgz.
- It looks like the name `castai-omni-agent` is not used anymore and was replaced by `omni-agent`.

---
### Kimchi Summary
### What changed
Removes the `castai-omni-agent` chart entry from the Helm repository `index.yaml`.

### Why
The referenced `castai-omni-agent` release does not exist, so the repository index was pointing to a non-existent artifact.

### Key changes
- `index.yaml`: Removed the `castai-omni-agent` entry (version `0.1.1`) to eliminate the broken reference.