### PR TITLE
only try to diff templates when changes between tags

### DIFF
--- a/.github/scripts/check-umbrella-drift.sh
+++ b/.github/scripts/check-umbrella-drift.sh
@@ -2,20 +2,25 @@
 # Detects structural drift between a component's Helm templates and the
 # corresponding copied templates in the kubecast umbrella chart.
 #
-# Uses Kimchi Inference (minimax-m3) to semantically compare templates,
-# handling the fact that umbrella templates have different Go template syntax
-# (.Values paths, helper names, $pp variables) but should represent the same
-# Kubernetes resource structure.
+# STRATEGY (since 2026-07):
+#   Instead of sending every template file to the AI on every release, we
+#   diff the component between its previous and current release tags first.
+#   - If only README / Chart.yaml-version-only / non-template files changed,
+#     we emit "no template changes" and skip the AI call entirely.
+#   - If template files DID change, we send the AI a unified diff per changed
+#     file together with the current umbrella file, and ask whether the
+#     umbrella reflects the component-side change.
 #
 # Required env vars:
 #   CHART_NAME        — e.g. castai-agent, castai-pod-pinner, castai-live
+#   CHART_VERSION     — e.g. 0.35.103 (used to assemble the current tag)
 #   KIMCHI_API_KEY    — Kimchi Inference API key
-#   CHART_VERSION     — required only for castai-live (cloned from GitLab at tag v<version>)
 #   GITLAB_TOKEN      — required only for castai-live (to clone gitlab.com/castai/live/clm)
 #
-# Paths expected to exist at call time:
-#   kubecast/         — clone of the kubecast repo
-#   helm-charts/      — optional, for evictor / chart-upgrader
+# Paths expected to exist at call time (created by release-umbrella-rc.yml):
+#   helm-charts/      — full clone of helm-charts at the release tag (fetch-depth:0)
+#   kubecast/         — full clone of the kubecast repo (no --depth)
+#   For castai-live the script clones gitlab.com/castai/live/clm itself.
 #
 # Writes markdown to stdout and, when GITHUB_OUTPUT is set, appends:
 #   drift_report<<DELIMITER / ... / DELIMITER
@@ -23,61 +28,137 @@
 set -euo pipefail
 
 CHART_NAME="${CHART_NAME:?CHART_NAME env var required}"
-CHART_VERSION="${CHART_VERSION:-}"
+CHART_VERSION="${CHART_VERSION:?CHART_VERSION env var required}"
 KIMCHI_API_KEY="${KIMCHI_API_KEY:?KIMCHI_API_KEY env var required}"
 
 KIMCHI_API_URL="https://llm.kimchi.dev/openai/v1/chat/completions"
 KIMCHI_MODEL="minimax-m3"
 
-# ── Locate component templates ────────────────────────────────────────────────
+# ── Component → (repo clone dir, component path, tag prefix) map ──────────────
+#
+# tag_prefix is the literal string we prepend to the version when building the
+# current tag and the glob used to list previous tags. Concretely:
+#   current_tag = <tag_prefix><CHART_VERSION>
+#
+# Repos:
+#   "helm-charts" — local checkout at ./helm-charts (full history)
+#   "kubecast"    — local clone at ./kubecast (full history)
+#   "clm"         — cloned on demand into /tmp/castai-live-source (full history)
+#
+# Components NOT listed here are not supported by the diff-based drift check
+# and will fall through to a "component not configured" skip.
 
+REPO_CLONE_DIR=""
+COMPONENT_PATH=""
+TAG_PREFIX=""
+CURRENT_TAG=""
 COMP_TEMPLATES=""
 COMP_DEPS_DIR=""
 
