### PR TITLE
[castai-db-optimizer] prefix templates (umbrella chart prerequisites)

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.80.0
+version: 0.80.1

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.80.0](https://img.shields.io/badge/Version-0.80.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.80.1](https://img.shields.io/badge/Version-0.80.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/_helpers.tpl
+++ b/charts/castai-db-optimizer/templates/_helpers.tpl
@@ -2,41 +2,41 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "castai-db-optimizer.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
+{{- define "castai-db-optimizer.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{- define "queryProcessorImage" -}}
-{{-  default (include "defaultQueryProcessorVersion" .) .Values.queryProcessorImage.tag }}
+{{- define "castai-db-optimizer.queryProcessorImage" -}}
+{{-  default (include "castai-db-optimizer.defaultQueryProcessorVersion" .) .Values.queryProcessorImage.tag }}
 {{- end }}
 
-{{- define "proxyImage" -}}
-{{-  default (include "defaultProxyVersion" .) .Values.proxyImage.tag }}
+{{- define "castai-db-optimizer.proxyImage" -}}
+{{-  default (include "castai-db-optimizer.defaultProxyVersion" .) .Values.proxyImage.tag }}
 {{- end }}
 
-{{- define "cloudSqlProxyImage" -}}
-{{-  default (include "defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
+{{- define "castai-db-optimizer.cloudSqlProxyImage" -}}
+{{-  default (include "castai-db-optimizer.defaultCloudSqlProxyVersion" .) .Values.cloudSqlProxyImage.tag }}
 {{- end }}
 
-{{- define "pgdogImage" -}}
-{{-  default (include "defaultPgdogVersion" .) .Values.pgdogImage.tag }}
+{{- define "castai-db-optimizer.pgdogImage" -}}
+{{-  default (include "castai-db-optimizer.defaultPgdogVersion" .) .Values.pgdogImage.tag }}
 {{- end }}
 
-{{- define "proxySqlImage" -}}
-{{-  default (include "defaultProxySqlVersion" .) .Values.proxySqlImage.tag }}
+{{- define "castai-db-optimizer.proxySqlImage" -}}
+{{-  default (include "castai-db-optimizer.defaultProxySqlVersion" .) .Values.proxySqlImage.tag }}
 {{- end }}
 
 {{/*
 Helpers for customizing proxy TLS settings.
 */}}
-{{- define "proxy.tls.certificates" -}}
+{{- define "castai-db-optimizer.proxy.tls.certificates" -}}
 tls_certificates:
   - certificate_chain:
       filename: "{{ if .Values.proxy.tlsSecretName }}/etc/tls/tls.crt{{ else }}cert.pem{{ end }}"
@@ -47,16 +47,16 @@ tls_certificates:
 {{/*
 How long other sidecars should wait for proxy to fully drain before terminating.
 */}}
-{{- define "proxy.draining.sidecarTerminationDelay" -}}
+{{- define "castai-db-optimizer.proxy.draining.sidecarTerminationDelay" -}}
 {{- add .Values.proxy.draining.gracePeriodSeconds 15 -}}
 {{- end -}}
 
 {{/*
 Helper for calculating terminationGracePeriodSeconds
 */}}
-{{- define "terminationGracePeriodSeconds" -}}
+{{- define "castai-db-optimizer.terminationGracePeriodSeconds" -}}
 {{- if .Values.proxy.draining.enabled -}}
-  {{- $grace := add (include "proxy.draining.sidecarTerminationDelay" .) 15 | int -}}
+  {{- $grace := add (include "castai-db-optimizer.proxy.draining.sidecarTerminationDelay" .) 15 | int -}}
   {{- if and .Values.pgdog .Values.pgdog.enabled -}}
     {{- add $grace (div .Values.pgdog.config.shutdown_timeout 1000) -}}
   {{- else if and .Values.proxySql .Values.proxySql.enabled -}}
@@ -72,7 +72,7 @@ Helper for calculating terminationGracePeriodSeconds
 {{/*
 Define common labels.
 */}}
-{{- define "labels" -}}
+{{- define "castai-db-optimizer.labels" -}}
 {{- if .Values.commonLabels }}
 {{ if gt (len .Values.commonLabels) 0 -}}
 {{- with .Values.commonLabels }}
@@ -84,14 +84,14 @@ app.kubernetes.io/managed-by: Helm
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/name: {{ include "name" . }}
-helm.sh/chart: {{ include "chart" . }}
+app.kubernetes.io/name: {{ include "castai-db-optimizer.name" . }}
+helm.sh/chart: {{ include "castai-db-optimizer.chart" . }}
 {{- end }}
 
 {{/*
 Common Annotations
 */}}
-{{- define "annotations" -}}
+{{- define "castai-db-optimizer.annotations" -}}
 {{- if .Values.commonAnnotations }}
 {{ if gt (len .Values.commonAnnotations) 0 -}}
 {{- with .Values.commonAnnotations }}
@@ -104,11 +104,11 @@ Common Annotations
 {{/*
 Selector labels
 */}}
-{{- define "selectorLabels" -}}
-app.kubernetes.io/name: {{ include "name" . }}
+{{- define "castai-db-optimizer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "castai-db-optimizer.name" . }}
 {{- end }}
 
-{{- define "workloads-annotations" -}}
+{{- define "castai-db-optimizer.workloads-annotations" -}}
 {{- if hasKey .Values "workloadsAnnotations" }}
   {{- if kindIs "map" .Values.workloadsAnnotations }}
     {{- if eq (len .Values.workloadsAnnotations) 0 }}
@@ -139,7 +139,7 @@ workloads.cast.ai/configuration: |
 {{/*
 Convert CPU resource limit to concurrency value.
 */}}
-{{- define "cpu-to-concurrency" -}}
+{{- define "castai-db-optimizer.cpu-to-concurrency" -}}
 {{- $cpu := toString . -}}
 {{- $cpuCores := 0.0 -}}
 {{- if hasSuffix "m" $cpu -}}

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,5 +1,5 @@
-{{- define "defaultProxyVersion" -}}v4.84.2{{- end -}}
-{{- define "defaultQueryProcessorVersion" -}}v0.48.0{{- end -}}
-{{- define "defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
-{{- define "defaultPgdogVersion" -}}v0.1.43{{- end -}}
-{{- define "defaultProxySqlVersion" -}}3.0.6{{- end -}}
+{{- define "castai-db-optimizer.defaultProxyVersion" -}}v4.84.2{{- end -}}
+{{- define "castai-db-optimizer.defaultQueryProcessorVersion" -}}v0.48.0{{- end -}}
+{{- define "castai-db-optimizer.defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
+{{- define "castai-db-optimizer.defaultPgdogVersion" -}}v0.1.43{{- end -}}
+{{- define "castai-db-optimizer.defaultProxySqlVersion" -}}3.0.6{{- end -}}

--- a/charts/castai-db-optimizer/templates/deployment.yaml
+++ b/charts/castai-db-optimizer/templates/deployment.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
-    {{- include "workloads-annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.workloads-annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 0
   selector:
     matchLabels:
-      {{- include "selectorLabels" . | nindent 6 }}
+      {{- include "castai-db-optimizer.selectorLabels" . | nindent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.rollingUpdate.maxSurge }}
@@ -28,7 +28,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "selectorLabels" . | nindent 8 }}
+        {{- include "castai-db-optimizer.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -38,7 +38,7 @@ spec:
       {{- if .Values.serviceAccountName }}
       serviceAccountName: {{ .Values.serviceAccountName }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ include "terminationGracePeriodSeconds" . }}
+      terminationGracePeriodSeconds: {{ include "castai-db-optimizer.terminationGracePeriodSeconds" . }}
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
@@ -67,7 +67,7 @@ spec:
       volumes:
         - name: envoy-config
           configMap:
-            name: {{ include "name" . }}-envoy-config
+            name: {{ include "castai-db-optimizer.name" . }}-envoy-config
         - name: temp-storage
           emptyDir: {}
         - name: data-storage
@@ -87,18 +87,18 @@ spec:
           emptyDir: {}
         - name: proxysql-config-template
           configMap:
-            name: {{ include "name" . }}-proxysql-config
+            name: {{ include "castai-db-optimizer.name" . }}-proxysql-config
         - name: proxysql-config-output
           emptyDir: {}
         - name: proxysql-users-secret-volume
           secret:
-            secretName: {{ ternary .Values.proxySql.usersSecretRef (printf "%s-proxysql-users" (include "name" .)) (ne .Values.proxySql.usersSecretRef "") }}
+            secretName: {{ ternary .Values.proxySql.usersSecretRef (printf "%s-proxysql-users" (include "castai-db-optimizer.name" .)) (ne .Values.proxySql.usersSecretRef "") }}
         {{- end }}
       {{- if or (and .Values.pgdog .Values.pgdog.enabled) (and .Values.proxySql .Values.proxySql.enabled) }}
       initContainers:
         {{- if and .Values.pgdog .Values.pgdog.enabled }}
         - name: pgdog-init
-          image: "{{.Values.pgdogImage.repository}}:{{ include "pgdogImage" . }}"
+          image: "{{.Values.pgdogImage.repository}}:{{ include "castai-db-optimizer.pgdogImage" . }}"
           imagePullPolicy: {{.Values.pgdogImage.pullPolicy}}
           command:
             - /bin/sh
@@ -128,7 +128,7 @@ spec:
         {{- end }}
         {{- if and .Values.proxySql .Values.proxySql.enabled }}
         - name: proxysql-init
-          image: "{{.Values.proxySqlImage.repository}}:{{ include "proxySqlImage" . }}"
+          image: "{{.Values.proxySqlImage.repository}}:{{ include "castai-db-optimizer.proxySqlImage" . }}"
           imagePullPolicy: {{.Values.proxySqlImage.pullPolicy}}
           command:
             - /bin/sh
@@ -153,7 +153,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
         - name: proxysql-users-init
-          image: "{{.Values.queryProcessorImage.repository}}:{{ include "queryProcessorImage" . }}"
+          image: "{{.Values.queryProcessorImage.repository}}:{{ include "castai-db-optimizer.queryProcessorImage" . }}"
           imagePullPolicy: {{.Values.queryProcessorImage.pullPolicy}}
           command:
             - query-processor
@@ -177,7 +177,7 @@ spec:
       {{- end }}
       containers:
         - name: query-processor
-          image: "{{.Values.queryProcessorImage.repository}}:{{ include "queryProcessorImage" . }}"
+          image: "{{.Values.queryProcessorImage.repository}}:{{ include "castai-db-optimizer.queryProcessorImage" . }}"
           imagePullPolicy: {{.Values.queryProcessorImage.pullPolicy}}
           securityContext:
             capabilities:
@@ -201,7 +201,7 @@ spec:
           envFrom:
             - secretRef:
               {{- if .Values.apiKey }}
-                name: {{ include "name" . -}}
+                name: {{ include "castai-db-optimizer.name" . -}}
               {{- else }}
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.apiKeySecretRef -}}
               {{- end }}
@@ -227,17 +227,17 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: QUERY_PROCESSOR_IMAGE
-              value: {{ include "queryProcessorImage" . }}
+              value: {{ include "castai-db-optimizer.queryProcessorImage" . }}
             - name: PROXY_IMAGE
-              value: {{ include "proxyImage" . }}
+              value: {{ include "castai-db-optimizer.proxyImage" . }}
             - name: K8S_SERVICE_NAME
-              value: {{ include "name" . }}
+              value: {{ include "castai-db-optimizer.name" . }}
             - name: SERVER_PORT
               value: "9050"
             - name: METRICS_PORT
               value: "2112"
             - name: PEERS_URL
-              value: headless-{{ include "name" . }}
+              value: headless-{{ include "castai-db-optimizer.name" . }}
             - name: CACHE_GROUP_ID
               value: {{ .Values.cacheGroupID | required ".Values.cacheGroupID is required." | quote }}
             {{- if and .Values.proxySql .Values.proxySql.enabled }}
@@ -272,7 +272,7 @@ spec:
             - name: PGDOG_CONFIG_TEMPLATE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "name" . }}-pgdog-config
+                  name: {{ include "castai-db-optimizer.name" . }}-pgdog-config
                   key: pgdog.toml
             - name: PGDOG_OUTPUT_FILE
               value: /etc/pgdog/pgdog.toml
@@ -283,7 +283,7 @@ spec:
                   {{- if .Values.pgdog.usersSecretRef }}
                   name: {{ .Values.pgdog.usersSecretRef }}
                   {{- else }}
-                  name: {{ include "name" . }}-pgdog-users
+                  name: {{ include "castai-db-optimizer.name" . }}-pgdog-users
                   {{- end }}
                   key: users.toml
             - name: PGDOG_USERS_OUTPUT_FILE
@@ -300,7 +300,7 @@ spec:
                 command:
                   - query-processor
                   - sleep
-                  - {{ include "proxy.draining.sidecarTerminationDelay" . }}s
+                  - {{ include "castai-db-optimizer.proxy.draining.sidecarTerminationDelay" . }}s
           {{- end }}
           readinessProbe:
             tcpSocket:
@@ -320,7 +320,7 @@ spec:
             limits:
               memory: {{ coalesce .Values.resources.queryProcessor.memory .Values.resources.queryProcessor.memoryLimit }}
         - name: proxy
-          image: "{{.Values.proxyImage.repository}}:{{ include "proxyImage" . }}"
+          image: "{{.Values.proxyImage.repository}}:{{ include "castai-db-optimizer.proxyImage" . }}"
           imagePullPolicy: {{.Values.proxyImage.pullPolicy}}
           {{- if .Values.proxy.draining.enabled }}
           lifecycle:
@@ -370,7 +370,7 @@ spec:
             {{- if (int .Values.proxy.concurrency) }}
             - "{{ .Values.proxy.concurrency }}"
             {{- else }}
-            - "{{ include "cpu-to-concurrency" .Values.resources.proxy.cpu }}"
+            - "{{ include "castai-db-optimizer.cpu-to-concurrency" .Values.resources.proxy.cpu }}"
             {{- end }}
             - --drain-strategy
             - immediate
@@ -407,7 +407,7 @@ spec:
           envFrom:
             - secretRef:
               {{- if .Values.apiKey }}
-                name: {{ include "name" . -}}
+                name: {{ include "castai-db-optimizer.name" . -}}
               {{- else }}
                 name: {{ required "apiKey or apiKeySecretRef must be provided" .Values.apiKeySecretRef -}}
               {{- end }}
@@ -426,7 +426,7 @@ spec:
             {{- end }}
         {{- if and .Values.cloudSqlProxy .Values.cloudSqlProxy.enabled }}
         - name: cloud-sql-proxy
-          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "cloudSqlProxyImage" . }}"
+          image: "{{.Values.cloudSqlProxyImage.repository}}:{{ include "castai-db-optimizer.cloudSqlProxyImage" . }}"
           imagePullPolicy: {{ $.Values.cloudSqlProxyImage.pullPolicy }}
           args:
             {{- if .Values.cloudSqlProxy.privateIp }}
@@ -448,7 +448,7 @@ spec:
         {{- end }}
         {{- if and .Values.pgdog .Values.pgdog.enabled }}
         - name: pgdog
-          image: "{{.Values.pgdogImage.repository}}:{{ include "pgdogImage" . }}"
+          image: "{{.Values.pgdogImage.repository}}:{{ include "castai-db-optimizer.pgdogImage" . }}"
           imagePullPolicy: {{.Values.pgdogImage.pullPolicy}}
           command:
             - pgdog
@@ -499,7 +499,7 @@ spec:
         {{- end }}
         {{- if and .Values.proxySql .Values.proxySql.enabled }}
         - name: proxysql
-          image: "{{.Values.proxySqlImage.repository}}:{{ include "proxySqlImage" . }}"
+          image: "{{.Values.proxySqlImage.repository}}:{{ include "castai-db-optimizer.proxySqlImage" . }}"
           imagePullPolicy: {{.Values.proxySqlImage.pullPolicy}}
           command:
             - proxysql

--- a/charts/castai-db-optimizer/templates/envoy_config.yaml
+++ b/charts/castai-db-optimizer/templates/envoy_config.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "name" . }}-envoy-config
+  name: {{ include "castai-db-optimizer.name" . }}-envoy-config
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 data:
   envoy-config.yaml: |-
     node:
@@ -96,7 +96,7 @@ data:
                 {{- end }}
                   tls_socket_config:
                     common_tls_context:
-                      {{- include "proxy.tls.certificates" $ | nindent 22  }}
+                      {{- include "castai-db-optimizer.proxy.tls.certificates" $ | nindent 22  }}
           socket_options:
             - description: "enable keep-alive"
               level: 1 # means socket level options

--- a/charts/castai-db-optimizer/templates/headless-service.yaml
+++ b/charts/castai-db-optimizer/templates/headless-service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: headless-{{ include "name" . }}
+  name: headless-{{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 spec:
   clusterIP: None
   ports:
@@ -14,4 +14,4 @@ spec:
       targetPort: grpc
       protocol: TCP
   selector:
-    {{- include "selectorLabels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.selectorLabels" . | nindent 4 }}

--- a/charts/castai-db-optimizer/templates/pdb.yaml
+++ b/charts/castai-db-optimizer/templates/pdb.yaml
@@ -1,13 +1,13 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      {{- include "selectorLabels" . | nindent 6 }}
+      {{- include "castai-db-optimizer.selectorLabels" . | nindent 6 }}

--- a/charts/castai-db-optimizer/templates/pgdog-config.yaml
+++ b/charts/castai-db-optimizer/templates/pgdog-config.yaml
@@ -28,11 +28,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "name" . }}-pgdog-config
+  name: {{ include "castai-db-optimizer.name" . }}-pgdog-config
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 data:
   pgdog.toml: |
     [general]

--- a/charts/castai-db-optimizer/templates/pgdog-users-secret.yaml
+++ b/charts/castai-db-optimizer/templates/pgdog-users-secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}-pgdog-users
+  name: {{ include "castai-db-optimizer.name" . }}-pgdog-users
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 type: Opaque
 stringData:
   users.toml: |

--- a/charts/castai-db-optimizer/templates/proxysql-config.yaml
+++ b/charts/castai-db-optimizer/templates/proxysql-config.yaml
@@ -17,11 +17,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "name" . }}-proxysql-config
+  name: {{ include "castai-db-optimizer.name" . }}-proxysql-config
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 data:
   proxysql.cnf: |
     datadir="/var/lib/proxysql"

--- a/charts/castai-db-optimizer/templates/proxysql-users-secret.yaml
+++ b/charts/castai-db-optimizer/templates/proxysql-users-secret.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}-proxysql-users
+  name: {{ include "castai-db-optimizer.name" . }}-proxysql-users
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 type: Opaque
 stringData:
   users.json: |

--- a/charts/castai-db-optimizer/templates/secret.yaml
+++ b/charts/castai-db-optimizer/templates/secret.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 data:
   API_KEY: {{ .Values.apiKey | b64enc | quote }}
 {{- end }}

--- a/charts/castai-db-optimizer/templates/service.yaml
+++ b/charts/castai-db-optimizer/templates/service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "castai-db-optimizer.name" . }}
   labels:
