### PR TITLE
small fix for AI driff detection in unififed umbrella

### DIFF
--- a/.github/scripts/check-umbrella-drift.sh
+++ b/.github/scripts/check-umbrella-drift.sh
@@ -15,12 +15,12 @@
 #   CHART_NAME        — e.g. castai-agent, castai-pod-pinner, castai-live
 #   CHART_VERSION     — e.g. 0.35.103 (used to assemble the current tag)
 #   KIMCHI_API_KEY    — Kimchi Inference API key
-#   GITLAB_TOKEN      — required only for castai-live (to clone gitlab.com/castai/live/clm)
+#   GITLAB_TOKEN      — required only for castai-live (to clone gitlab.com/castai/*)
 #
 # Paths expected to exist at call time (created by release-umbrella-rc.yml):
 #   helm-charts/      — full clone of helm-charts at the release tag (fetch-depth:0)
 #   kubecast/         — full clone of the kubecast repo (no --depth)
-#   For castai-live the script clones gitlab.com/castai/live/clm itself.
+#   For castai-live the script clones gitlab.com/castai/* itself.
 #
 # Writes markdown to stdout and, when GITHUB_OUTPUT is set, appends:
 #   drift_report<<DELIMITER / ... / DELIMITER
@@ -69,32 +69,32 @@ configure_component() {
       ;;
     castai-agent)
       REPO_CLONE_DIR="kubecast"
-      COMPONENT_PATH="services/castai-agent"
+      COMPONENT_PATH="services/castai-agent/chart"
       TAG_PREFIX="castai-agent/v"
       ;;
     castai-pod-pinner)
       REPO_CLONE_DIR="kubecast"
-      COMPONENT_PATH="services/castai-pod-pinner"
+      COMPONENT_PATH="services/castai-pod-pinner/chart"
       TAG_PREFIX="castai-pod-pinner/v"
       ;;
     castai-cluster-controller)
       REPO_CLONE_DIR="kubecast"
-      COMPONENT_PATH="services/cluster-controller"
+      COMPONENT_PATH="services/cluster-controller/charts/castai-cluster-controller"
       TAG_PREFIX="cluster-controller/v"
       ;;
     castai-kvisor)
       REPO_CLONE_DIR="kubecast"
-      COMPONENT_PATH="services/kvisor"
+      COMPONENT_PATH="services/kvisor/chart"
       TAG_PREFIX="kvisor/v"
       ;;
     castai-pod-mutator)
       REPO_CLONE_DIR="kubecast"
-      COMPONENT_PATH="services/pod-mutator"
+      COMPONENT_PATH="services/pod-mutator/chart"
       TAG_PREFIX="pod-mutator/v"
       ;;
     castai-spot-handler)
       REPO_CLONE_DIR="kubecast"
-      COMPONENT_PATH="services/spot-handler"
+      COMPONENT_PATH="services/spot-handler/charts/castai-spot-handler"
       TAG_PREFIX="spot-handler/v"
       ;;
     castai-workload-autoscaler)
@@ -105,12 +105,11 @@ configure_component() {
     castai-workload-autoscaler-exporter)
       REPO_CLONE_DIR="kubecast"
       COMPONENT_PATH="services/workload-autoscaler/charts/castai-workload-autoscaler-exporter"
-      # Shares the same release tag as castai-workload-autoscaler.
       TAG_PREFIX="workload-autoscaler/v"
       ;;
     castai-live)
-      REPO_CLONE_DIR="clm"   # cloned below
-      COMPONENT_PATH="helm"  # diff scope: helm/ subtree (templates + dependencies)
+      REPO_CLONE_DIR="clm"
+      COMPONENT_PATH="helm"
       TAG_PREFIX="v"
       ;;
     *)

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -103,6 +103,18 @@ jobs:
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         uses: mikefarah/yq@v4.44.3
 
+      - name: Install Helm
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
+        uses: azure/setup-helm@v4.3.1
+        with:
+          version: v3.17.0
+
+      - name: Set up Go
+        if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
       - name: Checkout helm-charts at release tag
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
         uses: actions/checkout@v4
@@ -316,6 +328,32 @@ jobs:
           echo "Bumped umbrella version: ${CURRENT} -> ${NEW_VERSION}"
           echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "tag=castai-${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Refresh subchart Chart.lock files
+        if: steps.changed.outputs.any == 'true' && steps.bump_deps.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          helm repo add castai-helm https://castai.github.io/helm-charts
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+          helm repo update
+
+          # Refresh Chart.lock and packaged .tgz for each mode subchart whose
+          # Chart.yaml was bumped, then refresh the umbrella chart itself so
+          # its Chart.lock stays consistent.
+          for sub in kent autoscaler-anywhere autoscaler-openshift; do
+            path="kubecast/castai-umbrella/chart/charts/${sub}"
+            if [ -d "$path" ]; then
+              echo "==> helm dependency update ${path}"
+              helm dependency update "$path"
+            fi
+          done
+          echo "==> helm dependency update kubecast/castai-umbrella/chart"
+          helm dependency update kubecast/castai-umbrella/chart
+
+      - name: Regenerate helm-docs README.md files
+        if: steps.changed.outputs.any == 'true'
+        working-directory: kubecast/castai-umbrella
+        run: make helm-docs
 
       - name: Check template drift between component and umbrella
         id: drift


### PR DESCRIPTION


---
### Kimchi Summary
### What changed

Aligns the umbrella drift check script with the new component chart directory layout and adds Helm/Go setup, `Chart.lock` refresh, and `helm-docs` regeneration steps to the umbrella RC release workflow.

### Why

Component charts in `kubecast` were moved under `chart`/`charts` subdirectories, so the drift check was looking at stale paths. Additionally, bumping subchart dependencies requires `Chart.lock` files and READMEs to be regenerated before drift detection runs.

### Key changes

- `.github/scripts/check-umbrella-drift.sh`
  - Updated `COMPONENT_PATH` for drift checks:
    - `castai-agent` → `services/castai-agent/chart`
    - `castai-pod-pinner` → `services/castai-pod-pinner/chart`
    - `castai-cluster-controller` → `services/cluster-controller/charts/castai-cluster-controller`
    - `castai-kvisor` → `services/kvisor/chart`
    - `castai-pod-mutator` → `services/pod-mutator/chart`
    - `castai-spot-handler` → `services/spot-handler/charts/castai-spot-handler`
  - Broadened `GITLAB_TOKEN` and `castai-live` clone comment from `gitlab.com/castai/live/clm` to `gitlab.com/castai/*`.
- `.github/workflows/release-umbrella-rc.yml`
  - Added `Install Helm` step (`azure/setup-helm@v4.3.1`, `v3.17.0`).
  - Added `Set up Go` step (`actions/setup-go@v5`, `1.22`).
  - Added `Refresh subchart Chart.lock files` step that adds the `castai-helm` and `metrics-server` repos and runs `helm dependency update` for `kent`, `autoscaler-anywhere`, `autoscaler-openshift`, and the umbrella chart.
  - Added `Regenerate helm-docs README.md files` step running `make helm-docs` in `kubecast/castai-umbrella`.

### Impact

- The workflow now depends on Helm, Go, and the `helm-docs` Makefile target being available in `kubecast/castai-umbrella`; failures in lock refresh or doc generation will block the RC release.
- Drift reports should now reflect the correct component chart subtrees, reducing false negatives after the repo reorganization.