### PR TITLE
[castai-umbrella] Be more explicit what to install in readme

### DIFF
--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.41.16
+version: 0.42.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/README.md
+++ b/charts/castai-umbrella/README.md
@@ -17,15 +17,17 @@ This chart bundles three independent product profiles. Enable exactly one per in
 
 | Bundle | Enabled by | Target clusters | Components |
 |--------|-----------|----------------|-----------|
-| **autoscaler** | `tags.<mode>=true` | Managed cloud (EKS, AKS, GKE) | Mode-dependent — see [Autoscaler](#autoscaler) |
-| **autoscaler-anywhere** | `tags.autoscaler-anywhere=true` | Non-managed (bare metal, on-prem, edge) | castai-agent, castai-cluster-controller, castai-workload-autoscaler, castai-workload-autoscaler-exporter, castai-evictor, castai-pod-mutator |
+| **autoscaler** | `tags.<mode>=true` | EKS, AKS, GKE (standard modes) | Mode-dependent — see [Autoscaler](#autoscaler) |
+| **autoscaler-anywhere** | `tags.autoscaler-anywhere=true` | All other clusters (bare metal, on-prem, edge, GKE Autopilot, etc.) | castai-agent, castai-cluster-controller, castai-workload-autoscaler, castai-workload-autoscaler-exporter, castai-evictor, castai-pod-mutator |
 | **kent** | `kent.enabled=true` | EKS only | castai-agent, castai-cluster-controller, castai-kentroller, castai-workload-autoscaler, castai-live, castai-pod-mutator |
+
+> Not sure which bundle applies to your cluster? See the [Cast AI documentation](https://docs.cast.ai) for a full guide.
 
 ---
 
 ## Autoscaler
 
-For managed cloud clusters (EKS, AKS, GKE). Select exactly one mode tag — each tag enables a fixed set of components on top of the base observability stack.
+For standard EKS, AKS, and GKE clusters. Select exactly one mode tag — each tag enables a fixed set of components on top of the base observability stack.
 
 ### Modes
 
@@ -188,7 +190,7 @@ helm upgrade castai castai-helm/castai \
 
 ## Autoscaler Anywhere
 
-For non-managed Kubernetes clusters (bare metal, on-prem, edge). Authentication uses a pre-created credentials Secret instead of inline API key flags.
+For all other Kubernetes clusters (bare metal, on-prem, edge, GKE Autopilot, etc.). Authentication uses a pre-created credentials Secret instead of inline API key flags.
 
 ### Prerequisites
 

--- a/charts/castai-umbrella/README.md.gotmpl
+++ b/charts/castai-umbrella/README.md.gotmpl
@@ -10,15 +10,17 @@ This chart bundles three independent product profiles. Enable exactly one per in
 
 | Bundle | Enabled by | Target clusters | Components |
 |--------|-----------|----------------|-----------|
-| **autoscaler** | `tags.<mode>=true` | Managed cloud (EKS, AKS, GKE) | Mode-dependent — see [Autoscaler](#autoscaler) |
-| **autoscaler-anywhere** | `tags.autoscaler-anywhere=true` | Non-managed (bare metal, on-prem, edge) | castai-agent, castai-cluster-controller, castai-workload-autoscaler, castai-workload-autoscaler-exporter, castai-evictor, castai-pod-mutator |
+| **autoscaler** | `tags.<mode>=true` | EKS, AKS, GKE (standard modes) | Mode-dependent — see [Autoscaler](#autoscaler) |
+| **autoscaler-anywhere** | `tags.autoscaler-anywhere=true` | All other clusters (bare metal, on-prem, edge, GKE Autopilot, etc.) | castai-agent, castai-cluster-controller, castai-workload-autoscaler, castai-workload-autoscaler-exporter, castai-evictor, castai-pod-mutator |
 | **kent** | `kent.enabled=true` | EKS only | castai-agent, castai-cluster-controller, castai-kentroller, castai-workload-autoscaler, castai-live, castai-pod-mutator |
+
+> Not sure which bundle applies to your cluster? See the [Cast AI documentation](https://docs.cast.ai) for a full guide.
 
 ---
 
 ## Autoscaler
 
-For managed cloud clusters (EKS, AKS, GKE). Select exactly one mode tag — each tag enables a fixed set of components on top of the base observability stack.
+For standard EKS, AKS, and GKE clusters. Select exactly one mode tag — each tag enables a fixed set of components on top of the base observability stack.
 
 ### Modes
 
@@ -181,7 +183,7 @@ helm upgrade castai castai-helm/castai \
 
 ## Autoscaler Anywhere
 
-For non-managed Kubernetes clusters (bare metal, on-prem, edge). Authentication uses a pre-created credentials Secret instead of inline API key flags.
+For all other Kubernetes clusters (bare metal, on-prem, edge, GKE Autopilot, etc.). Authentication uses a pre-created credentials Secret instead of inline API key flags.
 
 ### Prerequisites
 

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -10,8 +10,8 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.92 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.2 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.95 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.16.0 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.0 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.3.0 |
 

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -10,10 +10,10 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.92 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.163.2 |
-| https://castai.github.io/helm-charts | castai-live | 0.107.1 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.2 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.95 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.163.3 |
+| https://castai.github.io/helm-charts | castai-live | 0.108.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.16.0 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.4 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.0 |

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -11,10 +11,10 @@ Wrapper chart for CAST AI Kent profile.
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.2.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.163 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.163.2 |
-| https://castai.github.io/helm-charts | castai-live | 0.107.1 |
-| https://castai.github.io/helm-charts | castai-pod-mutator | 0.15.2 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.164 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.163.3 |
+| https://castai.github.io/helm-charts | castai-live | 0.108.0 |
+| https://castai.github.io/helm-charts | castai-pod-mutator | 0.16.0 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.4 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.0 |
 | https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.3.0 |


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the umbrella chart version to `0.42.0`, updates documented dependency versions for several CAST AI components, and clarifies README guidance for choosing between the `autoscaler` and `autoscaler-anywhere` bundles.

### Why
Removes ambiguity about which profile to enable by explicitly stating that standard EKS, AKS, and GKE clusters use the `autoscaler` bundle, while all others—including GKE Autopilot, bare metal, on-prem, and edge—use `autoscaler-anywhere`.

### Key changes
- `charts/castai-umbrella/Chart.yaml`: version bumped from `0.41.16` to `0.42.0`.
- `charts/castai-umbrella/README.md` and `README.md.gotmpl`: clarified bundle target cluster descriptions; added a link to Cast AI documentation for bundle selection guidance.
- `charts/castai-umbrella/charts/autoscaler/README.md`: updated dependency versions for `castai-evictor` (`0.35.95`), `castai-kvisor` (`1.163.3`), `castai-live` (`0.108.0`), and `castai-pod-mutator` (`0.16.0`).
- `charts/castai-umbrella/charts/autoscaler-anywhere/README.md`: updated dependency versions for `castai-evictor` (`0.35.95`) and `castai-pod-mutator` (`0.16.0`).
- `charts/castai-umbrella/charts/kent/README.md`: updated dependency versions for `castai-kentroller` (`0.1.164`), `castai-kvisor` (`1.163.3`), `castai-live` (`0.108.0`), and `castai-pod-mutator` (`0.16.0`).