### PR TITLE
[castai-dbo] add dbo umbrella chart

### DIFF
--- a/charts/castai-dbo/.helmignore
+++ b/charts/castai-dbo/.helmignore
@@ -1,0 +1,9 @@
+# Patterns to ignore when building packages.
+.git
+.gitignore
+.idea
+*.swp
+*.bak
+*.tmp
+*.orig
+.DS_Store

--- a/charts/castai-dbo/Chart.lock
+++ b/charts/castai-dbo/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: castai-db-proxy
+  repository: https://castai.github.io/helm-charts
+  version: 0.1.2
+- name: castai-db-agent
+  repository: https://castai.github.io/helm-charts
+  version: 0.22.0
+- name: castai-db-optimizer
+  repository: https://castai.github.io/helm-charts
+  version: 0.80.0
+digest: sha256:5a75d6d5727199b8c454e09dac029ed18b25655a55e2040581c4daed6bff2231
+generated: "2026-06-25T17:34:01.269699+03:00"

--- a/charts/castai-dbo/Chart.yaml
+++ b/charts/castai-dbo/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: castai-dbo
+description: Umbrella chart for CAST AI Database Optimizer components.
+type: application
+version: 0.1.0
+maintainers:
+  - name: CAST AI
+    url: https://cast.ai
+dependencies:
+  - name: castai-db-proxy
+    alias: db-proxy
+    version: "0.1.3"
+    repository: "https://castai.github.io/helm-charts"
+    condition: db-proxy.enabled
+  - name: castai-db-agent
+    alias: db-agent
+    version: "0.22.1"
+    repository: "https://castai.github.io/helm-charts"
+    condition: db-agent.enabled
+  - name: castai-db-optimizer
+    alias: db-optimizer
+    version: "0.80.1"
+    repository: "https://castai.github.io/helm-charts"
+    condition: db-optimizer.enabled

--- a/charts/castai-dbo/README.md
+++ b/charts/castai-dbo/README.md
@@ -1,0 +1,63 @@
+# castai-dbo
+
+Umbrella chart for CAST AI Database Optimizer components.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| CAST AI |  | <https://cast.ai> |
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://castai.github.io/helm-charts | db-agent(castai-db-agent) | 0.22.1 |
+| https://castai.github.io/helm-charts | db-optimizer(castai-db-optimizer) | 0.80.1 |
+| https://castai.github.io/helm-charts | db-proxy(castai-db-proxy) | 0.1.3 |
+
+## Usage
+
+```shell
+helm repo add castai-helm https://castai.github.io/helm-charts
+helm repo update
+
+helm upgrade --install castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent --create-namespace \
+  --set db-optimizer.apiKey=<API_KEY> \
+  --set db-optimizer.organizationID=<ORG_ID> \
+  --set db-optimizer.cacheGroupID=<CACHE_GROUP_ID> \
+  --set db-optimizer.protocol=PostgreSQL \
+  --set db-agent.apiKey=<API_KEY> \
+  --set db-agent.organizationID=<ORG_ID> \
+  --set db-agent.cacheGroupID=<CACHE_GROUP_ID>
+```
+
+### Configuring individual components
+
+Pass component-specific values through the `<component>.*` prefix:
+
+```shell
+helm upgrade --install castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent --create-namespace \
+  -f values.yaml
+```
+
+### Disabling a component
+
+Any sub-chart can be excluded:
+
+```shell
+helm upgrade castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent \
+  --reset-then-reuse-values \
+  --set db-proxy.enabled=false
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| db-agent.enabled | bool | `true` |  |
+| db-optimizer.enabled | bool | `true` |  |
+| db-proxy.enabled | bool | `true` |  |

--- a/charts/castai-dbo/README.md
+++ b/charts/castai-dbo/README.md
@@ -24,40 +24,67 @@ helm repo update
 
 helm upgrade --install castai-dbo castai-helm/castai-dbo \
   --namespace castai-agent --create-namespace \
-  --set db-optimizer.apiKey=<API_KEY> \
-  --set db-optimizer.organizationID=<ORG_ID> \
-  --set db-optimizer.cacheGroupID=<CACHE_GROUP_ID> \
-  --set db-optimizer.protocol=PostgreSQL \
-  --set db-agent.apiKey=<API_KEY> \
-  --set db-agent.organizationID=<ORG_ID> \
-  --set db-agent.cacheGroupID=<CACHE_GROUP_ID>
-```
-
-### Configuring individual components
-
-Pass component-specific values through the `<component>.*` prefix:
-
-```shell
-helm upgrade --install castai-dbo castai-helm/castai-dbo \
-  --namespace castai-agent --create-namespace \
   -f values.yaml
 ```
 
