### PR TITLE
finetune promt for umbrella template drift check

### DIFF
--- a/.github/scripts/bump-yaml-field.py
+++ b/.github/scripts/bump-yaml-field.py
@@ -1,27 +1,109 @@
 #!/usr/bin/env python3
 """
-Set a value at a yq-style dotted path in a YAML file, preserving formatting.
+Set a scalar value at a yq-style dotted path in a YAML file using
+line-by-line string replacement. Does NOT parse or re-serialize the YAML,
+so the file's formatting, comments, and ordering are completely preserved.
 
 Usage: bump-yaml-field.py <path> <new-value> <file>
 
-  path       yq-style path, e.g. .version or .autoscaler."castai-agent".image.tag
-  new-value  string value to set
+  path       yq-style path, e.g.:
+               .version
+               .autoscaler."castai-agent".image.tag
+               .autoscaler."castai-live".daemon.image.tag
+  new-value  string value to write
   file       YAML file to update in-place
+
+Algorithm:
+  Walks the key segments top-to-bottom, tracking indentation to stay in the
+  right nested block. When the final key is found at the expected indent level,
+  replaces only its value — preserving surrounding quotes if present.
+  Exits 1 if the path cannot be found.
 """
-import sys
+
 import re
-from ruamel.yaml import YAML
+import sys
 
-path_str, new_value, file_path = sys.argv[1], sys.argv[2], sys.argv[3]
-keys = [a or b for a, b in re.findall(r'"([^"]+)"|([a-zA-Z0-9_-]+)', path_str.lstrip('.'))]
 
