### PR TITLE
[castai-umbrella] Fix tag bumps and diff checker

### DIFF
--- a/.github/scripts/bump-chart-dep.py
+++ b/.github/scripts/bump-chart-dep.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+Update a dependency's version in a Chart.yaml dependencies list,
+preserving the file's exact formatting.
+
+Usage: bump-chart-dep.py <dep-name> <new-version> <Chart.yaml-path>
+"""
+import sys
+
+name, version, path = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).readlines()
+for i, line in enumerate(lines):
+    if f'name: {name}' in line:
+        for j in range(i + 1, min(i + 6, len(lines))):
+            stripped = lines[j].lstrip()
+            if stripped.startswith('version:'):
+                indent = len(lines[j]) - len(stripped)
+                lines[j] = ' ' * indent + f'version: {version}\n'
+                break
+        break
+open(path, 'w').writelines(lines)

--- a/.github/scripts/bump-yaml-field.py
+++ b/.github/scripts/bump-yaml-field.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""
+Set a value at a yq-style dotted path in a YAML file, preserving formatting.
+
+Usage: bump-yaml-field.py <path> <new-value> <file>
+
+  path       yq-style path, e.g. .version or .autoscaler."castai-agent".image.tag
+  new-value  string value to set
+  file       YAML file to update in-place
+"""
+import sys
+import re
+from ruamel.yaml import YAML
+
+path_str, new_value, file_path = sys.argv[1], sys.argv[2], sys.argv[3]
+keys = [a or b for a, b in re.findall(r'"([^"]+)"|([a-zA-Z0-9_-]+)', path_str.lstrip('.'))]
+
+yaml = YAML()
+yaml.preserve_quotes = True
+with open(file_path) as f:
+    doc = yaml.load(f)
+obj = doc
+for key in keys[:-1]:
+    obj = obj[key]
+obj[keys[-1]] = new_value
+with open(file_path, 'w') as f:
+    yaml.dump(doc, f)

--- a/.github/scripts/check-umbrella-drift.sh
+++ b/.github/scripts/check-umbrella-drift.sh
@@ -35,14 +35,20 @@ if [ "$CHART_NAME" = "castai-live" ]; then
     --untardir "$LIVE_UNTAR_DIR"
   COMP_TEMPLATES="${LIVE_UNTAR_DIR}/castai-live/templates"
 else
-  # Locate the chart inside kubecast/services/ by matching the chart name in Chart.yaml.
+  # Locate the chart by matching the chart name in Chart.yaml.
+  # Most components live in kubecast/services/; evictor and chart-upgrader
+  # live in the helm-charts repo (tag checkout at helm-charts/).
   CHART_YAML_PATH=$(find kubecast/services -name "Chart.yaml" -exec grep -l "^name: ${CHART_NAME}$" {} \; 2>/dev/null | head -1 || true)
+
+  if [ -z "$CHART_YAML_PATH" ] && [ -d "helm-charts/charts/${CHART_NAME}" ]; then
+    CHART_YAML_PATH="helm-charts/charts/${CHART_NAME}/Chart.yaml"
+  fi
+
   if [ -z "$CHART_YAML_PATH" ]; then
     cat <<MD
 ## Env-var drift: \`${CHART_NAME}\`
 