-### Disabling a component
+See below for the required values for each component.
 
-Any sub-chart can be excluded:
+> **Note:** `db-proxy` and `db-optimizer` are mutually exclusive — enable only one of them.
 
-```shell
-helm upgrade castai-dbo castai-helm/castai-dbo \
-  --namespace castai-agent \
-  --reset-then-reuse-values \
-  --set db-proxy.enabled=false
+### Example: db-optimizer + db-agent
+
+```yaml
+db-optimizer:
+  enabled: true
+  apiKey: "<API_KEY>"
+  organizationID: "<ORG_ID>"
+  cacheGroupID: "<CACHE_GROUP_ID>"
+  protocol: "PostgreSQL"
+  endpoints:
+    - name: "primary"
+      hostname: "<DB_HOST>"
+      port: 5433
+      targetPort: 5432
+      servicePort: 5433
+
+db-agent:
+  enabled: true
+  apiKey: "<API_KEY>"
+  organizationID: "<ORG_ID>"
+  cacheGroupID: "<CACHE_GROUP_ID>"
+  database:
+    host: "<DB_HOST>"
+    username: "<DB_USER>"
+    password: "<DB_PASSWORD>"
+```
+
+### Example: db-proxy + db-agent
+
+```yaml
+db-proxy:
+  enabled: true
+  apiKey: "<API_KEY>"
+  organizationID: "<ORG_ID>"
+  proxyID: "<PROXY_ID>"
+  endpoints:
+    - address: "<DB_HOST>:<DB_PORT>"
+      readonly: false
+
+db-agent:
+  enabled: true
+  apiKey: "<API_KEY>"
+  organizationID: "<ORG_ID>"
+  cacheGroupID: "<CACHE_GROUP_ID>"
+  database:
+    host: "<DB_HOST>"
+    username: "<DB_USER>"
+    password: "<DB_PASSWORD>"
 ```
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| db-agent.enabled | bool | `true` |  |
-| db-optimizer.enabled | bool | `true` |  |
-| db-proxy.enabled | bool | `true` |  |
+| db-agent.enabled | bool | `false` |  |
+| db-optimizer.enabled | bool | `false` |  |
+| db-proxy.enabled | bool | `false` |  |

--- a/charts/castai-dbo/README.md.gotmpl
+++ b/charts/castai-dbo/README.md.gotmpl
@@ -1,0 +1,52 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Usage
+
+```shell
+helm repo add castai-helm https://castai.github.io/helm-charts
+helm repo update
+
+helm upgrade --install castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent --create-namespace \
+  --set db-optimizer.apiKey=<API_KEY> \
+  --set db-optimizer.organizationID=<ORG_ID> \
+  --set db-optimizer.cacheGroupID=<CACHE_GROUP_ID> \
+  --set db-optimizer.protocol=PostgreSQL \
+  --set db-agent.apiKey=<API_KEY> \
+  --set db-agent.organizationID=<ORG_ID> \
+  --set db-agent.cacheGroupID=<CACHE_GROUP_ID>
+```
+
+### Configuring individual components
+
+Pass component-specific values through the `<component>.*` prefix:
+
+```shell
+helm upgrade --install castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent --create-namespace \
+  -f values.yaml
+```
+
+### Disabling a component
+
+Any sub-chart can be excluded:
+
+```shell
+helm upgrade castai-dbo castai-helm/castai-dbo \
+  --namespace castai-agent \
+  --reset-then-reuse-values \
+  --set db-proxy.enabled=false
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/castai-dbo/README.md.gotmpl
+++ b/charts/castai-dbo/README.md.gotmpl
@@ -19,34 +19,61 @@ helm repo update
 
 helm upgrade --install castai-dbo castai-helm/castai-dbo \
   --namespace castai-agent --create-namespace \
