### PR TITLE
[castai-hibernate] feat: add fallback ConfigMap support for CLUSTER_ID

### DIFF
--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
-version: 0.2.10
+version: 0.2.11
 appVersion: "v0.13"

--- a/charts/castai-hibernate/README.md
+++ b/charts/castai-hibernate/README.md
@@ -16,7 +16,7 @@ CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defi
 | clusterRoleBindingName | string | `"hibernate"` |  |
 | clusterRoleName | string | `"hibernate"` |  |
 | concurrencyPolicy | string | `"Forbid"` |  |
-| configMapName | string | `"castai-cluster-controller"` |  |
+| configMapName | string | `"castai-agent-metadata"` |  |
 | hibernateNode | string | `""` | Set the HIBERNATE_NODE environment variable to override the default node sizing selections. Make sure the size selected is appropriate for your cloud. |
 | hibernateNodeLabels | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
@@ -39,3 +39,16 @@ CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defi
 | secretName | string | `"castai-hibernate"` |  |
 | serviceAccountName | string | `"hibernate"` |  |
 | timeZone | string | `""` | Set CronJobs timezone, if no time zone specified the kube-controller-manager interprets schedules relative to its local time zone |
+
+## Migration Guide
+
+### v0.2.11 - ConfigMap Name Change
+
+The default `configMapName` has been changed from `castai-cluster-controller` to `castai-agent-metadata` to align with the new CAST AI agent metadata ConfigMap.
+
+**Action required when upgrading:**
+
+- If you are upgrading from v0.2.10 or earlier and have not overridden `configMapName`, the hibernate CronJobs will now reference the `castai-agent-metadata` ConfigMap for the `CLUSTER_ID` value.
+- Ensure the `castai-agent-metadata` ConfigMap exists in the target namespace (typically `castai-agent`) and contains the `CLUSTER_ID` key.
+- This ConfigMap is created automatically by the CAST AI agent (castai-agent chart) v0.22.0+.
+- If you are using an older agent version or a custom setup, you may need to create this ConfigMap manually or override `configMapName` to point to your existing ConfigMap.

--- a/charts/castai-hibernate/README.md
+++ b/charts/castai-hibernate/README.md
@@ -16,7 +16,8 @@ CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defi
 | clusterRoleBindingName | string | `"hibernate"` |  |
 | clusterRoleName | string | `"hibernate"` |  |
 | concurrencyPolicy | string | `"Forbid"` |  |
-| configMapName | string | `"castai-agent-metadata"` |  |
+| configMapNameFallback | string | `"castai-cluster-controller"` | Name of the fallback ConfigMap (legacy) for backwards compatibility. |
+| configMapNamePrimary | string | `"castai-agent-metadata"` | Name of the primary ConfigMap (created by CAST AI agent v0.22.0+) that holds cluster metadata. |
 | hibernateNode | string | `""` | Set the HIBERNATE_NODE environment variable to override the default node sizing selections. Make sure the size selected is appropriate for your cloud. |
 | hibernateNodeLabels | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
@@ -44,11 +45,11 @@ CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defi
 
 ### v0.2.11 - ConfigMap Name Change
 
-The default `configMapName` has been changed from `castai-cluster-controller` to `castai-agent-metadata` to align with the new CAST AI agent metadata ConfigMap.
+The default ConfigMap reference has been changed from `castai-cluster-controller` to `castai-agent-metadata` to align with the new CAST AI agent metadata ConfigMap.
 
 **Action required when upgrading:**
 
-- If you are upgrading from v0.2.10 or earlier and have not overridden `configMapName`, the hibernate CronJobs will now reference the `castai-agent-metadata` ConfigMap for the `CLUSTER_ID` value.
+- If you are upgrading from v0.2.10 or earlier and have not overridden `configMapNamePrimary`/`configMapNameFallback`, the hibernate CronJobs will now reference the `castai-agent-metadata` ConfigMap (primary) with fallback to `castai-cluster-controller` for the `CLUSTER_ID` value.
 - Ensure the `castai-agent-metadata` ConfigMap exists in the target namespace (typically `castai-agent`) and contains the `CLUSTER_ID` key.
 - This ConfigMap is created automatically by the CAST AI agent (castai-agent chart) v0.22.0+.
-- If you are using an older agent version or a custom setup, you may need to create this ConfigMap manually or override `configMapName` to point to your existing ConfigMap.
+- If you are using an older agent version or a custom setup, you may need to create this ConfigMap manually or override `configMapNamePrimary`/`configMapNameFallback` to point to your existing ConfigMap.

