### PR TITLE
[castai-db-proxy] Add K8S_NAMESPACE and K8S_DEPLOYMENT env vars

### DIFF
--- a/charts/castai-db-proxy/Chart.yaml
+++ b/charts/castai-db-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-proxy
 description: CAST AI database proxy cache deployment.
 type: application
-version: 0.1.1
+version: 0.1.2

--- a/charts/castai-db-proxy/README.md
+++ b/charts/castai-db-proxy/README.md
@@ -1,6 +1,6 @@
 # castai-db-proxy
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database proxy cache deployment.
 

--- a/charts/castai-db-proxy/templates/deployment.yaml
+++ b/charts/castai-db-proxy/templates/deployment.yaml
@@ -83,6 +83,12 @@ spec:
           env:
             - name: CHART_VERSION
               value: {{ .Chart.Version }}
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_DEPLOYMENT
+              value: {{ include "name" . }}
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
### Summary
This PR adds `K8S_NAMESPACE` and `K8S_DEPLOYMENT` environment variables to the `castai-db-proxy` deployment, aligning it with `castai-db-agent` and `castai-db-optimizer`.

---
### Kimchi Summary
### What changed
Bumps the `castai-db-proxy` Helm chart to `0.1.2` and injects the pod's namespace and deployment name into the proxy container as environment variables.

### Why
Enables the database proxy to identify its Kubernetes runtime environment for configuration or observability.

### Key changes
- `charts/castai-db-proxy/Chart.yaml`: Bumped chart version from `0.1.1` to `0.1.2`.
- `charts/castai-db-proxy/README.md`: Updated the version badge to `0.1.2`.
- `charts/castai-db-proxy/templates/deployment.yaml`: Added `K8S_NAMESPACE` environment variable sourced from the Downward API (`metadata.namespace`).
- `charts/castai-db-proxy/templates/deployment.yaml`: Added `K8S_DEPLOYMENT` environment variable set to the release name via `include "name" .`.