### PR TITLE
NOJIRA: Bumped db-proxy version

### DIFF
--- a/charts/castai-db-proxy/Chart.yaml
+++ b/charts/castai-db-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-proxy
 description: CAST AI database proxy cache deployment.
 type: application
-version: 0.1.2
+version: 0.2.0

--- a/charts/castai-db-proxy/README.md
+++ b/charts/castai-db-proxy/README.md
@@ -1,6 +1,6 @@
 # castai-db-proxy
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database proxy cache deployment.
 

--- a/charts/castai-db-proxy/templates/_versions.tpl
+++ b/charts/castai-db-proxy/templates/_versions.tpl
@@ -1,1 +1,1 @@
-{{- define "defaultProxyVersion" -}}v0.1.0{{- end -}}
+{{- define "defaultProxyVersion" -}}v0.2.0{{- end -}}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the default CAST AI database proxy image version from `v0.1.0` to `v0.2.0` and releases chart version `0.2.0`.

### Key changes
- `charts/castai-db-proxy/Chart.yaml` — chart version bumped from `0.1.2` to `0.2.0`.
- `charts/castai-db-proxy/README.md` — version badge updated to `0.2.0`.
- `charts/castai-db-proxy/templates/_versions.tpl` — `defaultProxyVersion` updated from `v0.1.0` to `v0.2.0`.

### Impact
This changes the default proxy image deployed by the chart. Existing installations that rely on the default version will be upgraded to `v0.2.0` on the next Helm upgrade.