### PR TITLE
[castai-dbo] add umbrella chart for DBO

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.22.0
+version: 0.22.1

--- a/charts/castai-db-agent/templates/_helpers.tpl
+++ b/charts/castai-db-agent/templates/_helpers.tpl
@@ -2,40 +2,40 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "castai-db-agent.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
+{{- define "castai-db-agent.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Define common labels.
 */}}
-{{- define "labels" -}}
+{{- define "castai-db-agent.labels" -}}
 app.kubernetes.io/managed-by: Helm
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/name: {{ include "name" . }}
-helm.sh/chart: {{ include "chart" . }}
+app.kubernetes.io/name: {{ include "castai-db-agent.name" . }}
+helm.sh/chart: {{ include "castai-db-agent.chart" . }}
 {{- end }}
 
-{{- define "dbAgentImage" -}}
-{{-  default (include "defaultDbAgentVersion" .) .Values.image.tag }}
+{{- define "castai-db-agent.dbAgentImage" -}}
+{{-  default (include "castai-db-agent.defaultDbAgentVersion" .) .Values.image.tag }}
 {{- end }}
 
-{{- define "cloudSqlProxyImage" -}}
-{{-  default (include "defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
+{{- define "castai-db-agent.cloudSqlProxyImage" -}}
+{{-  default (include "castai-db-agent.defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
 {{- end }}
 
 {{- define "castai-db-agent.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "name" .) .Values.serviceAccount.name }}
+{{- default (include "castai-db-agent.name" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/castai-db-agent/templates/_versions.tpl
+++ b/charts/castai-db-agent/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultDbAgentVersion" -}}v0.21.0{{- end -}}
-{{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
+{{- define "castai-db-agent.defaultDbAgentVersion" -}}v0.21.0{{- end -}}
+{{- define "castai-db-agent.defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}

--- a/charts/castai-db-agent/templates/api-key-secret.yaml
+++ b/charts/castai-db-agent/templates/api-key-secret.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}-api-key
+  name: {{ include "castai-db-agent.name" . }}-api-key
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-agent.labels" . | nindent 4 }}
 data:
   API_KEY: {{ .Values.apiKey | b64enc | quote }}
 {{- end }}

--- a/charts/castai-db-agent/templates/db-user-secret.yaml
+++ b/charts/castai-db-agent/templates/db-user-secret.yaml
@@ -8,9 +8,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}-db-user
+  name: {{ include "castai-db-agent.name" . }}-db-user
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-agent.labels" . | nindent 4 }}
 data:
   DATABASE_USERNAME: {{ .Values.database.username | b64enc | quote }}
   {{- if and (not .Values.database.useCloudSQLIAMAuth) (not .Values.database.useRDSIAMAuth) }}

--- a/charts/castai-db-agent/templates/deployment.yaml
+++ b/charts/castai-db-agent/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: API_URL
               value:  "{{ .Values.apiURL | default "https://api.cast.ai/" }}"
             - name: ORGANIZATION_ID
-              value: "{{ required "organization ID must be provided" .Values.organizationID }}"
+              value: "{{ .Values.organizationID | default (.Values.global | default dict).organizationID | required "organization ID must be provided" }}"
             - name: CACHE_GROUP_ID
               value: "{{ required "cache group ID must be provided" .Values.cacheGroupID }}"
             - name: DATABASE_HOST

--- a/charts/castai-db-agent/templates/deployment.yaml
+++ b/charts/castai-db-agent/templates/deployment.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "name" $ }}
+  name: {{ include "castai-db-agent.name" $ }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-agent.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "name" . }}
+      app.kubernetes.io/name: {{ include "castai-db-agent.name" . }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "name" . }}
+        app.kubernetes.io/name: {{ include "castai-db-agent.name" . }}
     spec:
       serviceAccountName: {{ include "castai-db-agent.serviceAccountName" . }}
       containers:
         - name: db-agent
-          image: "{{.Values.image.repository}}:{{ include "dbAgentImage" . }}"
+          image: "{{.Values.image.repository}}:{{ include "castai-db-agent.dbAgentImage" . }}"
           imagePullPolicy: {{.Values.image.pullPolicy}}
           securityContext:
             capabilities:
@@ -86,19 +86,19 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: K8S_DEPLOYMENT
-              value: {{ include "name" . }}
+              value: {{ include "castai-db-agent.name" . }}
             - name: AGENT_IMAGE
-              value: {{ include "dbAgentImage" . }}
+              value: {{ include "castai-db-agent.dbAgentImage" . }}
           envFrom:
             - secretRef:
               {{- if .Values.apiKey }}
-                name: {{ include "name" . -}}-api-key
+                name: {{ include "castai-db-agent.name" . -}}-api-key
               {{- else }}
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.apiKeySecretRef -}}
               {{- end }}
             {{- if .Values.database.username }}
             - secretRef:
-                name: {{ include "name" $ }}-db-user
+                name: {{ include "castai-db-agent.name" $ }}-db-user
             {{- else if .Values.database.credentialsSecretRef }}
             - secretRef:
                 name: {{ .Values.database.credentialsSecretRef -}}
@@ -107,7 +107,7 @@ spec:
             {{- end }}
         {{- if and .Values.cloudSqlProxy .Values.cloudSqlProxy.enabled }}
         - name: cloud-sql-proxy
-          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "cloudSqlProxyImage" . }}"
+          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "castai-db-agent.cloudSqlProxyImage" . }}"
           imagePullPolicy: {{ $.Values.cloudSqlProxyImage.pullPolicy }}
           args:
             {{- if .Values.cloudSqlProxy.privateIp }}

--- a/charts/castai-db-agent/templates/deployment.yaml
+++ b/charts/castai-db-agent/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: API_URL
               value:  "{{ .Values.apiURL | default "https://api.cast.ai/" }}"
             - name: ORGANIZATION_ID
-              value: "{{ .Values.organizationID | default (.Values.global | default dict).organizationID | required "organization ID must be provided" }}"
+              value: "{{ required "organization ID must be provided" .Values.organizationID }}"
             - name: CACHE_GROUP_ID
               value: "{{ required "cache group ID must be provided" .Values.cacheGroupID }}"
             - name: DATABASE_HOST

--- a/charts/castai-db-agent/templates/serviceaccount.yaml
+++ b/charts/castai-db-agent/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "castai-db-agent.serviceAccountName" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-agent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.80.0
+version: 0.80.1

--- a/charts/castai-db-optimizer/templates/NOTES.txt
+++ b/charts/castai-db-optimizer/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- if not (.Values.organizationID | default (.Values.global | default dict).organizationID) }}
+{{- if not .Values.organizationID }}
 WARNING: organizationID is not set. Some features may not work correctly.
          Set organizationID in your values to associate this deployment with your CAST AI organization.
 {{- end }}

--- a/charts/castai-db-optimizer/templates/NOTES.txt
+++ b/charts/castai-db-optimizer/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- if not .Values.organizationID }}
+{{- if not (.Values.organizationID | default (.Values.global | default dict).organizationID) }}
 WARNING: organizationID is not set. Some features may not work correctly.
          Set organizationID in your values to associate this deployment with your CAST AI organization.
 {{- end }}

