### PR TITLE
Fine tune live template diff check

### DIFF
--- a/.github/scripts/check-umbrella-drift.sh
+++ b/.github/scripts/check-umbrella-drift.sh
@@ -39,14 +39,18 @@ if [ "$CHART_NAME" = "castai-live" ]; then
     echo "CHART_VERSION is required for castai-live" >&2
     exit 1
   fi
-  LIVE_UNTAR_DIR="/tmp/castai-live-chart"
-  rm -rf "$LIVE_UNTAR_DIR"
-  helm repo add castai-helm https://castai.github.io/helm-charts --force-update >/dev/null 2>&1
-  helm pull castai-helm/castai-live \
-    --version "$CHART_VERSION" \
-    --untar \
-    --untardir "$LIVE_UNTAR_DIR"
-  COMP_TEMPLATES="${LIVE_UNTAR_DIR}/castai-live/templates"
+  GITLAB_TOKEN="${GITLAB_TOKEN:?GITLAB_TOKEN env var required for castai-live}"
+
+  LIVE_CLONE_DIR="/tmp/castai-live-source"
+  rm -rf "$LIVE_CLONE_DIR"
+
+  git clone \
+    --depth 1 \
+    --branch "v${CHART_VERSION}" \
+    "https://oauth2:${GITLAB_TOKEN}@gitlab.com/castai/live/clm.git" \
+    "$LIVE_CLONE_DIR"
+
+  COMP_TEMPLATES="${LIVE_CLONE_DIR}/helm"
 else
   CHART_YAML_PATH=$(find kubecast/services -name "Chart.yaml" \
     -exec grep -l "^name: ${CHART_NAME}$" {} \; 2>/dev/null | head -1 || true)
@@ -129,7 +133,10 @@ fi
 # castai-live note: its templates dir may contain flattened dependency templates
 CASTAI_LIVE_NOTE=""
 if [ "$CHART_NAME" = "castai-live" ]; then
-  CASTAI_LIVE_NOTE="NOTE: castai-live's component templates directory may contain flattened templates from chart dependencies mixed in with the main component's templates. Use your best judgment to identify which resources belong to the main castai-live workload versus dependencies when comparing."
+  CASTAI_LIVE_NOTE="NOTE: castai-live's component templates directory may contain flattened templates \
+from chart dependencies. However, you must still report ALL differences you find — do not skip or \
+excuse any diff on the grounds that it might belong to a dependency. Flag everything; the reviewer \
+will decide what is intentional."
 fi
 
 PROMPT="You are a Helm chart reviewer. Your job is to detect **structural drift** between a component's original Helm templates and a copied version of those templates inside an umbrella chart.

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Clone kubecast
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         env:
-          GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_PAT_OANA }}
         run: |
           git config --global credential.helper '!f() { echo "username=oauth2"; echo "password='"${GITLAB_TOKEN}"'"; }; f'
           git clone https://gitlab.com/castai/kubecast.git kubecast
@@ -303,6 +303,7 @@ jobs:
           CHART_NAME: ${{ steps.parse.outputs.chart_name }}
           CHART_VERSION: ${{ steps.parse.outputs.chart_version }}
           KIMCHI_API_KEY: ${{ secrets.KIMCHI_API_KEY }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_PAT_OANA }} 
         run: |
           bash helm-charts-head/.github/scripts/check-umbrella-drift.sh
 
@@ -315,7 +316,7 @@ jobs:
           RC_VERSION: ${{ steps.rc.outputs.version }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
-          GITLAB_TOKEN: ${{ secrets.KUBECAST_GITLAB_TOKEN }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_PAT_OANA }}
           IMAGE_OLD_TAG: ${{ steps.bump_image.outputs.old_tag }}
           DEPS_SUMMARY: ${{ steps.bump_deps.outputs.summary }}
           DRIFT_REPORT: ${{ steps.drift.outputs.drift_report }}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates the umbrella-chart drift check for `castai-live` to clone component templates directly from the GitLab source repository instead of pulling the published Helm chart. The AI review prompt is also tightened to require reporting every difference rather than allowing suspected dependency templates to be ignored.

### Why
Comparing against the raw Git repository ensures the drift check uses the exact source-of-truth templates instead of a packaged or flattened Helm chart that may mix in dependency manifests. The prompt change eliminates false negatives where diffs were previously excused because they looked like dependency artifacts.

### Key changes
- `.github/scripts/check-umbrella-drift.sh`:
  - Replaces `helm pull` from the `castai-helm` repo with `git clone --depth 1 --branch "v${CHART_VERSION}"` of `gitlab.com/castai/live/clm.git`
  - Requires the `GITLAB_TOKEN` environment variable when checking `castai-live`
  - Changes the comparison path from an untarred chart directory to `${LIVE_CLONE_DIR}/helm`
  - Revises the `CASTAI_LIVE_NOTE` prompt to instruct the reviewer to flag *all* differences and let the human reviewer decide what is intentional
- `.github/workflows/release-umbrella-rc.yml`:
  - Switches the GitLab secret from `KUBECAST_GITLAB_TOKEN` to `GITLAB_PAT_OANA`
  - Passes `GITLAB_TOKEN` into the drift-check step environment

### Impact
- `castai-live` drift checks now require the `GITLAB_PAT_OANA` secret and the `GITLAB_TOKEN` environment variable to authenticate against GitLab.
- Comparison results may differ from previous runs because templates are now sourced directly from the repository's `helm/` directory rather than a rendered Helm package.