-  --set db-optimizer.apiKey=<API_KEY> \
-  --set db-optimizer.organizationID=<ORG_ID> \
-  --set db-optimizer.cacheGroupID=<CACHE_GROUP_ID> \
-  --set db-optimizer.protocol=PostgreSQL \
-  --set db-agent.apiKey=<API_KEY> \
-  --set db-agent.organizationID=<ORG_ID> \
-  --set db-agent.cacheGroupID=<CACHE_GROUP_ID>
-```
-
-### Configuring individual components
-
-Pass component-specific values through the `<component>.*` prefix:
-
-```shell
-helm upgrade --install castai-dbo castai-helm/castai-dbo \
-  --namespace castai-agent --create-namespace \
   -f values.yaml
 ```
 
-### Disabling a component
+See below for the required values for each component.
 
-Any sub-chart can be excluded:
+> **Note:** `db-proxy` and `db-optimizer` are mutually exclusive — enable only one of them.
 
-```shell
-helm upgrade castai-dbo castai-helm/castai-dbo \
-  --namespace castai-agent \
-  --reset-then-reuse-values \
-  --set db-proxy.enabled=false
+### Example: db-optimizer + db-agent
+
+```yaml
+db-optimizer:
+  enabled: true
+  apiKey: "<API_KEY>"
+  organizationID: "<ORG_ID>"
+  cacheGroupID: "<CACHE_GROUP_ID>"
+  protocol: "PostgreSQL"
+  endpoints:
+    - name: "primary"
+      hostname: "<DB_HOST>"
+      port: 5433
+      targetPort: 5432
+      servicePort: 5433
+
+db-agent:
+  enabled: true
+  apiKey: "<API_KEY>"
+  organizationID: "<ORG_ID>"
+  cacheGroupID: "<CACHE_GROUP_ID>"
+  database:
+    host: "<DB_HOST>"
+    username: "<DB_USER>"
+    password: "<DB_PASSWORD>"
+```
+
+### Example: db-proxy + db-agent
+
+```yaml
+db-proxy:
+  enabled: true
+  apiKey: "<API_KEY>"
+  organizationID: "<ORG_ID>"
+  proxyID: "<PROXY_ID>"
+  endpoints:
+    - address: "<DB_HOST>:<DB_PORT>"
+      readonly: false
+
+db-agent:
+  enabled: true
+  apiKey: "<API_KEY>"
+  organizationID: "<ORG_ID>"
+  cacheGroupID: "<CACHE_GROUP_ID>"
+  database:
+    host: "<DB_HOST>"
+    username: "<DB_USER>"
+    password: "<DB_PASSWORD>"
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/charts/castai-dbo/ci/test-values.yaml
+++ b/charts/castai-dbo/ci/test-values.yaml
@@ -1,5 +1,5 @@
 db-proxy:
-  enabled: true
+  enabled: false
   organizationID: "test-org"
   proxyID: "test-proxy"
   apiKey: "test-key"
@@ -8,7 +8,7 @@ db-proxy:
       readonly: false
 
 db-agent:
-  enabled: true
+  enabled: false
   apiKey: "test-key"
   organizationID: "test-org"
   cacheGroupID: "test-cache-group"

--- a/charts/castai-dbo/ci/test-values.yaml
+++ b/charts/castai-dbo/ci/test-values.yaml
@@ -1,0 +1,32 @@
+db-proxy:
+  enabled: true
+  organizationID: "test-org"
+  proxyID: "test-proxy"
+  apiKey: "test-key"
+  endpoints:
+    - address: "db-primary:5432"
+      readonly: false
+
+db-agent:
+  enabled: true
+  apiKey: "test-key"
+  organizationID: "test-org"
+  cacheGroupID: "test-cache-group"
+  database:
+    host: "test-db"
+    username: "test-user"
+    password: "test-pass"
+  gRPCEndpoint: "grpc.example.com:443"
+
+db-optimizer:
+  enabled: true
+  cacheGroupID: "test-cache-group"
+  organizationID: "test-org"
+  apiKey: "test-key"
+  protocol: "PostgreSQL"
+  endpoints:
+    - name: "db1"
+      hostname: "db1.example.com"
+      port: 5433
+      targetPort: 5432
+      servicePort: 5433

--- a/charts/castai-dbo/templates/_helpers.tpl
+++ b/charts/castai-dbo/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "castai-dbo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "castai-dbo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "castai-dbo.labels" -}}
+helm.sh/chart: {{ include "castai-dbo.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/castai-dbo/values.yaml
+++ b/charts/castai-dbo/values.yaml
@@ -1,10 +1,10 @@
 # Default values for castai-dbo umbrella chart.
 
 db-proxy:
-  enabled: true
+  enabled: false
 
 db-agent:
-  enabled: true
+  enabled: false
 
 db-optimizer:
-  enabled: true
+  enabled: false

--- a/charts/castai-dbo/values.yaml
+++ b/charts/castai-dbo/values.yaml
@@ -1,0 +1,10 @@
+# Default values for castai-dbo umbrella chart.
+
+db-proxy:
+  enabled: true
+
+db-agent:
+  enabled: true
+
+db-optimizer:
+  enabled: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -18,4 +18,5 @@ excluded-charts:
   - castai-workload-autoscaler
   - castai-workload-autoscaler-exporter
   - castai-db-proxy
+  - castai-dbo
   - castai-watchdog

--- a/ct.yaml
+++ b/ct.yaml
@@ -18,5 +18,4 @@ excluded-charts:
   - castai-workload-autoscaler
   - castai-workload-autoscaler-exporter
   - castai-db-proxy
-  - castai-dbo
   - castai-watchdog

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,6 +4,7 @@ target-branch: main
 chart-dirs:
   - charts
 chart-repos:
+  - castai-helm=https://castai.github.io/helm-charts
   - tetragon=https://helm.cilium.io
   - vector=https://helm.vector.dev
 helm-extra-args: --timeout 600s


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds a new `castai-dbo` umbrella Helm chart that bundles the Database Optimizer components (`castai-db-proxy`, `castai-db-agent`, and `castai-db-optimizer`) into a single installable unit. All subcharts are disabled by default and must be opted in via `values.yaml`.

### Why
Provides a unified, simpler installation path for CAST AI Database Optimizer instead of requiring users to install and manage multiple individual charts separately.

### Key changes
- Added `charts/castai-dbo/Chart.yaml` defining the umbrella chart with three conditional dependencies: `castai-db-proxy` (`db-proxy`), `castai-db-agent` (`db-agent`), and `castai-db-optimizer` (`db-optimizer`).
- Added `charts/castai-dbo/Chart.lock` to pin dependency versions.
- Added `charts/castai-dbo/values.yaml` defaulting `db-proxy.enabled`, `db-agent.enabled`, and `db-optimizer.enabled` to `false`.
- Added `charts/castai-dbo/templates/_helpers.tpl` with standard Helm naming, chart label, and common label helpers.
- Added `charts/castai-dbo/README.md` and `README.md.gotmpl` with installation instructions and example values for `db-optimizer + db-agent` and `db-proxy + db-agent` configurations.
- Added `charts/castai-dbo/ci/test-values.yaml` to validate the umbrella chart in CI.
- Added `charts/castai-dbo/.helmignore` to exclude development files from packaged releases.
- Updated `ct.yaml` to register the `castai-helm=https://castai.github.io/helm-charts` repository so chart-testing can resolve dependencies.

### Impact
- This is an additive change that introduces a new public chart; existing charts are unaffected.
- `db-proxy` and `db-optimizer` are mutually exclusive — the README documents that only one should be enabled at a time.
- Users must explicitly enable desired components in `values.yaml`; with all defaults set to `false`, installing the chart without overrides deploys no workload resources.