-if [ "$CHART_NAME" = "castai-live" ]; then
-  if [ -z "$CHART_VERSION" ]; then
-    echo "CHART_VERSION is required for castai-live" >&2
-    exit 1
-  fi
-  GITLAB_TOKEN="${GITLAB_TOKEN:?GITLAB_TOKEN env var required for castai-live}"
+configure_component() {
+  case "$CHART_NAME" in
+    castai-evictor)
+      REPO_CLONE_DIR="helm-charts"
+      COMPONENT_PATH="charts/castai-evictor"
+      TAG_PREFIX="castai-evictor-"
+      ;;
+    castai-chart-upgrader)
+      REPO_CLONE_DIR="helm-charts"
+      COMPONENT_PATH="charts/castai-chart-upgrader"
+      TAG_PREFIX="castai-chart-upgrader-"
+      ;;
+    castai-agent)
+      REPO_CLONE_DIR="kubecast"
+      COMPONENT_PATH="services/castai-agent"
+      TAG_PREFIX="castai-agent/v"
+      ;;
+    castai-pod-pinner)
+      REPO_CLONE_DIR="kubecast"
+      COMPONENT_PATH="services/castai-pod-pinner"
+      TAG_PREFIX="castai-pod-pinner/v"
+      ;;
+    castai-cluster-controller)
+      REPO_CLONE_DIR="kubecast"
+      COMPONENT_PATH="services/cluster-controller"
+      TAG_PREFIX="cluster-controller/v"
+      ;;
+    castai-kvisor)
+      REPO_CLONE_DIR="kubecast"
+      COMPONENT_PATH="services/kvisor"
+      TAG_PREFIX="kvisor/v"
+      ;;
+    castai-pod-mutator)
+      REPO_CLONE_DIR="kubecast"
+      COMPONENT_PATH="services/pod-mutator"
+      TAG_PREFIX="pod-mutator/v"
+      ;;
+    castai-spot-handler)
+      REPO_CLONE_DIR="kubecast"
+      COMPONENT_PATH="services/spot-handler"
+      TAG_PREFIX="spot-handler/v"
+      ;;
+    castai-workload-autoscaler)
+      REPO_CLONE_DIR="kubecast"
+      COMPONENT_PATH="services/workload-autoscaler/charts/castai-workload-autoscaler"
+      TAG_PREFIX="workload-autoscaler/v"
+      ;;
+    castai-workload-autoscaler-exporter)
+      REPO_CLONE_DIR="kubecast"
+      COMPONENT_PATH="services/workload-autoscaler/charts/castai-workload-autoscaler-exporter"
+      # Shares the same release tag as castai-workload-autoscaler.
+      TAG_PREFIX="workload-autoscaler/v"
+      ;;
+    castai-live)
+      REPO_CLONE_DIR="clm"   # cloned below
+      COMPONENT_PATH="helm"  # diff scope: helm/ subtree (templates + dependencies)
+      TAG_PREFIX="v"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  CURRENT_TAG="${TAG_PREFIX}${CHART_VERSION}"
+  return 0
+}
 
-  LIVE_CLONE_DIR="/tmp/castai-live-source"
-  rm -rf "$LIVE_CLONE_DIR"
-
-  git clone \
-    --depth 1 \
-    --branch "v${CHART_VERSION}" \
-    "https://oauth2:${GITLAB_TOKEN}@gitlab.com/castai/live/clm.git" \
-    "$LIVE_CLONE_DIR"
-
-  COMP_TEMPLATES="${LIVE_CLONE_DIR}/helm/templates"
-  COMP_DEPS_DIR="${LIVE_CLONE_DIR}/helm/dependencies"
-else
-  CHART_YAML_PATH=$(find kubecast/services -name "Chart.yaml" \
-    -exec grep -l "^name: ${CHART_NAME}$" {} \; 2>/dev/null | head -1 || true)
-
-  if [ -z "$CHART_YAML_PATH" ] && [ -d "helm-charts/charts/${CHART_NAME}" ]; then
-    CHART_YAML_PATH="helm-charts/charts/${CHART_NAME}/Chart.yaml"
-  fi
-
-  if [ -z "$CHART_YAML_PATH" ]; then
-    cat <<MD
+if ! configure_component; then
+  cat <<MD
 ## Template drift: \`${CHART_NAME}\`
 
