### PR TITLE
[castai-umbrella] Disable vpc cni in kent mode

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.39.14
+version: 0.40.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -9,11 +9,11 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 | Repository | Name | Version |
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.6 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.82 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.86 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.5 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.5 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -9,15 +9,15 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 | Repository | Name | Version |
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.6 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.82 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.161.4 |
-| https://castai.github.io/helm-charts | castai-live | 0.105.0 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.86 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.162.2 |
+| https://castai.github.io/helm-charts | castai-live | 0.106.1 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.5 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.5 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -10,14 +10,14 @@ Wrapper chart for CAST AI Kent profile.
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.2.0 |
-| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.6 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.159 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.161.4 |
-| https://castai.github.io/helm-charts | castai-live | 0.105.0 |
+| https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.161 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.162.2 |
+| https://castai.github.io/helm-charts | castai-live | 0.106.1 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.5 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.5 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values
@@ -49,7 +49,7 @@ Wrapper chart for CAST AI Kent profile.
 | castai-kvisor.controller.extraArgs.cluster-proxy-enabled | string | `"true"` |  |
 | castai-kvisor.controller.extraArgs.log-level | string | `"info"` |  |
 | castai-kvisor.enabled | bool | `true` |  |
-| castai-live.castai-aws-vpc-cni.enabled | bool | `true` |  |
+| castai-live.castai-aws-vpc-cni.enabled | bool | `false` |  |
 | castai-live.castai.apiKeySecretRef | string | `""` |  |
 | castai-live.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-live.controller.replicaCount | int | `0` |  |

--- a/charts/castai-umbrella/charts/kent/values.yaml
+++ b/charts/castai-umbrella/charts/kent/values.yaml
@@ -47,7 +47,7 @@ castai-live:
     apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
   castai-aws-vpc-cni:
-    enabled: true
+    enabled: false
   daemon:
     labelNodeSubnet: true
   controller:


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the umbrella chart version to `0.40.0`, updates dependency versions across the `kent`, `autoscaler`, and `autoscaler-anywhere` profiles, and disables the AWS VPC CNI integration in the `kent` profile's `castai-live` subchart.

### Key changes
- `charts/castai-umbrella/Chart.yaml`: bumped chart version from `0.39.14` to `0.40.0`.
- `charts/castai-umbrella/charts/kent/values.yaml`: changed `castai-live.castai-aws-vpc-cni.enabled` from `true` to `false`.
- `charts/castai-umbrella/charts/kent/README.md`: updated documented dependency versions and reflected the new `castai-aws-vpc-cni` default.
- `charts/castai-umbrella/charts/autoscaler/README.md`: updated documented dependency versions for `castai-cluster-controller`, `castai-evictor`, `castai-kvisor`, `castai-live`, `castai-workload-autoscaler`, and `castai-workload-autoscaler-exporter`.
- `charts/castai-umbrella/charts/autoscaler-anywhere/README.md`: updated documented dependency versions for `castai-cluster-controller`, `castai-evictor`, `castai-workload-autoscaler`, and `castai-workload-autoscaler-exporter`.

### Impact
Users deploying the `kent` profile will no longer have `castai-aws-vpc-cni` enabled by default. If AWS VPC CNI functionality is required, explicitly set `castai-live.castai-aws-vpc-cni.enabled` to `true` in your custom values.