### PR TITLE
[castai-umbrella] Force new umbrella release - safety net

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.41.0
+version: 0.42.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the `castai-umbrella` Helm chart version from `0.41.0` to `0.42.0` to publish a new release.

### Key changes
- `charts/castai-umbrella/Chart.yaml`: incremented `version` from `0.41.0` to `0.42.0`