-> Chart not found in \`kubecast/services/\` or \`helm-charts/charts/\` — skipping drift check.
+> Component is not configured for the diff-based drift check — skipping.
+> Add it to \`configure_component\` in \`.github/scripts/check-umbrella-drift.sh\` to enable.
 MD
-    exit 0
-  fi
-  COMP_TEMPLATES="$(dirname "$CHART_YAML_PATH")/templates"
+  exit 0
+fi
+
+# ── Special handling for castai-live (clone clm with full history) ────────────
+
+if [ "$CHART_NAME" = "castai-live" ]; then
+  GITLAB_TOKEN="${GITLAB_TOKEN:?GITLAB_TOKEN env var required for castai-live}"
+  LIVE_CLONE_DIR="/tmp/castai-live-source"
+  rm -rf "$LIVE_CLONE_DIR"
+  git clone \
+    "https://oauth2:${GITLAB_TOKEN}@gitlab.com/castai/live/clm.git" \
+    "$LIVE_CLONE_DIR"
+  # Reroute REPO_CLONE_DIR to the actual checkout path.
+  REPO_CLONE_DIR="$LIVE_CLONE_DIR"
+  # Check out the release tag in a detached-head state so on-disk file reads
+  # (used by the umbrella-file matcher) reflect the released code.
+  git -C "$REPO_CLONE_DIR" checkout -q "$CURRENT_TAG"
+  COMP_TEMPLATES="${REPO_CLONE_DIR}/helm/templates"
+  COMP_DEPS_DIR="${REPO_CLONE_DIR}/helm/dependencies"
+else
+  COMP_TEMPLATES="${REPO_CLONE_DIR}/${COMPONENT_PATH}/templates"
 fi
 
 UMB_TEMPLATES="kubecast/castai-umbrella/chart/templates/${CHART_NAME}"
 
-if [ ! -d "$COMP_TEMPLATES" ]; then
+# Sanity-check clone exists.
+if [ ! -d "$REPO_CLONE_DIR/.git" ]; then
   cat <<MD
 ## Template drift: \`${CHART_NAME}\`
 
-> Component templates not found at \`${COMP_TEMPLATES}\` — skipping drift check.
+> Expected clone at \`${REPO_CLONE_DIR}\` not found — skipping drift check.
 MD
   exit 0
 fi
@@ -92,7 +173,154 @@ MD
   exit 0
 fi
 
-# ── Kimchi API call helper ────────────────────────────────────────────────────
+# ── Verify current tag exists in the clone ────────────────────────────────────
+
+if ! git -C "$REPO_CLONE_DIR" rev-parse --verify --quiet "refs/tags/${CURRENT_TAG}" >/dev/null; then
+  cat <<MD
+## Template drift: \`${CHART_NAME}\`
+
+> Current release tag \`${CURRENT_TAG}\` not found in \`${REPO_CLONE_DIR}\` — skipping drift check.
+> The clone may be shallow or the tag may not have been pushed yet.
+MD
+  exit 0
+fi
+
+# ── Find the previous tag for this component ──────────────────────────────────
+# We list every tag matching the prefix, version-sort descending, and pick the
+# entry immediately following the current tag. Using --sort=-v:refname keeps
+# semver ordering correct even when point releases land out of order.
+
+# Match `<prefix><digit>...` only — a bare `${TAG_PREFIX}*` glob would also
+# match sibling components whose name extends ours (e.g. `castai-evictor-*`
+# would match `castai-evictor-ext-0.5.0`).
+TAG_GLOB="${TAG_PREFIX}[0-9]*"
+
+PREV_TAG=$(git -C "$REPO_CLONE_DIR" tag -l "$TAG_GLOB" --sort=-v:refname \
+  | awk -v cur="$CURRENT_TAG" '
+      $0 == cur { found = 1; next }
+      found     { print; exit }
+    ')
+
+if [ -z "$PREV_TAG" ]; then
+  cat <<MD
+## Template drift: \`${CHART_NAME}\`
+
+> ℹ️ First release of this component (no prior tag matching \`${TAG_GLOB}\` before \`${CURRENT_TAG}\`) — AI drift check skipped.
+MD
+  exit 0
+fi
+
+echo "DEBUG: diffing ${PREV_TAG} → ${CURRENT_TAG} for ${COMPONENT_PATH}" >&2
+
+# ── Classify changed files ────────────────────────────────────────────────────
+#
+# Rules (per the agreed plan):
+#   - README* (case-insensitive)           → ignored
+#   - Chart.yaml with ONLY version/         → ignored
+#     appVersion lines changed
+#   - Chart.yaml with any other change      → template-relevant
+#   - ci/ test-values files                 → ignored
+#   - Anything outside templates/ and not   → ignored
+#     covered above
+#   - Anything inside templates/ (incl.     → template-relevant
+#     _helpers.tpl etc.)
+
+CHANGED_FILES=()
+IGNORED_FILES=()
+TEMPLATE_FILES=()
+
+# git diff prints paths relative to the repo root; we filter by COMPONENT_PATH.
+# Avoid `mapfile` for portability with bash 3.2 (macOS default).
+while IFS= read -r line; do
+  [ -n "$line" ] && CHANGED_FILES+=("$line")
+done < <(
+  git -C "$REPO_CLONE_DIR" diff --name-only "${PREV_TAG}..${CURRENT_TAG}" -- "${COMPONENT_PATH}"
+)
+
+# Is a Chart.yaml change limited to version: / appVersion:?
+# Returns 0 if yes (ignorable), 1 if no (template-relevant).
+chart_yaml_only_version_changed() {
+  local rel_path="$1"
+  local prev_content cur_content
+  prev_content=$(git -C "$REPO_CLONE_DIR" show "${PREV_TAG}:${rel_path}" 2>/dev/null || true)
+  cur_content=$(git -C "$REPO_CLONE_DIR" show "${CURRENT_TAG}:${rel_path}" 2>/dev/null || true)
+  # If either side is missing, treat as template-relevant (add/remove).
+  if [ -z "$prev_content" ] || [ -z "$cur_content" ]; then
+    return 1
+  fi
+  # Strip version: / appVersion: lines from both sides and compare.
+  local prev_stripped cur_stripped
+  prev_stripped=$(printf '%s\n' "$prev_content" | grep -Ev '^[[:space:]]*(version|appVersion)[[:space:]]*:')
+  cur_stripped=$(printf '%s\n' "$cur_content"  | grep -Ev '^[[:space:]]*(version|appVersion)[[:space:]]*:')
+  [ "$prev_stripped" = "$cur_stripped" ]
+}
+
+for f in "${CHANGED_FILES[@]}"; do
+  # Path relative to COMPONENT_PATH (e.g. "templates/deployment.yaml").
+  rel="${f#${COMPONENT_PATH}/}"
+  base=$(basename "$rel")
+
+  # README* (case-insensitive)
+  base_lower=$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')
+  if [[ "$base_lower" == readme* ]]; then
+    IGNORED_FILES+=("$f (README)")
+    continue
+  fi
+
+  # ci/ directory
+  if [[ "$rel" == ci/* ]]; then
+    IGNORED_FILES+=("$f (ci/)")
+    continue
+  fi
+
+  # Chart.yaml — ignore if only version/appVersion changed
+  if [ "$base" = "Chart.yaml" ]; then
+    if chart_yaml_only_version_changed "$f"; then
+      IGNORED_FILES+=("$f (Chart.yaml version-only)")
+      continue
+    fi
+    TEMPLATE_FILES+=("$f")
+    continue
+  fi
+
+  # Anything inside templates/ is template-relevant
+  if [[ "$rel" == templates/* ]]; then
+    TEMPLATE_FILES+=("$f")
+    continue
+  fi
+
+  # For castai-live, dependencies/ subtree is also template-relevant
+  # (it's flattened into umbrella files like aws-vpc-cni.yaml, crd.yaml).
+  if [ "$CHART_NAME" = "castai-live" ] && [[ "$rel" == dependencies/* ]]; then
+    TEMPLATE_FILES+=("$f")
+    continue
+  fi
+
+  # Everything else: outside templates/, not Chart.yaml/README/ci → ignored.
+  IGNORED_FILES+=("$f (outside templates/)")
+done
+
+# ── If nothing template-relevant changed, emit the short-circuit message ─────
+
+if [ ${#TEMPLATE_FILES[@]} -eq 0 ]; then
+  REPORT="## Template drift: \`${CHART_NAME}\`
+
+✅ No template changes between \`${PREV_TAG}\` and \`${CURRENT_TAG}\` — AI drift check skipped."
+
+  echo "$REPORT"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    DELIMITER="DRIFT_EOF_$(date +%s%N)"
+    {
+      echo "drift_report<<${DELIMITER}"
+      echo "$REPORT"
+      echo "${DELIMITER}"
+    } >> "$GITHUB_OUTPUT"
+  fi
+  exit 0
+fi
+
+# ── Kimchi API call helper (unchanged from previous revision) ─────────────────
 
 call_kimchi() {
   local prompt="$1"
@@ -150,106 +378,113 @@ EOF
   fi
 }
 
-# ── Find matching component files for an umbrella filename ───────────────────
-# For castai-live, umbrella files are flattened from subdirs and deps:
-#   controller.yaml  ← helm/templates/controller/*.yaml
-#   daemon.yaml      ← helm/templates/daemon/*.yaml
-#   tc.yaml          ← helm/templates/tc/*.yaml
-#   aws-vpc-cni.yaml ← helm/dependencies/aws-vpc-cni/templates/*.yaml
-#   crd.yaml         ← helm/dependencies/crds/templates/*.yaml
-# For other charts, filenames match 1:1.
+# ── Map a changed component-side path to the matching umbrella file ───────────
+#
+# For non-live components, umbrella filenames match the component-side basename
+# 1:1 (e.g. templates/deployment.yaml ↔ umbrella/deployment.yaml). Chart.yaml
+# has no umbrella counterpart and is reported on its own.
+#
+# For castai-live the umbrella collapses each subdir / dependency into a single
+# file:
+#   helm/templates/<subdir>/foo.yaml       → <subdir>.yaml
+#   helm/templates/<name>.yaml             → <name>.yaml
+#   helm/dependencies/<dep>/templates/*    → <dep>.yaml (or fuzzy variants)
 
-get_comp_content_for_umb() {
-  local umb_fname="$1"
-  local base="${umb_fname%.yaml}"
-  local out=""
+umbrella_file_for_component_path() {
+  local comp_rel="$1"   # relative to COMPONENT_PATH, e.g. "templates/deployment.yaml"
+  local base
+  base=$(basename "$comp_rel")
 
   if [ "$CHART_NAME" = "castai-live" ]; then
-    # Check for a matching subdir in helm/templates/<base>/
-    local subdir="${COMP_TEMPLATES}/${base}"
-    if [ -d "$subdir" ]; then
-      while IFS= read -r -d '' f; do
-        local fname
-        fname=$(basename "$f")
-        [[ "$fname" == _* ]] && continue
-        out+="### File: ${base}/${fname}\n\`\`\`yaml\n$(cat "$f")\n\`\`\`\n\n"
-      done < <(find "$subdir" -name '*.yaml' -o -name '*.tpl' | sort | tr '\n' '\0')
+    # helm/templates/<subdir>/foo.yaml → <subdir>.yaml
+    if [[ "$comp_rel" == templates/*/* ]]; then
+      local subdir
+      subdir=$(echo "$comp_rel" | awk -F/ '{print $2}')
+      echo "${UMB_TEMPLATES}/${subdir}.yaml"
+      return 0
     fi
-
-    # Check for a matching file directly in helm/templates/<base>.yaml
-    local direct_file="${COMP_TEMPLATES}/${umb_fname}"
-    if [ -f "$direct_file" ]; then
-      out+="### File: ${umb_fname}\n\`\`\`yaml\n$(cat "$direct_file")\n\`\`\`\n\n"
+    # helm/templates/<file>.yaml → <file>.yaml
+    if [[ "$comp_rel" == templates/* ]]; then
+      echo "${UMB_TEMPLATES}/${base}"
+      return 0
     fi
-
-    # Check for a matching dependency in helm/dependencies/
-    if [ -d "$COMP_DEPS_DIR" ]; then
-      # Try exact dep name match (e.g. aws-vpc-cni.yaml -> aws-vpc-cni/)
-      local dep_dir="${COMP_DEPS_DIR}/${base}"
-      if [ -d "${dep_dir}/templates" ]; then
-        while IFS= read -r -d '' f; do
-          local fname
-          fname=$(basename "$f")
-          [[ "$fname" == _* ]] && continue
-          out+="### File: ${base}/${fname}\n\`\`\`yaml\n$(cat "$f")\n\`\`\`\n\n"
-        done < <(find "${dep_dir}/templates" -name '*.yaml' -o -name '*.tpl' | sort | tr '\n' '\0')
-      fi
-
-      # Also try fuzzy match: dep dir name contains base or base contains dep name
-      # e.g. crd.yaml -> crds/, aws-vpc-cni-extra.yaml -> aws-vpc-cni-extra/
-      for dep in "$COMP_DEPS_DIR"/*/; do
-        [ -d "$dep" ] || continue
-        local dep_name
-        dep_name=$(basename "$dep")
-        [ "$dep_name" = "$base" ] && continue  # already handled above
-        if [[ "$dep_name" == "$base"* ]] || [[ "$base" == "$dep_name"* ]] || [[ "$dep_name" == "crds" && "$base" == "crd" ]]; then
-          if [ -d "${dep}/templates" ]; then
-            while IFS= read -r -d '' f; do
-              local fname
-              fname=$(basename "$f")
-              [[ "$fname" == _* ]] && continue
-              out+="### File: ${dep_name}/${fname}\n\`\`\`yaml\n$(cat "$f")\n\`\`\`\n\n"
-            done < <(find "${dep}/templates" -name '*.yaml' -o -name '*.tpl' | sort | tr '\n' '\0')
-          fi
-        fi
-      done
+    # helm/dependencies/<dep>/templates/*.yaml → <dep>.yaml (or crds → crd.yaml)
+    if [[ "$comp_rel" == dependencies/*/templates/* ]]; then
+      local dep
+      dep=$(echo "$comp_rel" | awk -F/ '{print $2}')
+      # crds → crd.yaml special-case (matches existing matcher)
+      [ "$dep" = "crds" ] && dep="crd"
+      echo "${UMB_TEMPLATES}/${dep}.yaml"
+      return 0
     fi
-  else
-    # Non-live: match by filename directly
-    local match
-    match=$(find "$COMP_TEMPLATES" -name "${umb_fname}" | head -1 || true)
-    if [ -n "$match" ]; then
-      out+="### File: ${umb_fname}\n\`\`\`yaml\n$(cat "$match")\n\`\`\`\n\n"
-    fi
+    # Anything else has no umbrella counterpart
+    echo ""
+    return 0
   fi
 
-  echo -e "$out"
+  # Non-live: 1:1 by basename, but only for files under templates/.
+  if [[ "$comp_rel" == templates/* ]]; then
+    echo "${UMB_TEMPLATES}/${base}"
+    return 0
+  fi
+
+  # Chart.yaml or other component-root file: no umbrella counterpart.
+  echo ""
+  return 0
 }
 
-# ── Build context note ────────────────────────────────────────────────────────
+# ── Per-file AI calls ─────────────────────────────────────────────────────────
 
 CASTAI_LIVE_NOTE=""
 if [ "$CHART_NAME" = "castai-live" ]; then
-  CASTAI_LIVE_NOTE="NOTE: castai-live's component templates are split across subdirectories (controller/, daemon/, tc/) and dependency charts (aws-vpc-cni, crds, etc.) which are all flattened into single files in the umbrella (controller.yaml, daemon.yaml, tc.yaml, aws-vpc-cni.yaml, crd.yaml, etc.). Match resources by kind and name pattern — do not report drift just because a resource appears in a different file. Report ALL structural differences; the reviewer will decide what is intentional."
+  CASTAI_LIVE_NOTE="NOTE: castai-live's component templates live in subdirectories (controller/, daemon/, tc/) and dependency charts (aws-vpc-cni/, crds/, …) which are all flattened into single files in the umbrella (controller.yaml, daemon.yaml, tc.yaml, aws-vpc-cni.yaml, crd.yaml, …). Match resources by kind and name pattern, not by file path."
 fi
-
-# ── Call Kimchi per umbrella file ─────────────────────────────────────────────
 
 AI_REPORT=""
 
-while IFS= read -r -d '' umb_file; do
-  umb_fname=$(basename "$umb_file")
-  umb_content=$(cat "$umb_file")
+for comp_path in "${TEMPLATE_FILES[@]}"; do
+  rel="${comp_path#${COMPONENT_PATH}/}"
+  echo "DEBUG: processing changed component file ${rel}" >&2
 
-  echo "DEBUG: processing umbrella file ${umb_fname}" >&2
+  # Compute the unified diff between the two tags for this file.
+  file_diff=$(git -C "$REPO_CLONE_DIR" diff --no-color "${PREV_TAG}..${CURRENT_TAG}" -- "${comp_path}")
+  if [ -z "$file_diff" ]; then
+    # Shouldn't happen — git already told us this file changed.
+    echo "DEBUG: empty diff for ${rel} — skipping" >&2
+    continue
+  fi
 
-  matched_comp=$(get_comp_content_for_umb "$umb_fname")
+  # Chart.yaml drift is reported standalone (no umbrella counterpart).
+  if [ "$(basename "$rel")" = "Chart.yaml" ]; then
+    AI_REPORT+="### ${rel}
 
-  if [ -z "$matched_comp" ]; then
-    echo "DEBUG: no matching component files found for ${umb_fname}" >&2
-    AI_REPORT+="### ${umb_fname}
+> ℹ️ Chart.yaml changed between \`${PREV_TAG}\` and \`${CURRENT_TAG}\` beyond the version/appVersion bump. Review manually — no umbrella counterpart exists for this file.
 
-> ⚠️ No matching component file found — may be an umbrella-only addition.
+\`\`\`diff
+${file_diff}
+\`\`\`
+
+"
+    continue
+  fi
+
+  # Find the matching umbrella file.
+  umb_path=$(umbrella_file_for_component_path "$rel")
+  umb_fname=""
+  umb_content=""
+  if [ -n "$umb_path" ] && [ -f "$umb_path" ]; then
+    umb_fname=$(basename "$umb_path")
+    umb_content=$(cat "$umb_path")
+  fi
+
+  if [ -z "$umb_content" ]; then
+    AI_REPORT+="### ${rel}
+
+> ⚠️ Component file changed but no matching umbrella file was found (expected at \`${umb_path:-unknown}\`). Manual review required.
+
+\`\`\`diff
+${file_diff}
+\`\`\`
 
 "
     continue
@@ -260,35 +495,25 @@ while IFS= read -r -d '' umb_file; do
 CONTEXT:
 - The umbrella chart is a near-verbatim copy of component templates, adapted with different .Values paths (e.g. \$pp.image.tag), different helper names, and an outer {{- \$pp := index .Values... }} binding. These are EXPECTED and should NOT be reported.
 - ${CASTAI_LIVE_NOTE}
+- The component file \`${rel}\` changed between tags \`${PREV_TAG}\` and \`${CURRENT_TAG}\`. The unified diff is below. Your job is to determine whether the CURRENT umbrella file already reflects each component-side change. If it does, the umbrella is in sync for that change. If it does not, that is drift.
 
-UMBRELLA FILE: ${umb_fname}
+COMPONENT DIFF (${rel}, ${PREV_TAG} → ${CURRENT_TAG}):
+\`\`\`diff
+${file_diff}
+\`\`\`
+
+CURRENT UMBRELLA FILE (${umb_fname}):
 \`\`\`yaml
 ${umb_content}
 \`\`\`
 
-COMPONENT FILES (matched to this umbrella file):
-${matched_comp}
-
 YOUR TASK:
-Compare every Kubernetes resource in the umbrella file against the component files. For each difference found in any of these fields:
-- env / envFrom entries (name, value, valueFrom)
-- volumes and volumeMounts (name, mountPath, type)
-- livenessProbe / readinessProbe / startupProbe
-- ports (name, containerPort, protocol)
-- securityContext (pod-level and container-level)
-- resources (requests and limits)
-- tolerations, affinity, nodeSelector, topologySpreadConstraints
-- RBAC rules (apiGroups, resources, verbs)
-- initContainers and sidecars
-- args and command
-- imagePullPolicy, serviceAccountName, hostNetwork, dnsPolicy
-- Any other spec fields present in either side
-
-Output exactly this format per difference:
+For every semantic change visible in the component diff (additions, deletions, modifications to env, volumes, probes, ports, securityContext, resources, tolerations, affinity, nodeSelector, RBAC rules, initContainers, args, command, imagePullPolicy, serviceAccountName, hostNetwork, dnsPolicy, or any other spec field), check whether the current umbrella file already contains the equivalent value. Ignore expected adaptations (helper names, .Values paths, \$pp variable). Use this format per finding:
 ---
+**Change in component:** <one-line summary of what changed in the diff>
 **Resource:** \`<kind>/<name-pattern>\`
 **Field:** \`<field path>\`
-**Component:**
+**Component (new value):**
 \`\`\`yaml
 <value or \"(absent)\">
 \`\`\`
@@ -296,57 +521,74 @@ Output exactly this format per difference:
 \`\`\`yaml
 <value or \"(absent)\">
 \`\`\`
-**Classification:** ACTION REQUIRED | INFORMATIONAL
+**Status:** IN SYNC | DRIFT
 **Reason:** <one sentence>
 
 ---
 
 Rules:
-- ACTION REQUIRED: component has something the umbrella is missing or has differently.
-- INFORMATIONAL: umbrella has something the component doesn't.
-- One finding block per differing field. Do NOT group or summarize.
-- If there is no drift, output EXACTLY this single line and nothing else: ✅ No drift in ${umb_fname}.
-- Do NOT output the word \"None\", \"N/A\", an empty string, or any other placeholder. Either emit one or more finding blocks in the format above, or the single ✅ line.
+- IN SYNC: the umbrella already reflects this component change (modulo expected adaptations).
+- DRIFT: the umbrella is missing this change or has a different value.
+- One finding block per distinct semantic change.
+- If every component-side change is already reflected in the umbrella, output EXACTLY this single line and nothing else: ✅ Umbrella in sync with ${rel} between ${PREV_TAG} and ${CURRENT_TAG}.
+- Do NOT output the word \"None\", \"N/A\", an empty string, or any other placeholder.
 - Use real markdown formatting (newlines, headings, fenced code blocks). Do NOT emit literal backslash-n escape sequences."
 
   file_report=$(call_kimchi "$per_file_prompt") || {
-    AI_REPORT+="### ${umb_fname}
+    AI_REPORT+="### ${rel}
 
-> ❌ API call failed — skipped.
+> ❌ API call failed — skipped. See workflow logs for the HTTP status and error body.
 
 "
     continue
   }
 
-  # Normalise the model output:
+  # Normalise model output:
   #  - strip surrounding whitespace
-  #  - convert literal backslash-n sequences (some models emit them) to real newlines
-  #  - collapse degenerate \"None\" / \"N/A\" / empty replies to the no-drift line
+  #  - convert literal backslash-n sequences to real newlines
+  #  - collapse degenerate "None" / "N/A" / empty replies to the no-drift line
   file_report=$(printf '%s' "$file_report" \
     | python3 -c "import sys; s=sys.stdin.read().strip(); s=s.replace('\\\\n','\n'); print(s)")
 
   normalised=$(printf '%s' "$file_report" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]./\\"'\''`')
   case "$normalised" in
