### PR TITLE
unified umbrella diff checker improvements

### DIFF
--- a/.github/scripts/check-umbrella-drift.sh
+++ b/.github/scripts/check-umbrella-drift.sh
@@ -7,9 +7,10 @@
 #   diff the component between its previous and current release tags first.
 #   - If only README / Chart.yaml-version-only / non-template files changed,
 #     we emit "no template changes" and skip the AI call entirely.
-#   - If template files DID change, we send the AI a unified diff per changed
-#     file together with the current umbrella file, and ask whether the
-#     umbrella reflects the component-side change.
+#   - If template files DID change, we send the AI a unified diff for all
+#     changed files together with the entire umbrella component directory,
+#     and ask whether the umbrella reflects the component-side changes.
+#     The AI resolves filename mapping itself (e.g. cluster-role.yaml → rbac.yaml).
 #
 # Required env vars:
 #   CHART_NAME        — e.g. castai-agent, castai-pod-pinner, castai-live
@@ -319,7 +320,7 @@ if [ ${#TEMPLATE_FILES[@]} -eq 0 ]; then
   exit 0
 fi
 
-# ── Kimchi API call helper (unchanged from previous revision) ─────────────────
+# ── Kimchi API call helper ────────────────────────────────────────────────────
 
 call_kimchi() {
   local prompt="$1"
@@ -377,145 +378,67 @@ EOF
   fi
 }
 
-# ── Map a changed component-side path to the matching umbrella file ───────────
-#
-# For non-live components, umbrella filenames match the component-side basename
-# 1:1 (e.g. templates/deployment.yaml ↔ umbrella/deployment.yaml). Chart.yaml
-# has no umbrella counterpart and is reported on its own.
-#
-# For castai-live the umbrella collapses each subdir / dependency into a single
-# file:
-#   helm/templates/<subdir>/foo.yaml       → <subdir>.yaml
-#   helm/templates/<name>.yaml             → <name>.yaml
-#   helm/dependencies/<dep>/templates/*    → <dep>.yaml (or fuzzy variants)
+# ── Collect full diff for all changed template files ──────────────────────────
 
-umbrella_file_for_component_path() {
-  local comp_rel="$1"   # relative to COMPONENT_PATH, e.g. "templates/deployment.yaml"
-  local base
-  base=$(basename "$comp_rel")
+FULL_DIFF=""
+for comp_path in "${TEMPLATE_FILES[@]}"; do
+  rel="${comp_path#${COMPONENT_PATH}/}"
+  file_diff=$(git -C "$REPO_CLONE_DIR" diff --no-color "${PREV_TAG}..${CURRENT_TAG}" -- "${comp_path}")
+  [ -z "$file_diff" ] && continue
+  FULL_DIFF+="### ${rel}
+\`\`\`diff
+${file_diff}
+\`\`\`
 
-  if [ "$CHART_NAME" = "castai-live" ]; then
-    # helm/templates/<subdir>/foo.yaml → <subdir>.yaml
-    if [[ "$comp_rel" == templates/*/* ]]; then
-      local subdir
-      subdir=$(echo "$comp_rel" | awk -F/ '{print $2}')
-      echo "${UMB_TEMPLATES}/${subdir}.yaml"
-      return 0
-    fi
-    # helm/templates/<file>.yaml → <file>.yaml
-    if [[ "$comp_rel" == templates/* ]]; then
-      echo "${UMB_TEMPLATES}/${base}"
-      return 0
-    fi
-    # helm/dependencies/<dep>/templates/*.yaml → <dep>.yaml (or crds → crd.yaml)
-    if [[ "$comp_rel" == dependencies/*/templates/* ]]; then
-      local dep
-      dep=$(echo "$comp_rel" | awk -F/ '{print $2}')
-      # crds → crd.yaml special-case (matches existing matcher)
-      [ "$dep" = "crds" ] && dep="crd"
-      echo "${UMB_TEMPLATES}/${dep}.yaml"
-      return 0
-    fi
-    # Anything else has no umbrella counterpart
-    echo ""
-    return 0
-  fi
+"
+done
 
-  # Non-live: 1:1 by basename, but only for files under templates/.
-  if [[ "$comp_rel" == templates/* ]]; then
-    echo "${UMB_TEMPLATES}/${base}"
-    return 0
-  fi
+# ── Collect all umbrella files for this component ─────────────────────────────
 
-  # Chart.yaml or other component-root file: no umbrella counterpart.
-  echo ""
-  return 0
-}
+UMB_CONTENTS=""
+for umb_file in "${UMB_TEMPLATES}"/*.yaml; do
+  [ -f "$umb_file" ] || continue
+  fname=$(basename "$umb_file")
+  UMB_CONTENTS+="### ${fname}
+\`\`\`yaml
+$(cat "$umb_file")
+\`\`\`
 
-# ── Per-file AI calls ─────────────────────────────────────────────────────────
+"
+done
+
+# ── Build and fire the single AI call ────────────────────────────────────────
 
 CASTAI_LIVE_NOTE=""
 if [ "$CHART_NAME" = "castai-live" ]; then
   CASTAI_LIVE_NOTE="NOTE: castai-live's component templates live in subdirectories (controller/, daemon/, tc/) and dependency charts (aws-vpc-cni/, crds/, …) which are all flattened into single files in the umbrella (controller.yaml, daemon.yaml, tc.yaml, aws-vpc-cni.yaml, crd.yaml, …). Match resources by kind and name pattern, not by file path."
 fi
 
-AI_REPORT=""
-
-for comp_path in "${TEMPLATE_FILES[@]}"; do
-  rel="${comp_path#${COMPONENT_PATH}/}"
-  echo "DEBUG: processing changed component file ${rel}" >&2
-
-  # Compute the unified diff between the two tags for this file.
-  file_diff=$(git -C "$REPO_CLONE_DIR" diff --no-color "${PREV_TAG}..${CURRENT_TAG}" -- "${comp_path}")
-  if [ -z "$file_diff" ]; then
-    # Shouldn't happen — git already told us this file changed.
-    echo "DEBUG: empty diff for ${rel} — skipping" >&2
-    continue
-  fi
-
-  # Chart.yaml drift is reported standalone (no umbrella counterpart).
-  if [ "$(basename "$rel")" = "Chart.yaml" ]; then
-    AI_REPORT+="### ${rel}
-
-> ℹ️ Chart.yaml changed between \`${PREV_TAG}\` and \`${CURRENT_TAG}\` beyond the version/appVersion bump. Review manually — no umbrella counterpart exists for this file.
-
-\`\`\`diff
-${file_diff}
-\`\`\`
-
-"
-    continue
-  fi
-
-  # Find the matching umbrella file.
-  umb_path=$(umbrella_file_for_component_path "$rel")
-  umb_fname=""
-  umb_content=""
-  if [ -n "$umb_path" ] && [ -f "$umb_path" ]; then
-    umb_fname=$(basename "$umb_path")
-    umb_content=$(cat "$umb_path")
-  fi
-
-  if [ -z "$umb_content" ]; then
-    AI_REPORT+="### ${rel}
-
-> ⚠️ Component file changed but no matching umbrella file was found (expected at \`${umb_path:-unknown}\`). Manual review required.
-
-\`\`\`diff
-${file_diff}
-\`\`\`
-
-"
-    continue
-  fi
-
-  per_file_prompt="You are a Helm chart reviewer detecting structural drift.
+PROMPT="You are a Helm chart reviewer detecting structural drift.
 
 CONTEXT:
 - The umbrella chart is a near-verbatim copy of component templates, adapted with different .Values paths (e.g. \$pp.image.tag), different helper names, and an outer {{- \$pp := index .Values... }} binding. These are EXPECTED and should NOT be reported.
+- The umbrella may consolidate multiple component files into fewer files (e.g. cluster-role.yaml + role.yaml → rbac.yaml). Match resources by kind and name pattern, not by filename.
 - ${CASTAI_LIVE_NOTE}
-- The component file \`${rel}\` changed between tags \`${PREV_TAG}\` and \`${CURRENT_TAG}\`. The unified diff is below. Your job is to determine whether the CURRENT umbrella file already reflects each component-side change. If it does, the umbrella is in sync for that change. If it does not, that is drift.
+- The component changed between tags \`${PREV_TAG}\` and \`${CURRENT_TAG}\`. The diffs for all changed template files are below.
 
-COMPONENT DIFF (${rel}, ${PREV_TAG} → ${CURRENT_TAG}):
-\`\`\`diff
-${file_diff}
-\`\`\`
+COMPONENT DIFFS (${PREV_TAG} → ${CURRENT_TAG}):
+${FULL_DIFF}
 
-CURRENT UMBRELLA FILE (${umb_fname}):
-\`\`\`yaml
-${umb_content}
-\`\`\`
+CURRENT UMBRELLA FILES (${UMB_TEMPLATES}/):
+${UMB_CONTENTS}
 
 YOUR TASK:
-For every semantic change visible in the component diff (additions, deletions, modifications to env, volumes, probes, ports, securityContext, resources, tolerations, affinity, nodeSelector, RBAC rules, initContainers, args, command, imagePullPolicy, serviceAccountName, hostNetwork, dnsPolicy, or any other spec field), check whether the current umbrella file already contains the equivalent value. Ignore expected adaptations (helper names, .Values paths, \$pp variable). Use this format per finding:
+For every semantic change visible in the component diffs (additions, deletions, modifications to env, volumes, probes, ports, securityContext, resources, tolerations, affinity, nodeSelector, RBAC rules, initContainers, args, command, imagePullPolicy, serviceAccountName, hostNetwork, dnsPolicy, or any other spec field), locate the equivalent resource across any of the umbrella files and check whether it already reflects the change. Use this format per finding:
 ---
-**Change in component:** <one-line summary of what changed in the diff>
+**Change in component:** <one-line summary>
 **Resource:** \`<kind>/<name-pattern>\`
 **Field:** \`<field path>\`
 **Component (new value):**
 \`\`\`yaml
 <value or \"(absent)\">
 \`\`\`
+**Umbrella file:** \`<filename>\`
 **Umbrella:**
 \`\`\`yaml
 <value or \"(absent)\">
@@ -529,39 +452,27 @@ Rules:
 - IN SYNC: the umbrella already reflects this component change (modulo expected adaptations).
 - DRIFT: the umbrella is missing this change or has a different value.
 - One finding block per distinct semantic change.
-- If every component-side change is already reflected in the umbrella, output EXACTLY this single line and nothing else: ✅ Umbrella in sync with ${rel} between ${PREV_TAG} and ${CURRENT_TAG}.
+- If every component-side change is already reflected in the umbrella, output EXACTLY this single line and nothing else: ✅ Umbrella in sync with all changed files between \`${PREV_TAG}\` and \`${CURRENT_TAG}\`.
 - Do NOT output the word \"None\", \"N/A\", an empty string, or any other placeholder.
 - Use real markdown formatting (newlines, headings, fenced code blocks). Do NOT emit literal backslash-n escape sequences."
 
-  file_report=$(call_kimchi "$per_file_prompt") || {
-    AI_REPORT+="### ${rel}
+AI_REPORT=$(call_kimchi "$PROMPT") || {
+  AI_REPORT="> ❌ API call failed — skipped. See workflow logs for the HTTP status and error body."
+}
 
-> ❌ API call failed — skipped. See workflow logs for the HTTP status and error body.
+# Normalise model output:
+#  - strip surrounding whitespace
+#  - convert literal backslash-n sequences to real newlines
+#  - collapse degenerate "None" / "N/A" / empty replies to the no-drift line
+AI_REPORT=$(printf '%s' "$AI_REPORT" \
+  | python3 -c "import sys; s=sys.stdin.read().strip(); s=s.replace('\\\\n','\n'); print(s)")
 
-"
-    continue
-  }
-
-  # Normalise model output:
-  #  - strip surrounding whitespace
-  #  - convert literal backslash-n sequences to real newlines
-  #  - collapse degenerate "None" / "N/A" / empty replies to the no-drift line
-  file_report=$(printf '%s' "$file_report" \
-    | python3 -c "import sys; s=sys.stdin.read().strip(); s=s.replace('\\\\n','\n'); print(s)")
-
-  normalised=$(printf '%s' "$file_report" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]./\\"'\''`')
-  case "$normalised" in
-    ''|none|na|nodrift|null|nil|empty|nochanges|nochange|nodifference|nodifferences|insync|umbrellainsync*)
-      file_report="✅ Umbrella in sync with ${rel} between \`${PREV_TAG}\` and \`${CURRENT_TAG}\`."
-      ;;
-  esac
-
-  AI_REPORT+="### ${rel}
-
-${file_report}
-
-"
-done
+normalised=$(printf '%s' "$AI_REPORT" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]./\\"'\''`')
+case "$normalised" in
+  ''|none|na|nodrift|null|nil|empty|nochanges|nochange|nodifference|nodifferences|insync|umbrellainsync*)
+    AI_REPORT="✅ Umbrella in sync with all changed files between \`${PREV_TAG}\` and \`${CURRENT_TAG}\`."
+    ;;
+esac
 
 # ── Build the ignored-files appendix ──────────────────────────────────────────
 
@@ -587,7 +498,8 @@ _Compared component tags \`${PREV_TAG}\` → \`${CURRENT_TAG}\` against umbrella
 
 **Changed template files:**
 ${CHANGED_LIST}
-${AI_REPORT}${IGNORED_BLOCK}"
+${AI_REPORT}
+${IGNORED_BLOCK}"
 
 echo "$REPORT"
 

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -337,18 +337,37 @@ jobs:
           helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
           helm repo update
 
-          # Refresh Chart.lock and packaged .tgz for each mode subchart whose
-          # Chart.yaml was bumped, then refresh the umbrella chart itself so
-          # its Chart.lock stays consistent.
+          # Retry helper — the newly released chart version can take a few minutes
+          # to propagate to the Helm repo index after the GitHub release publishes.
+          helm_dep_update_with_retry() {
+          local path="$1"
+          local max_attempts=5
+          local delay=90  # seconds between attempts
+
+          for attempt in $(seq 1 "$max_attempts"); do
+            echo "==> helm dependency update ${path} (attempt ${attempt}/${max_attempts})"
+            if helm dependency update "$path"; then
+              return 0
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "    Failed — chart version may not be indexed yet. Retrying in ${delay}s..."
+              helm repo update
+              sleep "$delay"
+            fi
+          done
+
+          echo "ERROR: helm dependency update ${path} failed after ${max_attempts} attempts."
+          return 1
+          }
+
           for sub in kent autoscaler-anywhere autoscaler-openshift; do
             path="kubecast/castai-umbrella/chart/charts/${sub}"
             if [ -d "$path" ]; then
-              echo "==> helm dependency update ${path}"
-              helm dependency update "$path"
+              helm_dep_update_with_retry "$path"
             fi
           done
-          echo "==> helm dependency update kubecast/castai-umbrella/chart"
-          helm dependency update kubecast/castai-umbrella/chart
+
+          helm_dep_update_with_retry "kubecast/castai-umbrella/chart"
 
       - name: Regenerate helm-docs README.md files
         if: steps.changed.outputs.any == 'true'


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
The umbrella drift checker now sends a single AI prompt containing all changed component template diffs plus the full umbrella component directory, instead of one API call per changed file with hard-coded filename mappings. The release workflow also retries `helm dependency update` to tolerate delays before a newly published chart appears in the Helm repo index.

### Why
- Per-file AI calls required brittle component-to-umbrella path mapping that broke when files were merged or renamed (e.g. `cluster-role.yaml` → `rbac.yaml`).
- Newly released chart versions are not always immediately available in the Helm repo index, causing `helm dependency update` to fail during umbrella RC creation.

### Key changes
- `.github/scripts/check-umbrella-drift.sh`
  - Removed `umbrella_file_for_component_path()` and the per-file AI loop.
  - Aggregates diffs for all changed template files into `FULL_DIFF`.
  - Reads every umbrella file under `${UMB_TEMPLATES}/*.yaml` into `UMB_CONTENTS`.
  - Sends one `call_kimchi` call with the complete diff and umbrella contents, instructing the model to match resources by `kind` and name across any umbrella file.
  - Updated the no-drift confirmation to `✅ Umbrella in sync with all changed files between \`${PREV_TAG}\` and \`${CURRENT_TAG}\``.
- `.github/workflows/release-umbrella-rc.yml`
  - Added `helm_dep_update_with_retry()` helper that retries `helm dependency update` up to 5 times with a 90-second backoff.
  - Applied the retry wrapper to the `kent`, `autoscaler-anywhere`, and `autoscaler-openshift` mode subcharts, as well as the main umbrella chart.

### Impact
- Drift reports now contain a single consolidated AI finding list rather than per-file sections, so filenames referenced in findings may differ from previous outputs.
- Consolidating all files into one prompt increases context size but eliminates multiple API round trips.
- Release jobs tolerate brief index propagation delays at the cost of potentially adding a few minutes when retries are needed.