### PR TITLE
[castai-evictor] Add seccompProfile

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.125
+version: 0.35.126
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -25,8 +25,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: |
-        Added global.rbac.clusterScoped.enabled toggle for cluster-scoped RBAC resources.
-        Set to false to disable ClusterRole and ClusterRoleBinding creation.
+        Set seccompProfile.type=RuntimeDefault on both the pod and container securityContext
+        so the evictor no longer runs with an unconfined seccomp profile.
 # GitHub actions fails when 'chart' directory is used for dependencies.
 dependencies:
   - name: castai-evictor-ext

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -29,6 +29,7 @@ Cluster utilization defragmentation tool
 | containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
+| containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | customConfig | object | `{}` |  |
 | cycleInterval | string | `"1m"` | Specifies the interval between eviction cycles. This property can be used to lower or raise the frequency of the evictor's find-and-drain operations. |
 | dnsPolicy | string | `""` | DNS Policy Override - Needed when using some custom CNI's. |
@@ -76,6 +77,7 @@ Cluster utilization defragmentation tool
 | securityContext.runAsGroup | int | `1004` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `1004` |  |
+| securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | service.port | int | `8080` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -167,6 +167,8 @@ securityContext:
   fsGroup: 1004
   runAsGroup: 1004
   runAsUser: 1004
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -251,6 +253,8 @@ containerSecurityContext:
   capabilities:
     drop:
       - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 # The referenced ConfigMap must provide the ClusterID in .data[<<.Values.clusterIdConfigMapKeyRef.key>>]
 clusterIdConfigMapKeyRef:


### PR DESCRIPTION
This MR addresses some vulnerability concerns raised about castai-evictor:

> Do not disable default seccomp profile: A process can set the no_new_priv bit in the kernel. It persists across fork, clone and execve. The no_new_priv bit ensures that the process or its children processes do not gain any additional privileges via suid or sgid bits. This way a lot of dangerous operations become a lot less dangerous because there is no possibility of subverting privileged binaries