-yaml = YAML()
-yaml.preserve_quotes = True
-with open(file_path) as f:
-    doc = yaml.load(f)
-obj = doc
-for key in keys[:-1]:
-    obj = obj[key]
-obj[keys[-1]] = new_value
-with open(file_path, 'w') as f:
-    yaml.dump(doc, f)
+def parse_keys(path_str: str) -> list[str]:
+    """Parse a yq-style dotted path into a list of key strings."""
+    return [a or b for a, b in re.findall(r'"([^"]+)"|([a-zA-Z0-9_-]+)', path_str.lstrip("."))]
+
+
+def find_key_line(lines: list[str], key: str, start: int, min_indent: int, max_indent: int | None) -> tuple[int, int]:
+    """
+    Find the next line matching `<indent><key>:` within [start, end).
+    indent must be >= min_indent and (if max_indent set) == max_indent.
+    Returns (line_index, indent_of_that_line).
+    Raises ValueError if not found.
+    """
+    pattern = re.compile(rf'^( *){re.escape(key)}\s*:')
+    for i in range(start, len(lines)):
+        m = pattern.match(lines[i])
+        if not m:
+            continue
+        indent = len(m.group(1))
+        if indent < min_indent:
+            # We've de-dented past where the key could live — stop searching.
+            raise ValueError(f"Key '{key}' not found (de-indented past min_indent={min_indent} at line {i+1})")
+        if max_indent is not None and indent != max_indent:
+            continue
+        return i, indent
+    raise ValueError(f"Key '{key}' not found after line {start+1}")
+
+
+def replace_scalar_value(lines: list[str], line_idx: int, new_value: str) -> None:
+    """
+    Replace the scalar value on a `key: <value>` line in-place.
+    Preserves surrounding quotes if the original value was quoted.
+    Handles both inline values (key: value) and block scalars (key: |).
+    """
+    line = lines[line_idx]
+    # Match:  <indent><key>: ["']?<value>["']?<trailing>
+    m = re.match(r'^( *\S[^:]*:\s*)(["\']?)(.+?)(["\']?)(\s*)$', line)
+    if not m:
+        raise ValueError(f"Cannot parse scalar on line {line_idx+1}: {line!r}")
+
+    prefix, open_q, _old_val, close_q, trailing = m.groups()
+
+    # If original had matching quotes, preserve them; otherwise write bare.
+    if open_q and open_q == close_q:
+        lines[line_idx] = f"{prefix}{open_q}{new_value}{close_q}{trailing}\n"
+    else:
+        lines[line_idx] = f"{prefix}{new_value}{trailing}\n"
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <path> <new-value> <file>", file=sys.stderr)
+        sys.exit(1)
+
+    path_str, new_value, file_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    keys = parse_keys(path_str)
+
+    with open(file_path) as f:
+        lines = f.readlines()
+
+    cursor = 0          # current search start line
+    indent = 0          # expected indent of next key (None = any)
+    exact_indent = None # None until we've seen the first key
+
+    for depth, key in enumerate(keys):
+        is_last = depth == len(keys) - 1
+        line_idx, found_indent = find_key_line(lines, key, cursor, indent, exact_indent)
+
+        if is_last:
+            replace_scalar_value(lines, line_idx, new_value)
+        else:
+            # Descend: next key must be indented more than current key.
+            cursor = line_idx + 1
+            indent = found_indent + 1
+            exact_indent = None   # don't know exact child indent yet; find_key_line will set it on first match
+
+    with open(file_path, "w") as f:
+        f.writelines(lines)
+
+    print(f"Updated {path_str} = {new_value!r} in {file_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/check-umbrella-drift.sh
+++ b/.github/scripts/check-umbrella-drift.sh
@@ -136,21 +136,56 @@ PROMPT="You are a Helm chart reviewer. Your job is to detect **structural drift*
 
 CONTEXT:
 - The umbrella chart is a near-verbatim copy of the component chart's templates, adapted to fit inside a larger umbrella Helm chart.
-- Adaptations include: different .Values paths (e.g. \`\$pp.image.tag\` instead of \`.Values.image.tag\`), different helper function names (e.g. \`umbrella.castai-pod-pinner.fullname\` instead of \`pod-pinner.fullname\`), and an outer \`{{- \$pp := index .Values... }}\` variable binding.
+- Adaptations include: different .Values paths (e.g. \$pp.image.tag instead of .Values.image.tag), different helper function names (e.g. umbrella.castai-pod-pinner.fullname instead of pod-pinner.fullname), and an outer {{- \$pp := index .Values... }} variable binding.
 - These syntactic differences are EXPECTED and should NOT be reported as drift.
 - What matters is the Kubernetes resource structure: which resource kinds exist, what fields they contain, what RBAC rules are defined, what env vars, volumes, volumeMounts, probes, ports, affinity rules, tolerations, sidecars, etc.
 
 ${CASTAI_LIVE_NOTE}
 
 YOUR TASK:
-Compare the two sets of templates below and produce a structured drift report in Markdown. For each finding:
-1. Match resources by their Kubernetes \`kind\` (and disambiguate by name pattern if there are multiple of the same kind).
-2. Report drift in BOTH directions:
-   a. **Component → Umbrella gaps**: things present in the component that are missing or structurally different in the umbrella. These likely need to be ported. Mark these clearly as ACTION REQUIRED.
-   b. **Umbrella → Component gaps**: things present in the umbrella but not in the component (umbrella additions or stale resources). Mark these as INFORMATIONAL — reviewer should verify whether these are intentional umbrella additions or stale resources from a dropped component feature.
-3. For each finding, be specific: name the resource kind, the field or section that changed, and briefly describe what changed.
-4. If there is no drift, say so clearly.
-5. Do NOT report differences that are purely syntactic Go template adaptations (helper names, .Values path changes, variable bindings).
+Go through every Kubernetes resource in both template sets. For each resource (matched by kind and name pattern):
+
+1. Extract and compare these fields exhaustively between component and umbrella:
+   - env / envFrom entries (name, value, valueFrom)
+   - volumes and volumeMounts (name, mountPath, type)
+   - livenessProbe / readinessProbe / startupProbe (path, port, scheme, thresholds)
+   - ports (name, containerPort, protocol)
+   - securityContext (pod-level and container-level)
+   - resources (requests and limits)
+   - tolerations, affinity, nodeSelector, topologySpreadConstraints
+   - RBAC rules (apiGroups, resources, verbs)
+   - initContainers and sidecars
+   - args and command
+   - imagePullPolicy, serviceAccountName, hostNetwork, dnsPolicy
+   - Any other spec fields present in either side
+
+2. For each field that differs or is absent on one side, output a finding block in exactly this format:
+
+---
+**Resource:** \`<kind>/<name-pattern>\`
+**Field:** \`<exact field path, e.g. spec.template.spec.containers[0].env[KARPENTER_MODE_ENABLED]>\`
+**Component:**
+\`\`\`yaml
+<exact lines from the component template, or \"(absent)\" if missing>
+\`\`\`
+**Umbrella:**
+\`\`\`yaml
+<exact lines from the umbrella template, or \"(absent)\" if missing>
+\`\`\`
+**Classification:** ACTION REQUIRED | INFORMATIONAL
+**Reason:** <one sentence: what this means and why it matters>
+
+---
+
+3. Rules for classification:
+   - ACTION REQUIRED: component has something the umbrella is missing or has differently — umbrella needs updating.
+   - INFORMATIONAL: umbrella has something the component doesn't — may be intentional addition or stale; reviewer must verify.
+
+4. For entire resources missing from one side, output one finding block for the whole resource with the full resource yaml in the relevant side's field.
+
+5. If there is zero drift after checking all fields, output only: \"✅ No structural drift detected.\"
+
+6. Do NOT group findings. One finding block per differing field. Do NOT summarize or omit fields — exhaustive coverage is required.
 
 ---
 
@@ -166,7 +201,7 @@ ${UMB_CONTENT}
 
 ---
 
-Now produce the drift report."
+Now produce the drift report. Be exhaustive. Show exact lines."
 
 # ── Call Kimchi Inference API ─────────────────────────────────────────────────
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Rewrites `bump-yaml-field.py` to update YAML scalar values via line-by-line text replacement instead of parsing with `ruamel.yaml`, ensuring formatting, comments, and key ordering are preserved. Also refines the LLM prompt in `check-umbrella-drift.sh` to request exhaustive, per-field Kubernetes resource drift comparisons with a strict structured output format.

### Why
The previous `ruamel.yaml` approach stripped comments and reformatted files when bumping fields (e.g., Chart versions). The drift-detection prompt was producing inconsistent, high-level summaries; the new instructions force detailed, actionable findings that are easier to review.

### Key changes
- `bump-yaml-field.py`:
  - Removed the `ruamel.yaml` dependency entirely.
  - Added `parse_keys()`, `find_key_line()`, and `replace_scalar_value()` helpers.
  - Walks the yq-style dotted path by tracking indentation line-by-line, finds the target key, and replaces only its scalar value while preserving surrounding quotes.
  - Exits with code `1` if the path cannot be found.
- `check-umbrella-drift.sh`:
  - Replaced the open-ended drift prompt with an explicit field checklist (`env`, `volumes`, `probes`, `securityContext`, `resources`, `tolerations`, `RBAC`, `initContainers`, etc.).
  - Mandated a rigid finding-block format: `Resource`, `Field`, `Component`, `Umbrella`, `Classification`, and `Reason`.
  - Requires one finding block per differing field with exact YAML snippets; prohibits grouping or summarization.

### Impact
- Scripts depending on `bump-yaml-field.py` no longer need `ruamel.yaml` installed.
- Drift reports will be substantially more verbose but also more complete and reproducible.
- No CLI interface changes; both scripts remain backward-compatible.