-    ''|none|na|nodrift|null|nil|empty|nochanges|nochange|nodifference|nodifferences)
-      file_report="✅ No drift in ${umb_fname}."
+    ''|none|na|nodrift|null|nil|empty|nochanges|nochange|nodifference|nodifferences|insync|umbrellainsync*)
+      file_report="✅ Umbrella in sync with ${rel} between \`${PREV_TAG}\` and \`${CURRENT_TAG}\`."
       ;;
   esac
 
-  AI_REPORT+="### ${umb_fname}
+  AI_REPORT+="### ${rel}
 
 ${file_report}
 
 "
+done
 
-done < <(find "$UMB_TEMPLATES" -name '*.yaml' | sort | tr '\n' '\0')
+# ── Build the ignored-files appendix ──────────────────────────────────────────
+
+IGNORED_BLOCK=""
+if [ ${#IGNORED_FILES[@]} -gt 0 ]; then
+  IGNORED_BLOCK=$'\n<details><summary>Filtered out '"${#IGNORED_FILES[@]}"$' non-template change(s)</summary>\n\n'
+  for f in "${IGNORED_FILES[@]}"; do
+    IGNORED_BLOCK+="- \`${f}\`"$'\n'
+  done
+  IGNORED_BLOCK+=$'\n</details>\n'
+fi
 
 # ── Build final report ────────────────────────────────────────────────────────
 
+CHANGED_LIST=""
+for f in "${TEMPLATE_FILES[@]}"; do
+  CHANGED_LIST+="- \`${f#${COMPONENT_PATH}/}\`"$'\n'
+done
+
 REPORT="## Template drift: \`${CHART_NAME}\`
 
-_Compared \`${COMP_TEMPLATES}\` (component) vs \`${UMB_TEMPLATES}\` (umbrella) using ${KIMCHI_MODEL}._
+_Compared component tags \`${PREV_TAG}\` → \`${CURRENT_TAG}\` against umbrella \`${UMB_TEMPLATES}\` using ${KIMCHI_MODEL}._
 
-${AI_REPORT}"
+**Changed template files:**
+${CHANGED_LIST}
+${AI_REPORT}${IGNORED_BLOCK}"
 
 echo "$REPORT"
 

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -108,7 +108,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag_name }}
-          fetch-depth: 1
+          # fetch-depth: 0 — drift check needs full tag history to diff
+          # the current release against the previous component tag.
+          fetch-depth: 0
           path: helm-charts
 
       - name: Checkout helm-charts at HEAD (for scripts)
@@ -125,6 +127,9 @@ jobs:
           GITLAB_TOKEN: ${{ secrets.GITLAB_PAT_OANA }}
         run: |
           git config --global credential.helper '!f() { echo "username=oauth2"; echo "password='"${GITLAB_TOKEN}"'"; }; f'
+          # Full clone (no --depth) is required: the drift check diffs the
+          # current component tag against the previous component tag via
+          # `git log` / `git diff` against the local tag list.
           git clone https://gitlab.com/castai/kubecast.git kubecast
           cd kubecast
           git config user.email "ci@cast.ai"


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
The umbrella drift check now diffs a component between its previous and current release tags before calling the AI. If only non-template files changed (README, version-only `Chart.yaml`, `ci/`, etc.) the AI check is skipped entirely. When templates do change, the AI receives the per-file unified diff plus the current umbrella file to determine if the umbrella already reflects the change.

### Why
Sending every template to the AI on every release was slow and expensive. Short-circuiting when no template files changed reduces cost and noise while keeping the drift signal meaningful.

### Key changes
- `.github/scripts/check-umbrella-drift.sh`
  - Added `configure_component()` mapping each `CHART_NAME` to its repo clone, component path, and tag prefix for both `helm-charts` and `kubecast` components.
  - `CHART_VERSION` is now required for all components (previously only for `castai-live`).
  - Components without a configured mapping now emit a skip message instead of failing.
  - Computes `PREV_TAG` and `CURRENT_TAG` from the local tag list using version-sorted tag globbing.
  - Classifies changed files with `chart_yaml_only_version_changed()` and ignores README files, `ci/`, `Chart.yaml` version-only bumps, and files outside `templates/` (or `dependencies/` for `castai-live`).
  - Short-circuits to a “no template changes” report when `TEMPLATE_FILES` is empty.
  - Switched AI comparison from umbrella-file-driven to component-diff-driven: computes `file_diff` via `git diff`, maps each changed component path to its umbrella file via `umbrella_file_for_component_path()`, and asks the model whether the umbrella is in sync with the diff.
  - Updated normalization logic for no-drift responses.
  - Added an ignored-files appendix to the final markdown report.
- `.github/workflows/release-umbrella-rc.yml`
  - Changed `helm-charts` checkout `fetch-depth` from `1` to `0` so the drift script can list and diff tags.
  - Changed `kubecast` clone from shallow to full history and added explanatory comments.

### Impact
- The workflow now does full clones of `helm-charts` and `kubecast`, which uses more disk/IO and checkout time than shallow clones.
- Drift checks for components with only metadata/version changes will now skip AI calls entirely.
- Any component not listed in `configure_component()` will be skipped; add it there to enable the diff-based check.