### PR TITLE
[castai-hibernate] bump appVersion to v0.14

### DIFF
--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
-version: 0.2.12
+version: 0.2.11
 appVersion: "v0.14"

--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "v0.14"

--- a/charts/castai-hibernate/Chart.yaml
+++ b/charts/castai-hibernate/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: castai-hibernate
 description: CAST AI hibernate CronJobs used to pause and resume Kubernetes cluster on a defined schedule.
 type: application
-version: 0.2.11
-appVersion: "v0.13"
+version: 0.2.12
+appVersion: "v0.14"


### PR DESCRIPTION
## Summary
- Bump `castai-hibernate` chart to `0.2.12`
- Set `appVersion` to `v0.14` to match Docker Hub image `castai/hibernate:v0.14` (published after hibernate [#41](https://github.com/castai/hibernate/pull/41))

Follow-up to [#1523](https://github.com/castai/helm-charts/pull/1523), which shipped ConfigMap fallback while still on `v0.13`.

## Test plan
- [ ] Confirm `castai/hibernate:v0.14` exists on Docker Hub
- [ ] `helm template` / install shows image `castai/hibernate:v0.14`
- [ ] Optional: smoke pause/resume on a test cluster


Made with [Cursor](https://cursor.com)