--- a/charts/castai-db-optimizer/templates/_helpers.tpl
+++ b/charts/castai-db-optimizer/templates/_helpers.tpl
@@ -2,41 +2,41 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "castai-db-optimizer.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
+{{- define "castai-db-optimizer.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{- define "queryProcessorImage" -}}
-{{-  default (include "defaultQueryProcessorVersion" .) .Values.queryProcessorImage.tag }}
+{{- define "castai-db-optimizer.queryProcessorImage" -}}
+{{-  default (include "castai-db-optimizer.defaultQueryProcessorVersion" .) .Values.queryProcessorImage.tag }}
 {{- end }}
 
-{{- define "proxyImage" -}}
-{{-  default (include "defaultProxyVersion" .) .Values.proxyImage.tag }}
+{{- define "castai-db-optimizer.proxyImage" -}}
+{{-  default (include "castai-db-optimizer.defaultProxyVersion" .) .Values.proxyImage.tag }}
 {{- end }}
 
-{{- define "cloudSqlProxyImage" -}}
-{{-  default (include "defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
+{{- define "castai-db-optimizer.cloudSqlProxyImage" -}}
+{{-  default (include "castai-db-optimizer.defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
 {{- end }}
 
-{{- define "pgdogImage" -}}
-{{-  default (include "defaultPgdogVersion" .) .Values.pgdogImage.tag }}
+{{- define "castai-db-optimizer.pgdogImage" -}}
+{{-  default (include "castai-db-optimizer.defaultPgdogVersion" .) .Values.pgdogImage.tag }}
 {{- end }}
 
-{{- define "proxySqlImage" -}}
-{{-  default (include "defaultProxySqlVersion" .) .Values.proxySqlImage.tag }}
+{{- define "castai-db-optimizer.proxySqlImage" -}}
+{{-  default (include "castai-db-optimizer.defaultProxySqlVersion" .) .Values.proxySqlImage.tag }}
 {{- end }}
 
 {{/*
 Helpers for customizing proxy TLS settings.
 */}}
-{{- define "proxy.tls.certificates" -}}
+{{- define "castai-db-optimizer.proxy.tls.certificates" -}}
 tls_certificates:
   - certificate_chain:
       filename: "{{ if .Values.proxy.tlsSecretName }}/etc/tls/tls.crt{{ else }}cert.pem{{ end }}"
@@ -47,16 +47,16 @@ tls_certificates:
 {{/*
 How long other sidecars should wait for proxy to fully drain before terminating.
 */}}
-{{- define "proxy.draining.sidecarTerminationDelay" -}}
+{{- define "castai-db-optimizer.proxy.draining.sidecarTerminationDelay" -}}
 {{- add .Values.proxy.draining.gracePeriodSeconds 15 -}}
 {{- end -}}
 
 {{/*
 Helper for calculating terminationGracePeriodSeconds
 */}}
-{{- define "terminationGracePeriodSeconds" -}}
+{{- define "castai-db-optimizer.terminationGracePeriodSeconds" -}}
 {{- if .Values.proxy.draining.enabled -}}
-  {{- $grace := add (include "proxy.draining.sidecarTerminationDelay" .) 15 | int -}}
+  {{- $grace := add (include "castai-db-optimizer.proxy.draining.sidecarTerminationDelay" .) 15 | int -}}
   {{- if and .Values.pgdog .Values.pgdog.enabled -}}
     {{- add $grace (div .Values.pgdog.config.shutdown_timeout 1000) -}}
   {{- else if and .Values.proxySql .Values.proxySql.enabled -}}
@@ -72,7 +72,7 @@ Helper for calculating terminationGracePeriodSeconds
 {{/*
 Define common labels.
 */}}
-{{- define "labels" -}}
+{{- define "castai-db-optimizer.labels" -}}
 {{- if .Values.commonLabels }}
 {{ if gt (len .Values.commonLabels) 0 -}}
 {{- with .Values.commonLabels }}
@@ -84,14 +84,14 @@ app.kubernetes.io/managed-by: Helm
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/name: {{ include "name" . }}
-helm.sh/chart: {{ include "chart" . }}
+app.kubernetes.io/name: {{ include "castai-db-optimizer.name" . }}
+helm.sh/chart: {{ include "castai-db-optimizer.chart" . }}
 {{- end }}
 
 {{/*
 Common Annotations
 */}}
-{{- define "annotations" -}}
+{{- define "castai-db-optimizer.annotations" -}}
 {{- if .Values.commonAnnotations }}
 {{ if gt (len .Values.commonAnnotations) 0 -}}
 {{- with .Values.commonAnnotations }}
@@ -104,11 +104,11 @@ Common Annotations
 {{/*
 Selector labels
 */}}
-{{- define "selectorLabels" -}}
-app.kubernetes.io/name: {{ include "name" . }}
+{{- define "castai-db-optimizer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "castai-db-optimizer.name" . }}
 {{- end }}
 
-{{- define "workloads-annotations" -}}
+{{- define "castai-db-optimizer.workloads-annotations" -}}
 {{- if hasKey .Values "workloadsAnnotations" }}
   {{- if kindIs "map" .Values.workloadsAnnotations }}
     {{- if eq (len .Values.workloadsAnnotations) 0 }}
@@ -139,7 +139,7 @@ workloads.cast.ai/configuration: |
 {{/*
 Convert CPU resource limit to concurrency value.
 */}}
-{{- define "cpu-to-concurrency" -}}
+{{- define "castai-db-optimizer.cpu-to-concurrency" -}}
 {{- $cpu := toString . -}}
 {{- $cpuCores := 0.0 -}}
 {{- if hasSuffix "m" $cpu -}}

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,5 +1,5 @@
-{{- define "defaultProxyVersion" -}}v4.84.2{{- end -}}
-{{- define "defaultQueryProcessorVersion" -}}v0.48.0{{- end -}}
-{{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
-{{- define "defaultPgdogVersion" -}}v0.1.43{{- end -}}
-{{- define "defaultProxySqlVersion" -}}3.0.6{{- end -}}
+{{- define "castai-db-optimizer.defaultProxyVersion" -}}v4.84.2{{- end -}}
+{{- define "castai-db-optimizer.defaultQueryProcessorVersion" -}}v0.48.0{{- end -}}
+{{- define "castai-db-optimizer.defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
+{{- define "castai-db-optimizer.defaultPgdogVersion" -}}v0.1.43{{- end -}}
+{{- define "castai-db-optimizer.defaultProxySqlVersion" -}}3.0.6{{- end -}}

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
-    {{- include "workloads-annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.workloads-annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 0
   selector:
     matchLabels:
-      {{- include "selectorLabels" . | nindent 6 }}
+      {{- include "castai-db-optimizer.selectorLabels" . | nindent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.rollingUpdate.maxSurge }}
@@ -28,7 +28,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "selectorLabels" . | nindent 8 }}
+        {{- include "castai-db-optimizer.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -38,7 +38,7 @@ spec:
       {{- if .Values.serviceAccountName }}
       serviceAccountName: {{ .Values.serviceAccountName }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ include "terminationGracePeriodSeconds" . }}
+      terminationGracePeriodSeconds: {{ include "castai-db-optimizer.terminationGracePeriodSeconds" . }}
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
@@ -67,7 +67,7 @@ spec:
       volumes:
         - name: envoy-config
           configMap:
-            name: {{ include "name" . }}-envoy-config
+            name: {{ include "castai-db-optimizer.name" . }}-envoy-config
         - name: temp-storage
           emptyDir: {}
         - name: data-storage
@@ -87,18 +87,18 @@ spec:
           emptyDir: {}
         - name: proxysql-config-template
           configMap:
-            name: {{ include "name" . }}-proxysql-config
+            name: {{ include "castai-db-optimizer.name" . }}-proxysql-config
         - name: proxysql-config-output
           emptyDir: {}
         - name: proxysql-users-secret-volume
           secret:
-            secretName: {{ ternary .Values.proxySql.usersSecretRef (printf "%s-proxysql-users" (include "name" .)) (ne .Values.proxySql.usersSecretRef "") }}
+            secretName: {{ ternary .Values.proxySql.usersSecretRef (printf "%s-proxysql-users" (include "castai-db-optimizer.name" .)) (ne .Values.proxySql.usersSecretRef "") }}
         {{- end }}
       {{- if or (and .Values.pgdog .Values.pgdog.enabled) (and .Values.proxySql .Values.proxySql.enabled) }}
       initContainers:
         {{- if and .Values.pgdog .Values.pgdog.enabled }}
         - name: pgdog-init
-          image: "{{.Values.pgdogImage.repository}}:{{ include "pgdogImage" . }}"
+          image: "{{.Values.pgdogImage.repository}}:{{ include "castai-db-optimizer.pgdogImage" . }}"
           imagePullPolicy: {{.Values.pgdogImage.pullPolicy}}
           command:
             - /bin/sh
@@ -128,7 +128,7 @@ spec:
         {{- end }}
         {{- if and .Values.proxySql .Values.proxySql.enabled }}
         - name: proxysql-init
-          image: "{{.Values.proxySqlImage.repository}}:{{ include "proxySqlImage" . }}"
+          image: "{{.Values.proxySqlImage.repository}}:{{ include "castai-db-optimizer.proxySqlImage" . }}"
           imagePullPolicy: {{.Values.proxySqlImage.pullPolicy}}
           command:
             - /bin/sh
@@ -153,7 +153,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
         - name: proxysql-users-init
-          image: "{{.Values.queryProcessorImage.repository}}:{{ include "queryProcessorImage" . }}"
+          image: "{{.Values.queryProcessorImage.repository}}:{{ include "castai-db-optimizer.queryProcessorImage" . }}"
           imagePullPolicy: {{.Values.queryProcessorImage.pullPolicy}}
           command:
             - query-processor
@@ -177,7 +177,7 @@ spec:
       {{- end }}
       containers:
         - name: query-processor
-          image: "{{.Values.queryProcessorImage.repository}}:{{ include "queryProcessorImage" . }}"
+          image: "{{.Values.queryProcessorImage.repository}}:{{ include "castai-db-optimizer.queryProcessorImage" . }}"
           imagePullPolicy: {{.Values.queryProcessorImage.pullPolicy}}
           securityContext:
             capabilities:
@@ -201,7 +201,7 @@ spec:
           envFrom:
             - secretRef:
               {{- if .Values.apiKey }}
-                name: {{ include "name" . -}}
+                name: {{ include "castai-db-optimizer.name" . -}}
               {{- else }}
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.apiKeySecretRef -}}
               {{- end }}
@@ -227,17 +227,17 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: QUERY_PROCESSOR_IMAGE
-              value: {{ include "queryProcessorImage" . }}
+              value: {{ include "castai-db-optimizer.queryProcessorImage" . }}
             - name: PROXY_IMAGE
-              value: {{ include "proxyImage" . }}
+              value: {{ include "castai-db-optimizer.proxyImage" . }}
             - name: K8S_SERVICE_NAME
-              value: {{ include "name" . }}
+              value: {{ include "castai-db-optimizer.name" . }}
             - name: SERVER_PORT
               value: "9050"
             - name: METRICS_PORT
               value: "2112"
             - name: PEERS_URL
-              value: headless-{{ include "name" . }}
+              value: headless-{{ include "castai-db-optimizer.name" . }}
             - name: CACHE_GROUP_ID
               value: {{ .Values.cacheGroupID | required ".Values.cacheGroupID is required." | quote }}
             {{- if and .Values.proxySql .Values.proxySql.enabled }}
@@ -272,7 +272,7 @@ spec:
             - name: PGDOG_CONFIG_TEMPLATE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "name" . }}-pgdog-config
+                  name: {{ include "castai-db-optimizer.name" . }}-pgdog-config
                   key: pgdog.toml
             - name: PGDOG_OUTPUT_FILE
               value: /etc/pgdog/pgdog.toml
@@ -283,7 +283,7 @@ spec:
                   {{- if .Values.pgdog.usersSecretRef }}
                   name: {{ .Values.pgdog.usersSecretRef }}
                   {{- else }}
-                  name: {{ include "name" . }}-pgdog-users
+                  name: {{ include "castai-db-optimizer.name" . }}-pgdog-users
                   {{- end }}
                   key: users.toml
             - name: PGDOG_USERS_OUTPUT_FILE
@@ -300,7 +300,7 @@ spec:
                 command:
                   - query-processor
                   - sleep
-                  - {{ include "proxy.draining.sidecarTerminationDelay" . }}s
+                  - {{ include "castai-db-optimizer.proxy.draining.sidecarTerminationDelay" . }}s
           {{- end }}
           readinessProbe:
             tcpSocket:
@@ -320,7 +320,7 @@ spec:
             limits:
               memory: {{ coalesce .Values.resources.queryProcessor.memory .Values.resources.queryProcessor.memoryLimit }}
         - name: proxy
-          image: "{{.Values.proxyImage.repository}}:{{ include "proxyImage" . }}"
+          image: "{{.Values.proxyImage.repository}}:{{ include "castai-db-optimizer.proxyImage" . }}"
           imagePullPolicy: {{.Values.proxyImage.pullPolicy}}
           {{- if .Values.proxy.draining.enabled }}
           lifecycle:
@@ -370,7 +370,7 @@ spec:
             {{- if (int .Values.proxy.concurrency) }}
             - "{{ .Values.proxy.concurrency }}"
             {{- else }}
-            - "{{ include "cpu-to-concurrency" .Values.resources.proxy.cpu }}"
+            - "{{ include "castai-db-optimizer.cpu-to-concurrency" .Values.resources.proxy.cpu }}"
             {{- end }}
             - --drain-strategy
             - immediate
@@ -407,7 +407,7 @@ spec:
           envFrom:
             - secretRef:
               {{- if .Values.apiKey }}
-                name: {{ include "name" . -}}
+                name: {{ include "castai-db-optimizer.name" . -}}
               {{- else }}
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.apiKeySecretRef -}}
               {{- end }}
@@ -426,7 +426,7 @@ spec:
             {{- end }}
         {{- if and .Values.cloudSqlProxy .Values.cloudSqlProxy.enabled }}
         - name: cloud-sql-proxy
-          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "cloudSqlProxyImage" . }}"
+          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "castai-db-optimizer.cloudSqlProxyImage" . }}"
           imagePullPolicy: {{ $.Values.cloudSqlProxyImage.pullPolicy }}
           args:
             {{- if .Values.cloudSqlProxy.privateIp }}
@@ -448,7 +448,7 @@ spec:
         {{- end }}
         {{- if and .Values.pgdog .Values.pgdog.enabled }}
         - name: pgdog
-          image: "{{.Values.pgdogImage.repository}}:{{ include "pgdogImage" . }}"
+          image: "{{.Values.pgdogImage.repository}}:{{ include "castai-db-optimizer.pgdogImage" . }}"
           imagePullPolicy: {{.Values.pgdogImage.pullPolicy}}
           command:
             - pgdog
@@ -499,7 +499,7 @@ spec:
         {{- end }}
         {{- if and .Values.proxySql .Values.proxySql.enabled }}
         - name: proxysql
-          image: "{{.Values.proxySqlImage.repository}}:{{ include "proxySqlImage" . }}"
+          image: "{{.Values.proxySqlImage.repository}}:{{ include "castai-db-optimizer.proxySqlImage" . }}"
           imagePullPolicy: {{.Values.proxySqlImage.pullPolicy}}
           command:
             - proxysql

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -246,9 +246,9 @@ spec:
             - name: POOLING_ENABLED
               value: "true"
             {{- end }}
-            {{- if .Values.organizationID }}
+            {{- with (.Values.organizationID | default (.Values.global | default dict).organizationID) }}
             - name: ORGANIZATION_ID
-              value: {{ .Values.organizationID | quote }}
+              value: {{ . | quote }}
             {{- end }}
             - name: CRASH_LOG_PATH
               value: {{ .Values.queryProcessor.crashLogPath }}

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -246,9 +246,9 @@ spec:
             - name: POOLING_ENABLED
               value: "true"
             {{- end }}
-            {{- with (.Values.organizationID | default (.Values.global | default dict).organizationID) }}
+            {{- if .Values.organizationID }}
             - name: ORGANIZATION_ID
-              value: {{ . | quote }}
+              value: {{ .Values.organizationID | quote }}
             {{- end }}
             - name: CRASH_LOG_PATH
               value: {{ .Values.queryProcessor.crashLogPath }}

--- a/charts/castai-db-optimizer/templates/envoy_config.yaml
+++ b/charts/castai-db-optimizer/templates/envoy_config.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "name" . }}-envoy-config
+  name: {{ include "castai-db-optimizer.name" . }}-envoy-config
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 data:
   envoy-config.yaml: |-
     node:
@@ -96,7 +96,7 @@ data:
                 {{- end }}
                   tls_socket_config:
                     common_tls_context:
-                      {{- include "proxy.tls.certificates" $ | nindent 22  }}
+                      {{- include "castai-db-optimizer.proxy.tls.certificates" $ | nindent 22  }}
           socket_options:
             - description: "enable keep-alive"
               level: 1 # means socket level options

--- a/charts/castai-db-optimizer/templates/headless-service.yaml
+++ b/charts/castai-db-optimizer/templates/headless-service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: headless-{{ include "name" . }}
+  name: headless-{{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 spec:
   clusterIP: None
   ports:
@@ -14,4 +14,4 @@ spec:
       targetPort: grpc
       protocol: TCP
   selector:
-    {{- include "selectorLabels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.selectorLabels" . | nindent 4 }}

--- a/charts/castai-db-optimizer/templates/pdb.yaml
+++ b/charts/castai-db-optimizer/templates/pdb.yaml
@@ -1,13 +1,13 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      {{- include "selectorLabels" . | nindent 6 }}
+      {{- include "castai-db-optimizer.selectorLabels" . | nindent 6 }}

--- a/charts/castai-db-optimizer/templates/pgdog-config.yaml
+++ b/charts/castai-db-optimizer/templates/pgdog-config.yaml
@@ -28,11 +28,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "name" . }}-pgdog-config
+  name: {{ include "castai-db-optimizer.name" . }}-pgdog-config
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 data:
   pgdog.toml: |
     [general]

--- a/charts/castai-db-optimizer/templates/pgdog-users-secret.yaml
+++ b/charts/castai-db-optimizer/templates/pgdog-users-secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}-pgdog-users
+  name: {{ include "castai-db-optimizer.name" . }}-pgdog-users
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 type: Opaque
 stringData:
   users.toml: |

--- a/charts/castai-db-optimizer/templates/proxysql-config.yaml
+++ b/charts/castai-db-optimizer/templates/proxysql-config.yaml
@@ -17,11 +17,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "name" . }}-proxysql-config
+  name: {{ include "castai-db-optimizer.name" . }}-proxysql-config
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 data:
   proxysql.cnf: |
     datadir="/var/lib/proxysql"

