### PR TITLE
[castai-db-agent] prefix template names

### DIFF
--- a/charts/castai-db-agent/Chart.yaml
+++ b/charts/castai-db-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-agent
 description: CAST AI DB agent deployment.
 type: application
-version: 0.22.0
+version: 0.22.1

--- a/charts/castai-db-agent/README.md
+++ b/charts/castai-db-agent/README.md
@@ -1,6 +1,6 @@
 # castai-db-agent
 
-![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.22.1](https://img.shields.io/badge/Version-0.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI DB agent deployment.
 

--- a/charts/castai-db-agent/templates/_helpers.tpl
+++ b/charts/castai-db-agent/templates/_helpers.tpl
@@ -2,40 +2,40 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "castai-db-agent.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
+{{- define "castai-db-agent.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Define common labels.
 */}}
-{{- define "labels" -}}
+{{- define "castai-db-agent.labels" -}}
 app.kubernetes.io/managed-by: Helm
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/name: {{ include "name" . }}
-helm.sh/chart: {{ include "chart" . }}
+app.kubernetes.io/name: {{ include "castai-db-agent.name" . }}
+helm.sh/chart: {{ include "castai-db-agent.chart" . }}
 {{- end }}
 
-{{- define "dbAgentImage" -}}
-{{-  default (include "defaultDbAgentVersion" .) .Values.image.tag }}
+{{- define "castai-db-agent.dbAgentImage" -}}
+{{-  default (include "castai-db-agent.defaultDbAgentVersion" .) .Values.image.tag }}
 {{- end }}
 
-{{- define "cloudSqlProxyImage" -}}
-{{-  default (include "defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
+{{- define "castai-db-agent.cloudSqlProxyImage" -}}
+{{-  default (include "castai-db-agent.defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
 {{- end }}
 
 {{- define "castai-db-agent.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "name" .) .Values.serviceAccount.name }}
+{{- default (include "castai-db-agent.name" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/castai-db-agent/templates/_versions.tpl
+++ b/charts/castai-db-agent/templates/_versions.tpl
@@ -1,2 +1,2 @@
-{{- define "defaultDbAgentVersion" -}}v0.21.0{{- end -}}
-{{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
+{{- define "castai-db-agent.defaultDbAgentVersion" -}}v0.21.0{{- end -}}
+{{- define "castai-db-agent.defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}

--- a/charts/castai-db-agent/templates/api-key-secret.yaml
+++ b/charts/castai-db-agent/templates/api-key-secret.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}-api-key
+  name: {{ include "castai-db-agent.name" . }}-api-key
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-agent.labels" . | nindent 4 }}
 data:
   API_KEY: {{ .Values.apiKey | b64enc | quote }}
 {{- end }}

--- a/charts/castai-db-agent/templates/db-user-secret.yaml
+++ b/charts/castai-db-agent/templates/db-user-secret.yaml
@@ -8,9 +8,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}-db-user
+  name: {{ include "castai-db-agent.name" . }}-db-user
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-agent.labels" . | nindent 4 }}
 data:
   DATABASE_USERNAME: {{ .Values.database.username | b64enc | quote }}
   {{- if and (not .Values.database.useCloudSQLIAMAuth) (not .Values.database.useRDSIAMAuth) }}

--- a/charts/castai-db-agent/templates/deployment.yaml
+++ b/charts/castai-db-agent/templates/deployment.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "name" $ }}
+  name: {{ include "castai-db-agent.name" $ }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-agent.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "name" . }}
+      app.kubernetes.io/name: {{ include "castai-db-agent.name" . }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "name" . }}
+        app.kubernetes.io/name: {{ include "castai-db-agent.name" . }}
     spec:
       serviceAccountName: {{ include "castai-db-agent.serviceAccountName" . }}
       containers:
         - name: db-agent
-          image: "{{.Values.image.repository}}:{{ include "dbAgentImage" . }}"
+          image: "{{.Values.image.repository}}:{{ include "castai-db-agent.dbAgentImage" . }}"
           imagePullPolicy: {{.Values.image.pullPolicy}}
           securityContext:
             capabilities:
@@ -86,19 +86,19 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: K8S_DEPLOYMENT
-              value: {{ include "name" . }}
+              value: {{ include "castai-db-agent.name" . }}
             - name: AGENT_IMAGE
-              value: {{ include "dbAgentImage" . }}
+              value: {{ include "castai-db-agent.dbAgentImage" . }}
           envFrom:
             - secretRef:
               {{- if .Values.apiKey }}
-                name: {{ include "name" . -}}-api-key
+                name: {{ include "castai-db-agent.name" . -}}-api-key
               {{- else }}
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.apiKeySecretRef -}}
               {{- end }}
             {{- if .Values.database.username }}
             - secretRef:
-                name: {{ include "name" $ }}-db-user
+                name: {{ include "castai-db-agent.name" $ }}-db-user
             {{- else if .Values.database.credentialsSecretRef }}
             - secretRef:
                 name: {{ .Values.database.credentialsSecretRef -}}
@@ -107,7 +107,7 @@ spec:
             {{- end }}
         {{- if and .Values.cloudSqlProxy .Values.cloudSqlProxy.enabled }}
         - name: cloud-sql-proxy
-          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "cloudSqlProxyImage" . }}"
+          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "castai-db-agent.cloudSqlProxyImage" . }}"
           imagePullPolicy: {{ $.Values.cloudSqlProxyImage.pullPolicy }}
           args:
             {{- if .Values.cloudSqlProxy.privateIp }}

--- a/charts/castai-db-agent/templates/serviceaccount.yaml
+++ b/charts/castai-db-agent/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "castai-db-agent.serviceAccountName" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-agent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Prefix all Helm named templates in the `castai-db-agent` chart with `castai-db-agent.` to avoid template name collisions when the chart is used as a dependency or alongside other charts.

### Why
Helm template definitions share a global namespace within a release. Generic names such as `name`, `labels`, and `chart` can conflict with templates from parent or sibling charts, leading to rendering errors or unexpected output.

### Key changes
- `templates/_helpers.tpl`: renamed definitions to `castai-db-agent.name`, `castai-db-agent.chart`, `castai-db-agent.labels`, `castai-db-agent.dbAgentImage`, and `castai-db-agent.cloudSqlProxyImage`; updated internal `include` references accordingly.
- `templates/_versions.tpl`: renamed `defaultDbAgentVersion` and `defaultCloudSqlProxyVersion` to `castai-db-agent.defaultDbAgentVersion` and `castai-db-agent.defaultCloudSqlProxyVersion`.
- `templates/deployment.yaml`, `templates/api-key-secret.yaml`, `templates/db-user-secret.yaml`, `templates/serviceaccount.yaml`: switched all `include` calls to the new prefixed template names.
- `Chart.yaml` and `README.md`: bumped chart version from `0.22.0` to `0.22.1`.

### Impact
No values file changes are required. This is an internal refactor; however, any external templates or parent charts that directly included the old unprefixed template names must update to the new prefixed names.