### PR TITLE
[castai-umbrella] Let live autodiscover vpc cni

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.40.12
+version: 0.41.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -10,10 +10,10 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.86 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.88 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.8 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.8 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -10,14 +10,14 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.86 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.162.2 |
-| https://castai.github.io/helm-charts | castai-live | 0.106.1 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.88 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.163.0 |
+| https://castai.github.io/helm-charts | castai-live | 0.107.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |
-| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.4 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.8 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.8 |
 
 ## Values
 
@@ -40,7 +40,6 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 | castai-kvisor.castai.clusterIdConfigMapKeyRef.key | string | `"CLUSTER_ID"` |  |
 | castai-kvisor.castai.clusterIdConfigMapKeyRef.name | string | `"castai-agent-metadata"` |  |
 | castai-kvisor.fullnameOverride | string | `"castai-kvisor"` |  |
-| castai-live.castai-aws-vpc-cni.enabled | bool | `false` |  |
 | castai-live.castai.apiKeySecretRef | string | `""` |  |
 | castai-live.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-live.controller.replicaCount | int | `2` |  |

--- a/charts/castai-umbrella/charts/autoscaler/values.yaml
+++ b/charts/castai-umbrella/charts/autoscaler/values.yaml
@@ -92,8 +92,6 @@ castai-live:
   castai:
     apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
-  castai-aws-vpc-cni:
-    enabled: false
   daemon:
     labelNodeSubnet: false
   controller:

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -11,13 +11,13 @@ Wrapper chart for CAST AI Kent profile.
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.2.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.161 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.162.2 |
-| https://castai.github.io/helm-charts | castai-live | 0.106.1 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.163 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.163.0 |
+| https://castai.github.io/helm-charts | castai-live | 0.107.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.1 |
-| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.2 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.6 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.6 |
+| https://castai.github.io/helm-charts | castai-spot-handler | 0.35.4 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.2.8 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.2.8 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values
@@ -49,7 +49,6 @@ Wrapper chart for CAST AI Kent profile.
 | castai-kvisor.controller.extraArgs.cluster-proxy-enabled | string | `"true"` |  |
 | castai-kvisor.controller.extraArgs.log-level | string | `"info"` |  |
 | castai-kvisor.enabled | bool | `true` |  |
-| castai-live.castai-aws-vpc-cni.enabled | bool | `false` |  |
 | castai-live.castai.apiKeySecretRef | string | `""` |  |
 | castai-live.castai.configMapRef | string | `"castai-agent-metadata"` |  |
 | castai-live.controller.replicaCount | int | `0` |  |

--- a/charts/castai-umbrella/charts/kent/values.yaml
+++ b/charts/castai-umbrella/charts/kent/values.yaml
@@ -46,8 +46,6 @@ castai-live:
   castai:
     apiKeySecretRef: ""
     configMapRef: castai-agent-metadata
-  castai-aws-vpc-cni:
-    enabled: false
   daemon:
     labelNodeSubnet: true
   controller:


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps CAST AI subchart dependencies across the umbrella chart and removes the explicit `castai-aws-vpc-cni.enabled: false` override from the `autoscaler` and `kent` profiles, allowing `castai-live` to auto-discover AWS VPC CNI.

### Why
The hard-coded `castai-aws-vpc-cni.enabled: false` setting prevented `castai-live` from automatically detecting and configuring itself for AWS VPC CNI environments. Removing it enables automatic discovery.

### Key changes
- `charts/castai-umbrella/Chart.yaml`: Bumps umbrella chart version to `0.41.0`.
- `charts/castai-umbrella/charts/autoscaler/values.yaml`: Removes `castai-aws-vpc-cni.enabled: false` from `castai-live` values.
- `charts/castai-umbrella/charts/kent/values.yaml`: Removes `castai-aws-vpc-cni.enabled: false` from `castai-live` values.
- `charts/castai-umbrella/charts/autoscaler/README.md` and `charts/castai-umbrella/charts/kent/README.md`: Removes documented `castai-live.castai-aws-vpc-cni.enabled` value and updates subchart dependency versions.
- `charts/castai-umbrella/charts/autoscaler-anywhere/README.md`: Bumps `castai-evictor`, `castai-workload-autoscaler`, and `castai-workload-autoscaler-exporter` versions.
- All affected profiles: Bumps `castai-kvisor` to `1.163.1`, `castai-live` to `0.107.1`, `castai-spot-handler` to `0.35.4`, `castai-kentroller` to `0.1.163`, `castai-evictor` to `0.35.88`, and workload autoscaler components to `1.2.8`.

### Impact
The `autoscaler` and `kent` profiles no longer force `castai-live` AWS VPC CNI support off. On clusters where VPC CNI is present, `castai-live` will now auto-enable it rather than remaining disabled.