### PR TITLE
[castai-evictor] Remove the CRD with uninstall.

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.97
+version: 0.35.98
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/templates/crd.yaml
+++ b/charts/castai-evictor/templates/crd.yaml
@@ -3,7 +3,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    helm.sh/resource-policy: keep
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation

--- a/charts/castai-evictor/tests/crd_test.yaml
+++ b/charts/castai-evictor/tests/crd_test.yaml
@@ -39,11 +39,10 @@ tests:
 
   # ── Helm lifecycle annotations ───────────────────────────────────────────────
 
-  - it: CRD has resource-policy keep so helm uninstall does not delete it
+  - it: CRD does not have resource-policy keep so helm uninstall cleans it up
     asserts:
-      - equal:
+      - isNull:
           path: metadata.annotations["helm.sh/resource-policy"]
-          value: keep
 
   - it: CRD is applied as a pre-install pre-upgrade hook so it exists before the CR post-install hook
     asserts:
@@ -217,7 +216,7 @@ tests:
       - contains:
           path: spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.evictionRules.items["x-kubernetes-validations"]
           content:
-            rule: "(has(self.podSelector) && !has(self.nodeSelector)) || (!has(self.podSelector) && has(self.nodeSelector))"
+            rule: "has(self.podSelector) != has(self.nodeSelector)"
             message: "exactly one of podSelector or nodeSelector must be set"
 
   - it: podSelector supports namespace kind replicasMin and labelSelector


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Removes the `helm.sh/resource-policy: keep` annotation from the Evictor CRD so it is deleted when the chart is uninstalled. Also bumps the chart patch version and simplifies an existing CEL validation rule.

### Why
The `keep` policy caused the Evictor CRD to persist after `helm uninstall`, leaving orphaned resources in the cluster. Removing it ensures a complete cleanup of Evictor-managed resources.

### Key changes
- `charts/castai-evictor/templates/crd.yaml`: removed the `helm.sh/resource-policy: keep` annotation from the CRD.
- `charts/castai-evictor/Chart.yaml`: bumped chart version from `0.35.97` to `0.35.98`.
- `charts/castai-evictor/tests/crd_test.yaml`: updated the test to assert `metadata.annotations["helm.sh/resource-policy"]` is null, and simplified the `evictionRules` validation rule from a boolean expression to `has(self.podSelector) != has(self.nodeSelector)`.

### Impact
- **Behavior change:** `helm uninstall` will now remove the Evictor CRD and any custom resources defined by it.
- Users who relied on the CRD surviving uninstall to preserve custom resources will need to back up those resources before uninstalling.