-    {{- include "labels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" . | nindent 4 }}
   annotations:
-    {{- include "annotations" . | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" . | nindent 4 }}
 spec:
   {{- with .Values.service.trafficDistribution }}
   trafficDistribution: {{ . }}
@@ -37,7 +37,7 @@ spec:
       targetPort: proxy-metrics
       protocol: TCP
   selector:
-    {{- include "selectorLabels" . | nindent 4 }}
+    {{- include "castai-db-optimizer.selectorLabels" . | nindent 4 }}
 
 
 # for each named port, define a named service
@@ -48,11 +48,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "name" $ }}-{{$endpoint.name}}
+  name: {{ include "castai-db-optimizer.name" $ }}-{{$endpoint.name}}
   labels:
-    {{- include "labels" $ | nindent 4 }}
+    {{- include "castai-db-optimizer.labels" $ | nindent 4 }}
   annotations:
-    {{- include "annotations" $ | nindent 4 }}
+    {{- include "castai-db-optimizer.annotations" $ | nindent 4 }}
 spec:
   {{- with $.Values.service.trafficDistribution }}
   trafficDistribution: {{ . }}
@@ -68,7 +68,7 @@ spec:
       appProtocol: postgresql
       {{- end }}
   selector:
-    {{- include "selectorLabels" $ | nindent 4 }}
+    {{- include "castai-db-optimizer.selectorLabels" $ | nindent 4 }}
 
 {{- end }}
 {{- end }}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Prefixed all Helm named templates in the `castai-db-optimizer` chart with `castai-db-optimizer.` and bumped the chart version from `0.80.0` to `0.80.1`.

