### PR TITLE
[castai-db-optimizer] bump dbo-proxy to latest version

### DIFF
--- a/charts/castai-db-optimizer/Chart.yaml
+++ b/charts/castai-db-optimizer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-optimizer
 description: CAST AI database cache deployment.
 type: application
-version: 0.80.1
+version: 0.80.2

--- a/charts/castai-db-optimizer/README.md
+++ b/charts/castai-db-optimizer/README.md
@@ -1,6 +1,6 @@
 # castai-db-optimizer
 
-![Version: 0.80.1](https://img.shields.io/badge/Version-0.80.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.80.2](https://img.shields.io/badge/Version-0.80.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database cache deployment.
 

--- a/charts/castai-db-optimizer/templates/_versions.tpl
+++ b/charts/castai-db-optimizer/templates/_versions.tpl
@@ -1,4 +1,4 @@
-{{- define "castai-db-optimizer.defaultProxyVersion" -}}v4.84.2{{- end -}}
+{{- define "castai-db-optimizer.defaultProxyVersion" -}}v4.84.3{{- end -}}
 {{- define "castai-db-optimizer.defaultQueryProcessorVersion" -}}v0.48.0{{- end -}}
 {{- define "castai-db-optimizer.defaultCloudSqlProxyVersion" -}}2.18.2{{- end -}}
 {{- define "castai-db-optimizer.defaultPgdogVersion" -}}v0.1.43{{- end -}}


### PR DESCRIPTION
Bumps default `dbo-proxy` version to `v4.84.3` that ships an EOF packet parsing fix affecting certain MySQL clients that don't negotiate `CLIENT_DEPRECATE_EOF`.