### PR TITLE
fix evictor version bump in unified umbrella

### DIFF
--- a/.github/scripts/check-umbrella-drift.sh
+++ b/.github/scripts/check-umbrella-drift.sh
@@ -247,7 +247,11 @@ while IFS= read -r -d '' umb_file; do
 
   if [ -z "$matched_comp" ]; then
     echo "DEBUG: no matching component files found for ${umb_fname}" >&2
-    AI_REPORT+="### ${umb_fname}\n> ⚠️ No matching component file found — may be an umbrella-only addition.\n\n"
+    AI_REPORT+="### ${umb_fname}
+
+> ⚠️ No matching component file found — may be an umbrella-only addition.
+
+"
     continue
   fi
 
@@ -301,13 +305,38 @@ Rules:
 - ACTION REQUIRED: component has something the umbrella is missing or has differently.
 - INFORMATIONAL: umbrella has something the component doesn't.
 - One finding block per differing field. Do NOT group or summarize.
-- If no drift, output only: \"✅ No drift in ${umb_fname}.\""
+- If there is no drift, output EXACTLY this single line and nothing else: ✅ No drift in ${umb_fname}.
+- Do NOT output the word \"None\", \"N/A\", an empty string, or any other placeholder. Either emit one or more finding blocks in the format above, or the single ✅ line.
+- Use real markdown formatting (newlines, headings, fenced code blocks). Do NOT emit literal backslash-n escape sequences."
 
   file_report=$(call_kimchi "$per_file_prompt") || {
-    AI_REPORT+="### ${umb_fname}\n> ❌ API call failed — skipped.\n\n"
+    AI_REPORT+="### ${umb_fname}
+
+> ❌ API call failed — skipped.
+
+"
     continue
   }
-  AI_REPORT+="### ${umb_fname}\n${file_report}\n\n"
+
+  # Normalise the model output:
+  #  - strip surrounding whitespace
+  #  - convert literal backslash-n sequences (some models emit them) to real newlines
+  #  - collapse degenerate \"None\" / \"N/A\" / empty replies to the no-drift line
+  file_report=$(printf '%s' "$file_report" \
+    | python3 -c "import sys; s=sys.stdin.read().strip(); s=s.replace('\\\\n','\n'); print(s)")
+
+  normalised=$(printf '%s' "$file_report" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]./\\"'\''`')
+  case "$normalised" in
+    ''|none|na|nodrift|null|nil|empty|nochanges|nochange|nodifference|nodifferences)
+      file_report="✅ No drift in ${umb_fname}."
+      ;;
+  esac
+
+  AI_REPORT+="### ${umb_fname}
+
+${file_report}
+
+"
 
 done < <(find "$UMB_TEMPLATES" -name '*.yaml' | sort | tr '\n' '\0')
 

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -139,9 +139,25 @@ jobs:
         run: |
           # Image tags follow the GitHub release tag directly:
           #   castai-kvisor-1.55.21 → v1.55.21
-          # castai-live is the exception — its images don't carry the v prefix.
+          # Exceptions:
+          #   - castai-live: images don't carry the v prefix.
+          #   - castai-evictor: image tag is the appVersion (commit SHA)
+          #     from charts/castai-evictor/Chart.yaml, not the chart version.
           if [ "$CHART_NAME" = "castai-live" ]; then
             echo "image_tag=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          elif [ "$CHART_NAME" = "castai-evictor" ]; then
+            EVICTOR_CHART="helm-charts/charts/castai-evictor/Chart.yaml"
+            if [ ! -f "$EVICTOR_CHART" ]; then
+              echo "Expected ${EVICTOR_CHART} to exist in the release checkout — aborting."
+              exit 1
+            fi
+            APP_VERSION=$(yq '.appVersion' "$EVICTOR_CHART")
+            if [ -z "$APP_VERSION" ] || [ "$APP_VERSION" = "null" ]; then
+              echo "castai-evictor Chart.yaml has no appVersion — aborting."
+              exit 1
+            fi
+            echo "castai-evictor: using appVersion '${APP_VERSION}' from ${EVICTOR_CHART} as image tag."
+            echo "image_tag=${APP_VERSION}" >> $GITHUB_OUTPUT
           else
             echo "image_tag=v${CHART_VERSION}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes two release-automation issues: the umbrella drift checker now correctly formats model-generated Markdown reports, and the umbrella RC release workflow now resolves the `castai-evictor` image tag from its `appVersion` instead of the chart version.

### Why
`castai-evictor` images are tagged with the commit SHA stored as `appVersion` in `charts/castai-evictor/Chart.yaml`, but the RC release workflow was tagging them with the chart version. Separately, the drift checker's AI reports sometimes contained literal `\n` sequences or placeholder responses such as `None`/`N/A`, which broke the generated report.

### Key changes
- `.github/scripts/check-umbrella-drift.sh`
  - Updated the LLM prompt to require the exact no-drift line (`✅ No drift in ${umb_fname}.`) and real Markdown formatting.
  - Post-processes the model output: trims whitespace, converts literal `\n` sequences to real newlines, and collapses degenerate placeholder replies to the no-drift line.
  - Switched `AI_REPORT` appends to actual newlines instead of escaped `\n` characters.

- `.github/workflows/release-umbrella-rc.yml`
  - Added a special case for `castai-evictor` that reads `appVersion` from `charts/castai-evictor/Chart.yaml` and uses it as `image_tag`.
  - Aborts the workflow if the evictor `Chart.yaml` is missing or has no `appVersion`.

### Impact
- `castai-evictor` RC images will now be tagged with the correct SHA-based `appVersion`.
- The drift report will no longer contain broken escape sequences or empty placeholder findings.
- The release job now fails fast if the evictor chart metadata is unexpectedly absent.