### PR TITLE
[castai-umbrella] bump kent to v0.15.0

### DIFF
--- a/charts/castai-umbrella/Chart.lock
+++ b/charts/castai-umbrella/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kent
   repository: file://charts/kent
-  version: 0.14.0
+  version: 0.15.0
 - name: autoscaler-anywhere
   repository: file://charts/autoscaler-anywhere
   version: 0.5.0
@@ -11,5 +11,5 @@ dependencies:
 - name: autoscaler
   repository: file://charts/autoscaler
   version: 0.2.0
-digest: sha256:49d34c9978c18f21f30f8d4c97894be20e93fe6806c150fcd8e9ec1c5b4a7135
-generated: "2026-06-17T09:03:13.787098+02:00"
+digest: sha256:3005755f3a8125a106984d969a12469a2c3027889a3db26f3bc03c072dbdbd12
+generated: "2026-06-23T12:24:25.246983+03:00"

--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.40.12
+version: 0.41.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -10,10 +10,10 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.86 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.88 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.8 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.8 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -10,14 +10,14 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.86 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.162.2 |
-| https://castai.github.io/helm-charts | castai-live | 0.106.1 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.88 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.163.0 |
+| https://castai.github.io/helm-charts | castai-live | 0.107.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |
-| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.4 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.8 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.8 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/kent/Chart.lock
+++ b/charts/castai-umbrella/charts/kent/Chart.lock
@@ -4,33 +4,33 @@ dependencies:
   version: 0.158.0
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
-  version: 0.92.6
+  version: 0.92.7
 - name: castai-kentroller
   repository: https://castai.github.io/helm-charts
-  version: 0.1.159
+  version: 0.1.163
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 1.2.5
+  version: 1.2.8
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 1.2.5
+  version: 1.2.8
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.105.0
+  version: 0.107.0
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
   version: 0.15.1
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
-  version: 0.35.2
+  version: 0.35.4
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
   version: 3.13.0
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.161.4
+  version: 1.163.0
 - name: castai-chart-upgrader
   repository: https://castai.github.io/helm-charts
   version: 0.2.0
-digest: sha256:ea8ceebe9f112561e510ff0c26ffdf00f97b130c55f671c723a57c7f10d2bf9c
-generated: "2026-06-17T09:02:35.71492+02:00"
+digest: sha256:0084bbf5f74b599e53eed93b1cc07b88c59d1369589a6b747a1e6f3a6071ad05
+generated: "2026-06-23T12:24:18.32387+03:00"

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kent
 description: Wrapper chart for CAST AI Kent profile.
 type: application
-version: 0.14.0
+version: 0.15.0
 dependencies:
   - name: castai-agent
     version: "0.158.0"

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -1,6 +1,6 @@
 # kent
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Kent profile.
 
@@ -11,13 +11,13 @@ Wrapper chart for CAST AI Kent profile.
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.2.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.161 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.162.2 |
-| https://castai.github.io/helm-charts | castai-live | 0.106.1 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.163 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.163.0 |
+| https://castai.github.io/helm-charts | castai-live | 0.107.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
-| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.4 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.8 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.8 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the `kent` sub-chart from `0.14.0` to `0.15.0` and propagates updated CAST AI component dependencies to the umbrella chart and README docs.

### Key changes
- `charts/castai-umbrella/charts/kent/Chart.yaml`: Bump `kent` chart version from `0.14.0` to `0.15.0`
- `charts/castai-umbrella/charts/kent/Chart.lock`: Update sub-chart dependencies including `castai-kentroller` (`0.1.163`), `castai-kvisor` (`1.163.0`), `castai-live` (`0.107.0`), `castai-spot-handler` (`0.35.4`), `castai-workload-autoscaler` (`1.2.8`), `castai-workload-autoscaler-exporter` (`1.2.8`), and `castai-cluster-controller` (`0.92.7`)
- `charts/castai-umbrella/Chart.yaml` and `Chart.lock`: Bump umbrella chart version from `0.40.12` to `0.41.0` and update `kent` dependency to `0.15.0`
- `charts/castai-umbrella/charts/autoscaler/README.md` and `charts/castai-umbrella/charts/autoscaler-anywhere/README.md`: Refresh documented dependency versions to match resolved chart locks