### PR TITLE
[castai-db-proxy] Sync connection draining with k8s termination

### DIFF
--- a/charts/castai-db-proxy/Chart.yaml
+++ b/charts/castai-db-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-proxy
 description: CAST AI database proxy cache deployment.
 type: application
-version: 0.2.1
+version: 0.3.0

--- a/charts/castai-db-proxy/README.md
+++ b/charts/castai-db-proxy/README.md
@@ -1,6 +1,6 @@
 # castai-db-proxy
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database proxy cache deployment.
 
@@ -16,6 +16,9 @@ CAST AI database proxy cache deployment.
 | cluster.enabled | bool | `true` | Enable distributed cache cluster mode. |
 | commonAnnotations | object | `{}` | Annotations to add to all resources. |
 | commonLabels | object | `{}` | Labels to add to all resources. |
+| connection_draining | object | `{"grace_period_seconds":55,"graceful_shutdown_timeout_seconds":5}` | Connection draining configuration |
+| connection_draining.grace_period_seconds | int | `55` | How long existing connections have to finish after SIGTERM. Must be > 0 |
+| connection_draining.graceful_shutdown_timeout_seconds | int | `5` | How long the server waits for runtimes to shut down after the grace period. Must be > 0 |
 | dnsConfig | object | `{}` | Pod DNS configuration. |
 | dnsPolicy | string | `""` | Pod DNS policy. |
 | endpoints | list | `[]` | Upstream database endpoints. Each entry needs `address` (host:port) and `readonly` (bool). |

--- a/charts/castai-db-proxy/templates/_versions.tpl
+++ b/charts/castai-db-proxy/templates/_versions.tpl
@@ -1,1 +1,1 @@
-{{- define "castai-db-proxy.defaultProxyVersion" -}}v0.2.0{{- end -}}
+{{- define "castai-db-proxy.defaultProxyVersion" -}}v0.3.0{{- end -}}

--- a/charts/castai-db-proxy/templates/configmap.yaml
+++ b/charts/castai-db-proxy/templates/configmap.yaml
@@ -37,3 +37,7 @@ data:
     host = "headless-{{ include "castai-db-proxy.name" . }}.{{ .Release.Namespace }}.svc.cluster.local"
     port = {{ .Values.ports.cluster }}
     {{- end }}
+
+    [server]
+    grace_period_seconds = {{ .Values.connection_draining.grace_period_seconds }}
+    graceful_shutdown_timeout_seconds = {{ .Values.connection_draining.graceful_shutdown_timeout_seconds }}

--- a/charts/castai-db-proxy/templates/deployment.yaml
+++ b/charts/castai-db-proxy/templates/deployment.yaml
@@ -33,7 +33,10 @@ spec:
       {{- if .Values.serviceAccountName }}
       serviceAccountName: {{ .Values.serviceAccountName }}
       {{- end }}
-      terminationGracePeriodSeconds: 60
+      {{- if or (lt (int .Values.connection_draining.grace_period_seconds) 1) (lt (int .Values.connection_draining.graceful_shutdown_timeout_seconds) 1) }}
+        {{- fail "connection_draining.grace_period_seconds and graceful_shutdown_timeout_seconds must be positive integers" }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ add .Values.connection_draining.grace_period_seconds .Values.connection_draining.graceful_shutdown_timeout_seconds 5 }}
       {{- with .Values.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}

--- a/charts/castai-db-proxy/values.yaml
+++ b/charts/castai-db-proxy/values.yaml
@@ -130,3 +130,10 @@ dnsPolicy: ""
 
 # -- Pod DNS configuration.
 dnsConfig: {}
+
+# -- Connection draining configuration
+connection_draining:
+  # -- How long existing connections have to finish after SIGTERM. Must be > 0
+  grace_period_seconds: 55
+  # -- How long the server waits for runtimes to shut down after the grace period. Must be > 0
+  graceful_shutdown_timeout_seconds: 5


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds configurable connection draining to the `castai-db-proxy` Helm chart. Pod `terminationGracePeriodSeconds` is now derived from the new draining settings, and the proxy configuration includes a `[server]` block with grace period values.

### Why
Enables controlled graceful shutdown of existing database connections during pod termination, aligning Kubernetes pod lifecycle configuration with the proxy's internal draining behavior.

### Key changes
- `values.yaml`: Added `connection_draining` block with `grace_period_seconds` (default `55`) and `graceful_shutdown_timeout_seconds` (default `5`).
- `templates/configmap.yaml`: Added `[server]` section populated from `connection_draining` values.
- `templates/deployment.yaml`: Added validation requiring both draining values to be positive integers; `terminationGracePeriodSeconds` is now computed as `grace_period_seconds + graceful_shutdown_timeout_seconds + 5`.
- `templates/_versions.tpl`: Bumped default proxy image version from `v0.2.0` to `v0.3.0`.
- `Chart.yaml` and `README.md`: Bumped chart version to `0.3.0` and documented new values.

### Impact
- The default proxy image tag is updated to `v0.3.0`; ensure the new image supports the `[server]` configuration block before deploying.
- `terminationGracePeriodSeconds` now defaults to `65` (`55 + 5 + 5`) instead of the previous hard-coded `60`.
- Invalid `connection_draining` values (zero or negative) will cause `helm install/upgrade` to fail with a validation error.