### Why
Unprefixed named templates such as `name`, `labels`, and `selectorLabels` can collide with templates from other charts included as subcharts or umbrella charts. Prefixing them prevents naming conflicts and follows Helm best practices.

### Key changes
- `Chart.yaml`: bumped version to `0.80.1`.
- `README.md`: updated version badge to `0.80.1`.
- `templates/_helpers.tpl`: renamed all `define` blocks to use the `castai-db-optimizer.` prefix, including:
  - `castai-db-optimizer.name`
  - `castai-db-optimizer.chart`
  - `castai-db-optimizer.labels`
  - `castai-db-optimizer.selectorLabels`
  - `castai-db-optimizer.annotations`
  - `castai-db-optimizer.terminationGracePeriodSeconds`
  - `castai-db-optimizer.queryProcessorImage`, `proxyImage`, `cloudSqlProxyImage`, `pgdogImage`, `proxySqlImage`
  - `castai-db-optimizer.proxy.tls.certificates`
  - `castai-db-optimizer.cpu-to-concurrency`
- `templates/_versions.tpl`: prefixed default image version templates (e.g., `castai-db-optimizer.defaultProxyVersion`).
- All templates (`deployment.yaml`, `envoy_config.yaml`, `headless-service.yaml`, `pdb.yaml`, `pgdog-config.yaml`, `pgdog-users-secret.yaml`, `proxysql-config.yaml`, `proxysql-users-secret.yaml`, `secret.yaml`, `service.yaml`): updated all `include` calls to reference the new prefixed template names.

### Impact
No functional or breaking changes are expected. The rendered Kubernetes resource names and labels remain unchanged because only the Helm template definition names were renamed, not their outputs.