-> Chart not found under \`kubecast/services/\` — skipping drift check.
-> This component may be a subchart dependency only (e.g. castai-kentroller, castai-chart-upgrader).
+> Chart not found in \`kubecast/services/\` or \`helm-charts/charts/\` — skipping drift check.
 MD
     exit 0
   fi
@@ -72,7 +78,15 @@ fi
 
 extract_env_vars() {
   local dir="$1"
-  grep -rh '^\s*- name:\s*[A-Z_]' "$dir" \
+  # Only scan files that define a DaemonSet or Deployment — skip infrastructure
+  # templates (clickhouse, secrets, standalone jobs, etc.) that contain env vars
+  # not applicable to the umbrella workload containers.
+  while IFS= read -r -d '' f; do
+    if grep -q 'kind: DaemonSet\|kind: Deployment' "$f"; then
+      cat "$f"
+    fi
+  done < <(find "$dir" -name '*.yaml' -print0) \
+    | grep '^\s*- name:\s*[A-Z_]' \
     | sed 's/.*- name:[[:space:]]*//' \
     | sed 's/[[:space:]]*$//' \
     | sort -u

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -111,36 +111,13 @@ jobs:
           fetch-depth: 1
           path: helm-charts
 
-      - name: Read appVersion (image tag) from released chart
-        id: image
+      - name: Checkout helm-charts at HEAD (for scripts)
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
-        env:
-          CHART_NAME: ${{ steps.parse.outputs.chart_name }}
-          CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
-        run: |
-          # Components that have no chart in this repo; use the release chart_version
-          # directly as the image tag (images are versioned alongside the chart).
-          USES_CHART_VERSION=(castai-live)
-          for name in "${USES_CHART_VERSION[@]}"; do
-            if [ "$name" = "$CHART_NAME" ]; then
-              echo "image_tag=${CHART_VERSION}" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-          done
-
-          CHART_FILE="helm-charts/charts/${CHART_NAME}/Chart.yaml"
-          if [ ! -f "$CHART_FILE" ]; then
-            echo "Chart file '${CHART_FILE}' not found — image tag update will be skipped."
-            echo "image_tag=" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          APP_VERSION=$(yq e '.appVersion' "$CHART_FILE")
-          if [ -z "$APP_VERSION" ] || [ "$APP_VERSION" = "null" ]; then
-            echo "No appVersion in ${CHART_FILE} — image tag update will be skipped."
-            echo "image_tag=" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          echo "image_tag=${APP_VERSION}" >> $GITHUB_OUTPUT
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          path: helm-charts-head
 
       - name: Clone kubecast
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
@@ -152,6 +129,64 @@ jobs:
           cd kubecast
           git config user.email "ci@cast.ai"
           git config user.name "GitHub Actions"
+
+      - name: Read appVersion (image tag) from released chart
+        id: image
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
+        env:
+          CHART_NAME: ${{ steps.parse.outputs.chart_name }}
+          CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
+        run: |
+          # castai-live templates come from the clm repo — no chart source available;
+          # its images are versioned identically to the chart release.
+          if [ "$CHART_NAME" = "castai-live" ]; then
+            echo "image_tag=${CHART_VERSION}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Chart source directories — paths relative to the workspace root.
+          # evictor and chart-upgrader live in the helm-charts repo (this repo, tag checkout).
+          # Everything else lives in kubecast/services/.
+          declare -A CHART_DIRS=(
+            [castai-agent]="kubecast/services/castai-agent/chart"
+            [castai-cluster-controller]="kubecast/services/cluster-controller/charts"
+            [castai-kvisor]="kubecast/services/kvisor/chart"
+            [castai-pod-mutator]="kubecast/services/pod-mutator/chart"
+            [castai-pod-pinner]="kubecast/services/castai-pod-pinner/chart"
+            [castai-spot-handler]="kubecast/services/spot-handler/charts"
+            [castai-kentroller]="kubecast/services/kentroller/charts"
+            [castai-workload-autoscaler]="kubecast/services/workload-autoscaler/charts/castai-workload-autoscaler"
+            [castai-workload-autoscaler-exporter]="kubecast/services/workload-autoscaler/charts/castai-workload-autoscaler-exporter"
+            [castai-evictor]="helm-charts/charts/castai-evictor"
+            [castai-chart-upgrader]="helm-charts/charts/castai-chart-upgrader"
+          )
+
+          CHART_DIR="${CHART_DIRS[$CHART_NAME]}"
+          if [ -z "$CHART_DIR" ]; then
+            echo "No chart source mapping for ${CHART_NAME} — image tag update will be skipped."
+            echo "image_tag=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CHART_FILE="${CHART_DIR}/Chart.yaml"
+          if [ ! -f "$CHART_FILE" ]; then
+            echo "Chart file not found: ${CHART_FILE} — image tag update will be skipped."
+            echo "image_tag=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          APP_VERSION=$(yq e '.appVersion' "$CHART_FILE")
+          if [ -z "$APP_VERSION" ] || [ "$APP_VERSION" = "null" ]; then
+            echo "No appVersion in ${CHART_FILE} — image tag update will be skipped."
+            echo "image_tag=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "image_tag=${APP_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Install Python dependencies
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
+        run: pip install --quiet ruamel.yaml
 
       # ── Update 1: image tag in flat-template umbrella values.yaml ─────────────
 
@@ -186,7 +221,7 @@ jobs:
               echo "${COMPONENT}: ${YQ_PATH} already at ${IMAGE_TAG} — no change."
               continue
             fi
-            yq -i "${YQ_PATH} = \"${IMAGE_TAG}\"" "$VALUES"
+            python3 helm-charts-head/.github/scripts/bump-yaml-field.py "$YQ_PATH" "$IMAGE_TAG" "$VALUES"
             echo "Bumped ${COMPONENT} ${YQ_PATH}: ${CURRENT} -> ${IMAGE_TAG}"
             CHANGED=true
             OLD_TAGS="${OLD_TAGS:+$OLD_TAGS, }${CURRENT}"
@@ -224,7 +259,8 @@ jobs:
             if yq ".dependencies[].name" "$SUBCHART_FILE" | grep -qx "$CHART_NAME"; then
               CURRENT=$(yq ".dependencies[] | select(.name == \"$CHART_NAME\") | .version" "$SUBCHART_FILE")
               if [ "$CURRENT" != "$CHART_VERSION" ]; then
-                yq -i "(.dependencies[] | select(.name == \"$CHART_NAME\") | .version) = \"${CHART_VERSION}\"" "$SUBCHART_FILE"
+                python3 helm-charts-head/.github/scripts/bump-chart-dep.py \
+                  "$CHART_NAME" "$CHART_VERSION" "$SUBCHART_FILE"
                 echo "Updated ${CHART_NAME} in ${SUBCHART_FILE}: ${CURRENT} -> ${CHART_VERSION}"
                 CHANGED=true
                 SUBCHART_NAME=$(yq '.name' "$SUBCHART_FILE")
@@ -237,6 +273,34 @@ jobs:
 
           echo "changed=${CHANGED}" >> $GITHUB_OUTPUT
           echo "summary=${BUMP_SUMMARY}" >> $GITHUB_OUTPUT
+
+      # ── Validate modified YAML files ──────────────────────────────────────────
+
+      - name: Validate modified YAML files
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          FILES=(
+            "kubecast/castai-umbrella/chart/values.yaml"
+            "kubecast/castai-umbrella/chart/Chart.yaml"
+            "kubecast/castai-umbrella/chart/charts/kent/Chart.yaml"
+            "kubecast/castai-umbrella/chart/charts/autoscaler-anywhere/Chart.yaml"
+            "kubecast/castai-umbrella/chart/charts/autoscaler-openshift/Chart.yaml"
+          )
+          FAILED=false
+          for f in "${FILES[@]}"; do
+            [ -f "$f" ] || continue
+            if yq . "$f" > /dev/null 2>&1; then
+              echo "OK: $f"
+            else
+              echo "ERROR: $f is not valid YAML"
+              FAILED=true
+            fi
+          done
+          if [ "$FAILED" = "true" ]; then
+            echo "One or more YAML files are invalid — aborting before commit."
+            exit 1
+          fi
 
       # ── Gate the rest on at least one change ──────────────────────────────────
 
@@ -264,7 +328,8 @@ jobs:
           NEXT_RC=$((RC_NUM + 1))
           NEW_VERSION="0.0.0-rc${NEXT_RC}"
 
-          yq -i ".version = \"${NEW_VERSION}\"" "$CHART_YAML"
+          python3 helm-charts-head/.github/scripts/bump-yaml-field.py \
+            ".version" "$NEW_VERSION" "$CHART_YAML"
           echo "Bumped umbrella version: ${CURRENT} -> ${NEW_VERSION}"
           echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "tag=castai-${NEW_VERSION}" >> $GITHUB_OUTPUT
@@ -276,7 +341,7 @@ jobs:
           CHART_NAME: ${{ steps.parse.outputs.chart_name }}
           CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
         run: |
-          bash helm-charts/.github/scripts/check-umbrella-drift.sh
+          bash helm-charts-head/.github/scripts/check-umbrella-drift.sh
 
       - name: Commit to kubecast and open GitLab MR
         if: steps.changed.outputs.any == 'true'


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes the umbrella RC release workflow to correctly bump image tags and chart dependencies for components hosted in this repository (`castai-evictor`, `castai-chart-upgrader`), replaces `yq` in-place edits with formatting-preserving Python scripts, and adds a YAML validation gate before committing to `kubecast`.

### Why
The workflow previously failed to locate chart sources for evictor and chart-upgrader, and `yq` in-place modifications were altering YAML formatting (quotes, indentation) unnecessarily. The drift checker also scanned infrastructure templates and only looked under `kubecast/services/`.

### Key changes
- `.github/scripts/bump-chart-dep.py` — New helper script to update a dependency's `version` in `Chart.yaml` while preserving exact file formatting.
- `.github/scripts/bump-yaml-field.py` — New helper script using `ruamel.yaml` that sets a value at a dotted path (e.g. `.autoscaler."castai-agent".image.tag`) without reformatting the file.
- `.github/scripts/check-umbrella-drift.sh` — Falls back to `helm-charts/charts/${CHART_NAME}` when a chart is not found in `kubecast/services/`; restricts env-var extraction to files containing `kind: DaemonSet` or `kind: Deployment`.
- `.github/workflows/release-umbrella-rc.yml` — 
  - Maps chart source directories explicitly, including `castai-evictor` and `castai-chart-upgrader` under `helm-charts/charts/`.
  - Checks out the repo `HEAD` into `helm-charts-head` so the workflow can invoke the latest helper scripts even when triggered from an old tag.
  - Replaces all `yq -i` calls with `bump-yaml-field.py` and `bump-chart-dep.py`.
  - Adds a pre-commit "Validate modified YAML files" step that runs `yq` against modified umbrella files and fails the job if any are invalid.

### Impact
- Workflow now installs the Python package `ruamel.yaml` at runtime.
- YAML formatting (comments, quotes, indentation) in modified files is preserved.
- Drift checks and image-tag bumps now work correctly for `castai-evictor` and `castai-chart-upgrader`.
- Invalid YAML modifications are caught before the commit to `kubecast` is made.