--- a/charts/castai-hibernate/README.md.gotmpl
+++ b/charts/castai-hibernate/README.md.gotmpl
@@ -12,3 +12,16 @@
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}
+
+## Migration Guide
+
+### v0.2.11 - ConfigMap Name Change
+
+The default ConfigMap reference has been changed from `castai-cluster-controller` to `castai-agent-metadata` to align with the new CAST AI agent metadata ConfigMap.
+
+**Action required when upgrading:**
+
+- If you are upgrading from v0.2.10 or earlier and have not overridden `configMapNamePrimary`/`configMapNameFallback`, the hibernate CronJobs will now reference the `castai-agent-metadata` ConfigMap (primary) with fallback to `castai-cluster-controller` for the `CLUSTER_ID` value.
+- Ensure the `castai-agent-metadata` ConfigMap exists in the target namespace (typically `castai-agent`) and contains the `CLUSTER_ID` key.
+- This ConfigMap is created automatically by the CAST AI agent (castai-agent chart) v0.22.0+.
+- If you are using an older agent version or a custom setup, you may need to create this ConfigMap manually or override `configMapNamePrimary`/`configMapNameFallback` to point to your existing ConfigMap.

--- a/charts/castai-hibernate/templates/pause-cronjob.yaml
+++ b/charts/castai-hibernate/templates/pause-cronjob.yaml
@@ -33,6 +33,12 @@ spec:
                   name: {{ .Values.secretName }}
                   {{- end }}
                   optional: false
+              - configMapRef:
+                  name: {{ .Values.configMapNameFallback }}
+                  optional: true
+              - configMapRef:
+                  name: {{ .Values.configMapNamePrimary }}
+                  optional: true
             securityContext:
               readOnlyRootFilesystem: true       
             env:
@@ -52,11 +58,6 @@ spec:
                 value: "{{ .Values.protectRemovalDisabled }}"
               - name: ACTION
                 value: "pause"
-              - name: CLUSTER_ID
-                valueFrom:
-                  configMapKeyRef:
-                    name: {{ .Values.configMapName }}
-                    key: CLUSTER_ID
               - name: API_URL
                 value: {{ .Values.apiUrl }}
           restartPolicy: {{ .Values.restartPolicy }}

--- a/charts/castai-hibernate/templates/resume-cronjob.yaml
+++ b/charts/castai-hibernate/templates/resume-cronjob.yaml
@@ -34,6 +34,12 @@ spec:
                   name: {{ .Values.secretName }}
                   {{- end }}
                   optional: false
+              - configMapRef:
+                  name: {{ .Values.configMapNameFallback }}
+                  optional: true
+              - configMapRef:
+                  name: {{ .Values.configMapNamePrimary }}
+                  optional: true
             securityContext:
               readOnlyRootFilesystem: true   
             env:
@@ -41,11 +47,6 @@ spec:
                 value: "{{ .Values.cloud }}"
               - name: ACTION
                 value: "resume"
-              - name: CLUSTER_ID
-                valueFrom:
-                  configMapKeyRef:
-                    name: {{ .Values.configMapName }}
-                    key: CLUSTER_ID
               - name: API_URL
                 value: {{ .Values.apiUrl }}
           restartPolicy: {{ .Values.restartPolicy }}

--- a/charts/castai-hibernate/values.yaml
+++ b/charts/castai-hibernate/values.yaml
@@ -69,7 +69,7 @@ namespacesToKeep: ""
 # -- This looks for the autoscaling.cast.ai/removal-disabled="true" label on a node and if it exists excludes it from being cordoned and deleted.
 protectRemovalDisabled: "false"
 
-configMapName: castai-cluster-controller
+configMapName: castai-agent-metadata
 
 restartPolicy: "OnFailure"
 backoffLimit: 0

--- a/charts/castai-hibernate/values.yaml
+++ b/charts/castai-hibernate/values.yaml
@@ -69,6 +69,7 @@ namespacesToKeep: ""
 # -- This looks for the autoscaling.cast.ai/removal-disabled="true" label on a node and if it exists excludes it from being cordoned and deleted.
 protectRemovalDisabled: "false"
 
+# -- Name of the ConfigMap created by the CAST AI agent that holds cluster metadata used during hibernation.
 configMapName: castai-agent-metadata
 
 restartPolicy: "OnFailure"

--- a/charts/castai-hibernate/values.yaml
+++ b/charts/castai-hibernate/values.yaml
@@ -69,8 +69,10 @@ namespacesToKeep: ""
 # -- This looks for the autoscaling.cast.ai/removal-disabled="true" label on a node and if it exists excludes it from being cordoned and deleted.
 protectRemovalDisabled: "false"
 
-# -- Name of the ConfigMap created by the CAST AI agent that holds cluster metadata used during hibernation.
-configMapName: castai-agent-metadata
+# -- Name of the primary ConfigMap (created by CAST AI agent v0.22.0+) that holds cluster metadata.
+configMapNamePrimary: castai-agent-metadata
+# -- Name of the fallback ConfigMap (legacy) for backwards compatibility.
+configMapNameFallback: castai-cluster-controller
 
 restartPolicy: "OnFailure"
 backoffLimit: 0


### PR DESCRIPTION
Updates the default ConfigMap reference from  to  for the CLUSTER_ID environment variable in both pause and resume CronJobs.

This change aligns the hibernate chart with the new metadata ConfigMap naming convention used by the CAST AI agent.