--- a/charts/castai-db-optimizer/templates/proxysql-users-secret.yaml
+++ b/charts/castai-db-optimizer/templates/proxysql-users-secret.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}-proxysql-users
+  name: {{ include "castai-db-optimizer.name" . }}-proxysql-users
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 type: Opaque
 stringData:
   users.json: |

--- a/charts/castai-db-optimizer/templates/secret.yaml
+++ b/charts/castai-db-optimizer/templates/secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 data:
   API_KEY: {{ .Values.apiKey | b64enc | quote }}
 {{- end }}

--- a/charts/castai-db-optimizer/templates/service.yaml
+++ b/charts/castai-db-optimizer/templates/service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 spec:
   {{- with .Values.service.trafficDistribution }}
   trafficDistribution: {{ . }}
@@ -37,7 +37,7 @@ spec:
       targetPort: proxy-metrics
       protocol: TCP
   selector:
-    {{- include "selectorLabels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.selectorLabels" . | nindent 4 }}
 
 
 # for each named port, define a named service
@@ -48,11 +48,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "name" $ }}-{{$endpoint.name}}
+  name: {{ include "castai-db-optimizer.name" $ }}-{{$endpoint.name}}
   labels:
-    {{- include "labels" $ | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" $ | nindent 4 }}
   annotations:
-    {{- include "annotations" $ | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" $ | nindent 4 }}
 spec:
   {{- with $.Values.service.trafficDistribution }}
   trafficDistribution: {{ . }}
@@ -68,7 +68,7 @@ spec:
       appProtocol: postgresql
       {{- end }}
   selector:
-    {{- include "selectorLabels" $ | nindent 4 }}
+    {{- include "castai-db-optimizer.selectorLabels" $ | nindent 4 }}
 
 {{- end }}
 {{- end }}

--- a/charts/castai-db-proxy/Chart.yaml
+++ b/charts/castai-db-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-proxy
 description: CAST AI database proxy cache deployment.
 type: application
-version: 0.1.2
+version: 0.1.3

--- a/charts/castai-db-proxy/templates/_helpers.tpl
+++ b/charts/castai-db-proxy/templates/_helpers.tpl
@@ -2,21 +2,21 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "castai-db-proxy.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
+{{- define "castai-db-proxy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Define common labels.
 */}}
-{{- define "labels" -}}
+{{- define "castai-db-proxy.labels" -}}
 {{- if .Values.commonLabels }}
 {{ if gt (len .Values.commonLabels) 0 -}}
 {{- with .Values.commonLabels }}
@@ -28,14 +28,14 @@ app.kubernetes.io/managed-by: Helm
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/name: {{ include "name" . }}
-helm.sh/chart: {{ include "chart" . }}
+app.kubernetes.io/name: {{ include "castai-db-proxy.name" . }}
+helm.sh/chart: {{ include "castai-db-proxy.chart" . }}
 {{- end }}
 
 {{/*
 Common Annotations
 */}}
-{{- define "annotations" -}}
+{{- define "castai-db-proxy.annotations" -}}
 {{- if .Values.commonAnnotations }}
 {{ if gt (len .Values.commonAnnotations) 0 -}}
 {{- with .Values.commonAnnotations }}
@@ -45,13 +45,13 @@ Common Annotations
 {{- end }}
 {{- end }}
 
-{{- define "proxyImage" -}}
-{{- default (include "defaultProxyVersion" .) .Values.image.tag }}
+{{- define "castai-db-proxy.proxyImage" -}}
+{{- default (include "castai-db-proxy.defaultProxyVersion" .) .Values.image.tag }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
-{{- define "selectorLabels" -}}
-app.kubernetes.io/name: {{ include "name" . }}
+{{- define "castai-db-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "castai-db-proxy.name" . }}
 {{- end }}

--- a/charts/castai-db-proxy/templates/_versions.tpl
+++ b/charts/castai-db-proxy/templates/_versions.tpl
@@ -1,1 +1,1 @@
-{{- define "defaultProxyVersion" -}}v0.1.0{{- end -}}
+{{- define "castai-db-proxy.defaultProxyVersion" -}}v0.1.0{{- end -}}

--- a/charts/castai-db-proxy/templates/configmap.yaml
+++ b/charts/castai-db-proxy/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
 
     [api]
     url = {{ printf "https://%s" (required "apiURL must be provided" .Values.apiURL) | quote }}
-    organization_id = {{ .Values.organizationID | default (.Values.global | default dict).organizationID | required "organizationID must be provided" | quote }}
+    organization_id = {{ required "organizationID must be provided" .Values.organizationID | quote }}
     proxy_id = {{ required "proxyID must be provided" .Values.proxyID | quote }}
 
     [cache]

--- a/charts/castai-db-proxy/templates/configmap.yaml
+++ b/charts/castai-db-proxy/templates/configmap.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "name" . }}-config
+  name: {{ include "castai-db-proxy.name" . }}-config
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-proxy.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-proxy.annotations" . | nindent 4 }}
 data:
   config.toml: |
     protocol = {{ .Values.protocol | quote }}
@@ -34,6 +34,6 @@ data:
 
     [cluster.discovery]
     type = "dns"
-    host = "headless-{{ include "name" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    host = "headless-{{ include "castai-db-proxy.name" . }}.{{ .Release.Namespace }}.svc.cluster.local"
     port = {{ .Values.ports.cluster }}
     {{- end }}

--- a/charts/castai-db-proxy/templates/configmap.yaml
+++ b/charts/castai-db-proxy/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
 
     [api]
     url = {{ printf "https://%s" (required "apiURL must be provided" .Values.apiURL) | quote }}
-    organization_id = {{ required "organizationID must be provided" .Values.organizationID | quote }}
+    organization_id = {{ .Values.organizationID | default (.Values.global | default dict).organizationID | required "organizationID must be provided" | quote }}
     proxy_id = {{ required "proxyID must be provided" .Values.proxyID | quote }}
 
     [cache]

--- a/charts/castai-db-proxy/templates/deployment.yaml
+++ b/charts/castai-db-proxy/templates/deployment.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-proxy.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-proxy.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-proxy.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 0
   selector:
     matchLabels:
-      {{- include "selectorLabels" . | nindent 6 }}
+      {{- include "castai-db-proxy.selectorLabels" . | nindent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.rollingUpdate.maxSurge }}
@@ -25,7 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "selectorLabels" . | nindent 8 }}
+        {{- include "castai-db-proxy.selectorLabels" . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -62,11 +62,11 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "name" . }}-config
+            name: {{ include "castai-db-proxy.name" . }}-config
 
       containers:
         - name: proxy
-          image: "{{ .Values.image.repository }}:{{ include "proxyImage" . }}"
+          image: "{{ .Values.image.repository }}:{{ include "castai-db-proxy.proxyImage" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --config
@@ -76,7 +76,7 @@ spec:
           envFrom:
             - secretRef:
               {{- if .Values.apiKey }}
-                name: {{ include "name" . }}
+                name: {{ include "castai-db-proxy.name" . }}
               {{- else }}
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.apiKeySecretRef }}
               {{- end }}
@@ -88,7 +88,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: K8S_DEPLOYMENT
-              value: {{ include "name" . }}
+              value: {{ include "castai-db-proxy.name" . }}
           securityContext:
             capabilities:
               drop:

--- a/charts/castai-db-proxy/templates/headless-service.yaml
+++ b/charts/castai-db-proxy/templates/headless-service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: headless-{{ include "name" . }}
+  name: headless-{{ include "castai-db-proxy.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-proxy.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-proxy.annotations" . | nindent 4 }}
 spec:
   clusterIP: None
   ports:
@@ -14,4 +14,4 @@ spec:
       targetPort: cluster
       protocol: TCP
   selector:
-    {{- include "selectorLabels" . | nindent 4 }}
+    {{- include "castai-db-proxy.selectorLabels" . | nindent 4 }}

--- a/charts/castai-db-proxy/templates/pdb.yaml
+++ b/charts/castai-db-proxy/templates/pdb.yaml
@@ -1,13 +1,13 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-proxy.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-proxy.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-proxy.annotations" . | nindent 4 }}
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      {{- include "selectorLabels" . | nindent 6 }}
+      {{- include "castai-db-proxy.selectorLabels" . | nindent 6 }}

--- a/charts/castai-db-proxy/templates/secret.yaml
+++ b/charts/castai-db-proxy/templates/secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-proxy.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-proxy.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-proxy.annotations" . | nindent 4 }}
 data:
   API_KEY: {{ .Values.apiKey | b64enc | quote }}
 {{- end }}

--- a/charts/castai-db-proxy/templates/service.yaml
+++ b/charts/castai-db-proxy/templates/service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-proxy.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-proxy.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-proxy.annotations" . | nindent 4 }}
 spec:
   {{- with .Values.service.trafficDistribution }}
   trafficDistribution: {{ . }}
@@ -24,4 +24,4 @@ spec:
       targetPort: metrics
       protocol: TCP
   selector:
-    {{- include "selectorLabels" . | nindent 4 }}
+    {{- include "castai-db-proxy.selectorLabels" . | nindent 4 }}

--- a/charts/castai-dbo/.helmignore
+++ b/charts/castai-dbo/.helmignore
@@ -1,0 +1,9 @@
+# Patterns to ignore when building packages.
+.git
+.gitignore
+.idea
+*.swp
+*.bak
+*.tmp
+*.orig
+.DS_Store

--- a/charts/castai-dbo/Chart.lock
+++ b/charts/castai-dbo/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: castai-db-proxy
+  repository: https://castai.github.io/helm-charts
+  version: 0.1.2
+- name: castai-db-agent
+  repository: https://castai.github.io/helm-charts
+  version: 0.22.0
+- name: castai-db-optimizer
+  repository: https://castai.github.io/helm-charts
+  version: 0.80.0
+digest: sha256:5a75d6d5727199b8c454e09dac029ed18b25655a55e2040581c4daed6bff2231
+generated: "2026-06-25T17:34:01.269699+03:00"

--- a/charts/castai-dbo/Chart.yaml
+++ b/charts/castai-dbo/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: castai-dbo
+description: Umbrella chart for CAST AI Database Optimizer components.
+type: application
+version: 0.1.0
+maintainers:
+  - name: CAST AI
+    url: https://cast.ai
+dependencies:
+  - name: castai-db-proxy
+    alias: db-proxy
+    version: "0.1.3"
+    repository: "https://castai.github.io/helm-charts"
+    condition: db-proxy.enabled
+  - name: castai-db-agent
+    alias: db-agent
+    version: "0.22.1"
+    repository: "https://castai.github.io/helm-charts"
+    condition: db-agent.enabled
+  - name: castai-db-optimizer
+    alias: db-optimizer
+    version: "0.80.1"
+    repository: "https://castai.github.io/helm-charts"
+    condition: db-optimizer.enabled

--- a/charts/castai-dbo/README.md
+++ b/charts/castai-dbo/README.md
@@ -1,0 +1,63 @@
+# castai-dbo
+
+Umbrella chart for CAST AI Database Optimizer components.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| CAST AI |  | <https://cast.ai> |
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://castai.github.io/helm-charts | db-agent(castai-db-agent) | 0.22.1 |
+| https://castai.github.io/helm-charts | db-optimizer(castai-db-optimizer) | 0.80.1 |
+| https://castai.github.io/helm-charts | db-proxy(castai-db-proxy) | 0.1.3 |
+
+## Usage
+
+```shell
+helm repo add castai-helm https://castai.github.io/helm-charts
+helm repo update
+
+helm upgrade --install castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent --create-namespace \
+  --set db-optimizer.apiKey=<API_KEY> \
+  --set db-optimizer.organizationID=<ORG_ID> \
+  --set db-optimizer.cacheGroupID=<CACHE_GROUP_ID> \
+  --set db-optimizer.protocol=PostgreSQL \
+  --set db-agent.apiKey=<API_KEY> \
+  --set db-agent.organizationID=<ORG_ID> \
+  --set db-agent.cacheGroupID=<CACHE_GROUP_ID>
+```
+
+### Configuring individual components
+
+Pass component-specific values through the `<component>.*` prefix:
+
+```shell
+helm upgrade --install castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent --create-namespace \
+  -f values.yaml
+```
+
+### Disabling a component
+
+Any sub-chart can be excluded:
+
+```shell
+helm upgrade castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent \
+  --reset-then-reuse-values \
+  --set db-proxy.enabled=false
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| db-agent.enabled | bool | `true` |  |
+| db-optimizer.enabled | bool | `true` |  |
+| db-proxy.enabled | bool | `true` |  |

--- a/charts/castai-dbo/README.md
+++ b/charts/castai-dbo/README.md
@@ -61,5 +61,3 @@ helm upgrade castai-dbo castai-helm/castai-dbo \
 | db-agent.enabled | bool | `true` |  |
 | db-optimizer.enabled | bool | `true` |  |
 | db-proxy.enabled | bool | `true` |  |
-| global | object | `{"organizationID":""}` | Global values forwarded to all sub-charts. |
-| global.organizationID | string | `""` | Organization ID shared by all DBO components. |

--- a/charts/castai-dbo/README.md
+++ b/charts/castai-dbo/README.md
@@ -61,3 +61,5 @@ helm upgrade castai-dbo castai-helm/castai-dbo \
 | db-agent.enabled | bool | `true` |  |
 | db-optimizer.enabled | bool | `true` |  |
 | db-proxy.enabled | bool | `true` |  |
+| global | object | `{"organizationID":""}` | Global values forwarded to all sub-charts. |
+| global.organizationID | string | `""` | Organization ID shared by all DBO components. |

--- a/charts/castai-dbo/README.md.gotmpl
+++ b/charts/castai-dbo/README.md.gotmpl
@@ -1,0 +1,52 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Usage
+
+```shell
+helm repo add castai-helm https://castai.github.io/helm-charts
+helm repo update
+
+helm upgrade --install castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent --create-namespace \
+  --set db-optimizer.apiKey=<API_KEY> \
+  --set db-optimizer.organizationID=<ORG_ID> \
+  --set db-optimizer.cacheGroupID=<CACHE_GROUP_ID> \
+  --set db-optimizer.protocol=PostgreSQL \
+  --set db-agent.apiKey=<API_KEY> \
+  --set db-agent.organizationID=<ORG_ID> \
+  --set db-agent.cacheGroupID=<CACHE_GROUP_ID>
+```
+
+### Configuring individual components
+
+Pass component-specific values through the `<component>.*` prefix:
+
+```shell
+helm upgrade --install castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent --create-namespace \
+  -f values.yaml
+```
+
+### Disabling a component
+
+Any sub-chart can be excluded:
+
+```shell
+helm upgrade castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent \
+  --reset-then-reuse-values \
+  --set db-proxy.enabled=false
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/castai-dbo/ci/test-values.yaml
+++ b/charts/castai-dbo/ci/test-values.yaml
@@ -1,6 +1,8 @@
+global:
+  organizationID: "test-org"
+
 db-proxy:
   enabled: true
-  organizationID: "test-org"
   proxyID: "test-proxy"
   apiKey: "test-key"
   endpoints:
@@ -10,7 +12,6 @@ db-proxy:
 db-agent:
   enabled: true
   apiKey: "test-key"
-  organizationID: "test-org"
   cacheGroupID: "test-cache-group"
   database:
     host: "test-db"
@@ -21,7 +22,6 @@ db-agent:
 db-optimizer:
   enabled: true
   cacheGroupID: "test-cache-group"
-  organizationID: "test-org"
   apiKey: "test-key"
   protocol: "PostgreSQL"
   endpoints:

--- a/charts/castai-dbo/ci/test-values.yaml
+++ b/charts/castai-dbo/ci/test-values.yaml
@@ -1,0 +1,32 @@
+db-proxy:
+  enabled: true
+  organizationID: "test-org"
+  proxyID: "test-proxy"
+  apiKey: "test-key"
+  endpoints:
+    - address: "db-primary:5432"
+      readonly: false
+
+db-agent:
+  enabled: true
+  apiKey: "test-key"
+  organizationID: "test-org"
+  cacheGroupID: "test-cache-group"
+  database:
+    host: "test-db"
+    username: "test-user"
+    password: "test-pass"
+  gRPCEndpoint: "grpc.example.com:443"
+
+db-optimizer:
+  enabled: true
+  cacheGroupID: "test-cache-group"
+  organizationID: "test-org"
+  apiKey: "test-key"
+  protocol: "PostgreSQL"
+  endpoints:
+    - name: "db1"
+      hostname: "db1.example.com"
+      port: 5433
+      targetPort: 5432
+      servicePort: 5433

--- a/charts/castai-dbo/ci/test-values.yaml
+++ b/charts/castai-dbo/ci/test-values.yaml
@@ -1,8 +1,6 @@
-global:
-  organizationID: "test-org"
-
 db-proxy:
   enabled: true
+  organizationID: "test-org"
   proxyID: "test-proxy"
   apiKey: "test-key"
   endpoints:
@@ -12,6 +10,7 @@ db-proxy:
 db-agent:
   enabled: true
   apiKey: "test-key"
+  organizationID: "test-org"
   cacheGroupID: "test-cache-group"
   database:
     host: "test-db"
@@ -22,6 +21,7 @@ db-agent:
 db-optimizer:
   enabled: true
   cacheGroupID: "test-cache-group"
+  organizationID: "test-org"
   apiKey: "test-key"
   protocol: "PostgreSQL"
   endpoints:

--- a/charts/castai-dbo/templates/_helpers.tpl
+++ b/charts/castai-dbo/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "castai-dbo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "castai-dbo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "castai-dbo.labels" -}}
+helm.sh/chart: {{ include "castai-dbo.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/castai-dbo/values.yaml
+++ b/charts/castai-dbo/values.yaml
@@ -1,10 +1,5 @@
 # Default values for castai-dbo umbrella chart.
 
-# -- Global values forwarded to all sub-charts.
-global:
-  # -- Organization ID shared by all DBO components.
-  organizationID: ""
-
 db-proxy:
   enabled: true
 

--- a/charts/castai-dbo/values.yaml
+++ b/charts/castai-dbo/values.yaml
@@ -1,0 +1,10 @@
+# Default values for castai-dbo umbrella chart.
+
+db-proxy:
+  enabled: true
+
+db-agent:
+  enabled: true
+
+db-optimizer:
+  enabled: true

--- a/charts/castai-dbo/values.yaml
+++ b/charts/castai-dbo/values.yaml
@@ -1,5 +1,10 @@
 # Default values for castai-dbo umbrella chart.
 
+# -- Global values forwarded to all sub-charts.
+global:
+  # -- Organization ID shared by all DBO components.
+  organizationID: ""
+
 db-proxy:
   enabled: true
 

--- a/ct.yaml
+++ b/ct.yaml
@@ -18,4 +18,5 @@ excluded-charts:
   - castai-workload-autoscaler
   - castai-workload-autoscaler-exporter
   - castai-db-proxy
+  - castai-dbo
   - castai-watchdog


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Standardizes Helm named templates across `castai-db-agent`, `castai-db-optimizer`, and `castai-db-proxy` by prefixing every helper with its chart name. Bumps each chart's patch version and adds a `.helmignore` for the new `castai-dbo` chart.

### Why
Generic template names such as `name`, `labels`, and `proxyImage` can collide when charts are combined as subcharts in an umbrella chart. Chart-scoped template names avoid these conflicts and make the templates safe to compose under `castai-dbo`.

### Key changes
- `charts/castai-db-agent/templates/_helpers.tpl` and `_versions.tpl`: renamed all defines to the `castai-db-agent.*` namespace and updated every `include` call in templates.
- `charts/castai-db-optimizer/templates/_helpers.tpl` and `_versions.tpl`: renamed all defines to the `castai-db-optimizer.*` namespace and updated every `include` call in templates.
- `charts/castai-db-proxy/templates/_helpers.tpl` and `_versions.tpl`: renamed all defines to the `castai-db-proxy.*` namespace and updated every `include` call in templates.
- Bumped chart versions: `castai-db-agent` to `0.22.1`, `castai-db-optimizer` to `0.80.1`, and `castai-db-proxy` to `0.1.3`.
- Added `charts/castai-dbo/.helmignore`.

### Impact
No user-facing behavior change or values schema change. Existing installations will render identical Kubernetes manifests. This is a non-breaking refactoring that prepares the DB charts for use as dependencies in the `castai-dbo` umbrella chart.