### PR TITLE
[castai-umbrella] Bump umbrella chart kent variant subcharts

### DIFF
--- a/charts/castai-umbrella/Chart.lock
+++ b/charts/castai-umbrella/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kent
   repository: file://charts/kent
-  version: 0.14.0
+  version: 0.15.0
 - name: autoscaler-anywhere
   repository: file://charts/autoscaler-anywhere
   version: 0.5.0
@@ -11,5 +11,5 @@ dependencies:
 - name: autoscaler
   repository: file://charts/autoscaler
   version: 0.2.0
-digest: sha256:49d34c9978c18f21f30f8d4c97894be20e93fe6806c150fcd8e9ec1c5b4a7135
-generated: "2026-06-17T09:03:13.787098+02:00"
+digest: sha256:3005755f3a8125a106984d969a12469a2c3027889a3db26f3bc03c072dbdbd12
+generated: "2026-06-30T19:49:03.389711+03:00"

--- a/charts/castai-umbrella/Chart.yaml
+++ b/charts/castai-umbrella/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: castai
 description: Umbrella chart for CAST AI components.
 type: application
-version: 0.42.17
+version: 0.43.0
 dependencies:
   # ── Legacy profile sub-charts ─────────────────────────────────────────────────
   - name: kent

--- a/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
+++ b/charts/castai-umbrella/charts/autoscaler-anywhere/README.md
@@ -10,10 +10,10 @@ Wrapper chart for CAST AI Autoscaler Anywhere profile (non-managed clusters).
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.95 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.103 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.16.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.3.0 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.2 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.3.2 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/autoscaler/README.md
+++ b/charts/castai-umbrella/charts/autoscaler/README.md
@@ -10,14 +10,14 @@ CAST AI autoscaler modes — readonly, node-autoscaler, workload-autoscaler, ful
 |------------|------|---------|
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-evictor | 0.35.95 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.163.3 |
-| https://castai.github.io/helm-charts | castai-live | 0.108.0 |
+| https://castai.github.io/helm-charts | castai-evictor | 0.35.103 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.163.6 |
+| https://castai.github.io/helm-charts | castai-live | 0.109.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.16.0 |
 | https://castai.github.io/helm-charts | castai-pod-pinner | 1.12.5 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.4 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.3.0 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.2 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.3.2 |
 
 ## Values
 

--- a/charts/castai-umbrella/charts/kent/Chart.lock
+++ b/charts/castai-umbrella/charts/kent/Chart.lock
@@ -4,33 +4,33 @@ dependencies:
   version: 0.158.0
 - name: castai-cluster-controller
   repository: https://castai.github.io/helm-charts
-  version: 0.92.6
+  version: 0.92.7
 - name: castai-kentroller
   repository: https://castai.github.io/helm-charts
-  version: 0.1.159
+  version: 0.1.165
 - name: castai-workload-autoscaler
   repository: https://castai.github.io/helm-charts
-  version: 1.2.5
+  version: 1.3.2
 - name: castai-workload-autoscaler-exporter
   repository: https://castai.github.io/helm-charts
-  version: 1.2.5
+  version: 1.3.2
 - name: castai-live
   repository: https://castai.github.io/helm-charts
-  version: 0.105.0
+  version: 0.109.0
 - name: castai-pod-mutator
   repository: https://castai.github.io/helm-charts
-  version: 0.15.1
+  version: 0.16.0
 - name: castai-spot-handler
   repository: https://castai.github.io/helm-charts
-  version: 0.35.2
+  version: 0.35.4
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server/
   version: 3.13.0
 - name: castai-kvisor
   repository: https://castai.github.io/helm-charts
-  version: 1.161.4
+  version: 1.163.6
 - name: castai-chart-upgrader
   repository: https://castai.github.io/helm-charts
   version: 0.2.0
-digest: sha256:ea8ceebe9f112561e510ff0c26ffdf00f97b130c55f671c723a57c7f10d2bf9c
-generated: "2026-06-17T09:02:35.71492+02:00"
+digest: sha256:8f6fdecdb6e35d22aa76717c3c911d39c25b0ed215a9f4cfd419c77be2481969
+generated: "2026-06-30T19:48:54.231692+03:00"

--- a/charts/castai-umbrella/charts/kent/Chart.yaml
+++ b/charts/castai-umbrella/charts/kent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kent
 description: Wrapper chart for CAST AI Kent profile.
 type: application
-version: 0.14.0
+version: 0.15.0
 dependencies:
   - name: castai-agent
     version: "0.158.0"

--- a/charts/castai-umbrella/charts/kent/README.md
+++ b/charts/castai-umbrella/charts/kent/README.md
@@ -1,6 +1,6 @@
 # kent
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Wrapper chart for CAST AI Kent profile.
 
@@ -11,13 +11,13 @@ Wrapper chart for CAST AI Kent profile.
 | https://castai.github.io/helm-charts | castai-agent | 0.158.0 |
 | https://castai.github.io/helm-charts | castai-chart-upgrader | 0.2.0 |
 | https://castai.github.io/helm-charts | castai-cluster-controller | 0.92.7 |
-| https://castai.github.io/helm-charts | castai-kentroller | 0.1.164 |
-| https://castai.github.io/helm-charts | castai-kvisor | 1.163.3 |
-| https://castai.github.io/helm-charts | castai-live | 0.108.0 |
+| https://castai.github.io/helm-charts | castai-kentroller | 0.1.165 |
+| https://castai.github.io/helm-charts | castai-kvisor | 1.163.6 |
+| https://castai.github.io/helm-charts | castai-live | 0.109.0 |
 | https://castai.github.io/helm-charts | castai-pod-mutator | 0.16.0 |
 | https://castai.github.io/helm-charts | castai-spot-handler | 0.35.4 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.0 |
-| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.3.0 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler | 1.3.2 |
+| https://castai.github.io/helm-charts | castai-workload-autoscaler-exporter | 1.3.2 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 
 ## Values


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the `kent` subchart from `0.14.0` to `0.15.0` and the `castai-umbrella` chart to `0.43.0`, refreshing locked and documented dependency versions for the latest CAST AI components.

### Why
Pulls in the latest `castai-kentroller` release and aligns the Kent profile dependencies with current component chart versions.

### Key changes
- `charts/castai-umbrella/Chart.yaml`: bump umbrella chart version to `0.43.0`.
- `charts/castai-umbrella/Chart.lock`: update locked `kent` dependency to `0.15.0` and regenerate digest.
- `charts/castai-umbrella/charts/kent/Chart.yaml`: bump `kent` chart version to `0.15.0`.
- `charts/castai-umbrella/charts/kent/Chart.lock`: upgrade `castai-kentroller` to `0.1.165`, `castai-workload-autoscaler` and `castai-workload-autoscaler-exporter` to `1.3.2`, `castai-live` to `0.109.0`, `castai-kvisor` to `1.163.6`, `castai-pod-mutator` to `0.16.0`, `castai-spot-handler` to `0.35.4`, and `castai-cluster-controller` to `0.92.7`.
- `charts/castai-umbrella/charts/kent/README.md`, `autoscaler/README.md`, and `autoscaler-anywhere/README.md`: refresh documented dependency versions.

### Impact
Component version bumps may include upstream behavior changes; review the CAST AI subchart release notes before upgrading.