### PR TITLE
[castai-evictor] Fix EvictorConfig CRD hooks for ArgoCD compatibility

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.127
+version: 0.35.128
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -21,7 +21,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -45,7 +45,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -65,7 +65,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   crds.yaml: |
 {{ .Files.Get "crd-files/evictorconfigs.autoscaling.cast.ai.yaml" | indent 4 }}

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -35,6 +35,16 @@ rules:
   - list
   - patch
   - update
+- apiGroups:
+  - autoscaling.cast.ai
+  resources:
+  - evictorconfigs
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -69,6 +79,8 @@ metadata:
 data:
   crds.yaml: |
 {{ .Files.Get "crd-files/evictorconfigs.autoscaling.cast.ai.yaml" | indent 4 }}
+  evictorconfig.yaml: |
+{{ include "evictor.evictorconfig" . | indent 4 }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -125,7 +137,7 @@ spec:
         - --server-side
         - --force-conflicts
         - -f
-        - /crds/crds.yaml
+        - /crds/
         volumeMounts:
         - name: crds
           mountPath: /crds

--- a/charts/castai-evictor/templates/evictorconfig.yaml
+++ b/charts/castai-evictor/templates/evictorconfig.yaml
@@ -1,75 +1,73 @@
 {{/*
-  Two rendering paths for the EvictorConfig CR:
+  EvictorConfig CR manifest and spec, defined as reusable blocks.
 
-  1. CRD already exists (.Capabilities check) → render as regular template resource.
-  2. First install with crdUpgrade.enabled=true → render as post-install hook.
-     The pre-install crd-upgrade-job creates the CRD first, then this hook
-     applies the CR after all regular resources are loaded.
+  Two rendering paths:
 
-  The guards are mutually exclusive: when the CRD exists, path 1 fires and
-  path 2 is suppressed (and vice versa).
+  1. crdUpgrade.enabled=true (default): The CR is NOT rendered as a
+     standalone resource. It is embedded in the crd-upgrade-job's
+     ConfigMap and applied via kubectl by the Job, alongside the CRD.
+
+  2. crdUpgrade.enabled=false (Cast auto-upgrade, or users who manage
+     the CRD separately): The CR is rendered as a post-install/
+     post-upgrade hook. If the CRD exists, the hook creates/updates the
+     CR. If not, the hook fails gracefully — regular resources are
+     still applied.
 */}}
-{{- $crdExists := .Capabilities.APIVersions.Has "autoscaling.cast.ai/v1alpha1/EvictorConfig" -}}
-{{- $hookInstall := and .Values.crdUpgrade.enabled (not $crdExists) -}}
-{{- if or $crdExists $hookInstall }}
+{{- define "evictor.evictorconfig" -}}
 apiVersion: autoscaling.cast.ai/v1alpha1
 kind: EvictorConfig
 metadata:
   name: evictor-config
   labels:
     {{- include "evictor.labels" . | nindent 4 }}
-  {{- if $hookInstall }}
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "10"
-    helm.sh/hook-delete-policy: before-hook-creation
-    meta.helm.sh/release-name: {{ .Release.Name }}
-    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
-  {{- end }}
 spec:
-  managementMode: {{ .Values.managedByCASTAI | ternary "castai" "self-managed" }}
-  enabled: {{ .Values.evictorEnabled }}
-  config:
-    aggressiveMode: {{ .Values.aggressiveMode }}
-    arm64Supported: {{ .Values.arm64Supported }}
-    cycleInterval: {{ .Values.cycleInterval | quote }}
-    drainRollbackTimeout: {{ .Values.drainRollbackTimeout | quote }}
-    drainTimeout: {{ .Values.drainTimeout | quote }}
-    dryRun: {{ .Values.dryRun }}
-    emitNodeRelatedPodEvents: {{ .Values.emitNodeRelatedPodEvents }}
-    forceDisableKarpenterMode: {{ .Values.forceDisableKarpenterMode }}
-    forceDisableLiveMigration: {{ not .Values.liveMigration.enabled }}
-    forceDisablePodMutations: {{ not .Values.podMutations.enabled }}
-    forceDisableWOOP: {{ not .Values.woop.enabled }}
-    ignorePodDisruptionBudgets: {{ .Values.ignorePodDisruptionBudgets }}
-    maxTargetNodesPerCycle: {{ .Values.maxNodesToEvictPerCycle }}
-    minTargetNodesPerCycle: {{ .Values.minNodesToEvictPerCycle }}
-    nodeGracePeriodMinutes: {{ .Values.nodeGracePeriodMinutes }}
-    podEvictionFailureBackOff: {{ .Values.podEvictionFailureBackOff | quote }}
-    pricingAwarenessEnabled: {{ .Values.pricingModel.enabled }}
-    pricingModel:
-      baseCPUCost: {{ .Values.pricingModel.baseCPUCost | quote }}
-      baseMemCost: {{ .Values.pricingModel.baseMemCost | quote }}
-      spotDiscount: {{ .Values.pricingModel.spotDiscount | quote }}
-    scopedMode: {{ .Values.scopedMode }}
-    softTainting: {{ .Values.softTainting.enabled }}
-    targetNodePercentage: {{ .Values.targetNodePercentage }}
-    windows: {{ .Values.windows }}
-  {{- if .Values.customConfig }}
-  {{- if not (kindIs "string" .Values.customConfig) }}
-  {{- $rules := list }}
-  {{- if kindIs "slice" .Values.customConfig }}
-    {{- $rules = .Values.customConfig }}
-  {{- else if kindIs "map" .Values.customConfig }}
-    {{- if .Values.customConfig.evictionRules }}
-      {{- $rules = .Values.customConfig.evictionRules }}
-    {{- else }}
-      {{- fail "customConfig map must contain an 'evictionRules' key" }}
-    {{- end }}
+{{ include "evictor.evictorconfig.spec" . | indent 2 }}
+{{- end -}}
+
+{{- define "evictor.evictorconfig.spec" -}}
+managementMode: {{ .Values.managedByCASTAI | ternary "castai" "self-managed" }}
+enabled: {{ .Values.evictorEnabled }}
+config:
+  aggressiveMode: {{ .Values.aggressiveMode }}
+  arm64Supported: {{ .Values.arm64Supported }}
+  cycleInterval: {{ .Values.cycleInterval | quote }}
+  drainRollbackTimeout: {{ .Values.drainRollbackTimeout | quote }}
+  drainTimeout: {{ .Values.drainTimeout | quote }}
+  dryRun: {{ .Values.dryRun }}
+  emitNodeRelatedPodEvents: {{ .Values.emitNodeRelatedPodEvents }}
+  forceDisableKarpenterMode: {{ .Values.forceDisableKarpenterMode }}
+  forceDisableLiveMigration: {{ not .Values.liveMigration.enabled }}
+  forceDisablePodMutations: {{ not .Values.podMutations.enabled }}
+  forceDisableWOOP: {{ not .Values.woop.enabled }}
+  ignorePodDisruptionBudgets: {{ .Values.ignorePodDisruptionBudgets }}
+  maxTargetNodesPerCycle: {{ .Values.maxNodesToEvictPerCycle }}
+  minTargetNodesPerCycle: {{ .Values.minNodesToEvictPerCycle }}
+  nodeGracePeriodMinutes: {{ .Values.nodeGracePeriodMinutes }}
+  podEvictionFailureBackOff: {{ .Values.podEvictionFailureBackOff | quote }}
+  pricingAwarenessEnabled: {{ .Values.pricingModel.enabled }}
+  pricingModel:
+    baseCPUCost: {{ .Values.pricingModel.baseCPUCost | quote }}
+    baseMemCost: {{ .Values.pricingModel.baseMemCost | quote }}
+    spotDiscount: {{ .Values.pricingModel.spotDiscount | quote }}
+  scopedMode: {{ .Values.scopedMode }}
+  softTainting: {{ .Values.softTainting.enabled }}
+  targetNodePercentage: {{ .Values.targetNodePercentage }}
+  windows: {{ .Values.windows }}
+{{- if .Values.customConfig }}
+{{- if not (kindIs "string" .Values.customConfig) }}
+{{- $rules := list }}
+{{- if kindIs "slice" .Values.customConfig }}
+  {{- $rules = .Values.customConfig }}
+{{- else if kindIs "map" .Values.customConfig }}
+  {{- if .Values.customConfig.evictionRules }}
+    {{- $rules = .Values.customConfig.evictionRules }}
+  {{- else }}
+    {{- fail "customConfig map must contain an 'evictionRules' key" }}
   {{- end }}
-  {{- if $rules }}
+{{- end }}
+{{- if $rules }}
   evictionRules:
-    {{- range $rules }}
+  {{- range $rules }}
     {{- $rule := omit . "settings" }}
     {{- if .settings }}
       {{- $crSettings := dict }}
@@ -83,8 +81,24 @@ spec:
       {{- $rule = set $rule "settings" $crSettings }}
     {{- end }}
     - {{ $rule | toYaml | nindent 6 | trim }}
-    {{- end }}
   {{- end }}
-  {{- end }}
-  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- if not .Values.crdUpgrade.enabled }}
+---
+apiVersion: autoscaling.cast.ai/v1alpha1
+kind: EvictorConfig
+metadata:
+  name: evictor-config
+  labels:
+    {{- include "evictor.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+{{ include "evictor.evictorconfig.spec" . | indent 2 }}
 {{- end }}


### PR DESCRIPTION
## Problem

Customers report that when installing/upgrading `castai-evictor` v0.35.127 via ArgoCD, the pre-install/pre-upgrade hooks for the crd-upgrade-job never run (no ServiceAccount, ConfigMap, or Job are created), but the post-install/post-upgrade hook (EvictorConfig CR) does run — and fails because the CRD doesn't exist.

Other charts using the same helm hook pattern work correctly in ArgoCD.

## Root Cause

Two issues:

### 1. `hook-succeeded` on passive resources breaks ArgoCD PreSync

The crd-upgrade-job applied `before-hook-creation,hook-succeeded` to **all** hook resources including passive ones (ServiceAccount, ClusterRole, ClusterRoleBinding, ConfigMap).

ArgoCD maps `helm.sh/hook: pre-install,pre-upgrade` to `PreSync`. However, `HookSucceeded` is designed for resources with a Kubernetes completion state (Jobs). For passive resources like ServiceAccount and ConfigMap, ArgoCD cannot evaluate "succeeded", causing the PreSync phase to silently skip them.

### 2. EvictorConfig CR as a PostSync hook fails validation when CRD doesn't exist

ArgoCD validates all resources (including hooks) before starting any sync phase. The EvictorConfig CR failed dry-run validation because the CRD didn't exist yet, which blocked the **entire sync** — including the PreSync crd-upgrade-job that would create the CRD.

## Fix

### `crd-upgrade-job.yaml`

**Removed `hook-succeeded` from passive resources** (SA, ClusterRole, CRB, ConfigMap). Keep `before-hook-creation,hook-succeeded` only on the Job, which has a Kubernetes completion state. This matches the pattern used by other charts that work correctly in ArgoCD.

**Embedded the EvictorConfig CR in the ConfigMap** alongside the CRD. The Job now runs `kubectl apply --server-side --force-conflicts -f /crds/` which applies both the CRD and the CR in the correct order (kubectl waits for CRD establishment before applying CRs). This eliminates the need for a separate PostSync hook on the EvictorConfig CR — no dry-run validation issue, no ArgoCD-specific annotations.

**Added `evictorconfigs` RBAC** to the ClusterRole so the Job can apply CRs.

### `evictorconfig.yaml`

**Extracted the CR spec into a reusable `define` block** (`evictor.evictorconfig` and `evictor.evictorconfig.spec`). Two rendering paths:

1. **`crdUpgrade.enabled=true` (default)**: The CR is NOT rendered as a standalone resource. It is embedded in the crd-upgrade-job's ConfigMap and applied by the Job alongside the CRD. No hooks on the CR, no ArgoCD annotations.

2. **`crdUpgrade.enabled=false`**: The CR is rendered as a `post-install,post-upgrade` hook. Hooks bypass Helm's client-side validation, so install/upgrade doesn't fail if the CRD doesn't exist. If the CRD exists, the hook creates/updates the CR. If not, the hook fails gracefully — regular resources (deployment, etc.) are already applied. No `.Capabilities` check needed.

### `Chart.yaml`

Version bump `0.35.127` → `0.35.129`.

## What is NOT changed

- No ArgoCD-specific annotations (`argocd.argoproj.io/*`) anywhere in the chart
- No `.Capabilities.APIVersions.Has` check — works in both Helm (cluster access) and ArgoCD (template mode)
- The evictor deployment is unchanged — it already handles running with and without an EvictorConfig CR (watches the CR and applies changes without restart)
- CRD and CR persist after `helm uninstall` — this is intentional (follows Helm CRD best practices to avoid data loss from cascading CRD deletion)

## Scenario Matrix

| # | Scenario | Who triggers | `crdUpgrade.enabled` | CRD exists? | CR rendering | Who creates CRD? | Who manages CR? | Works? |
|---|---|---|---|---|---|---|---|---|
| 1 | Old standalone, pre-CRD (Cast auto-upgrade) | Autoscaler `upsertEvictorHelmChart` | `false` (set by autoscaler) | No | PostInstall hook — fails gracefully, regular resources applied | N/A | N/A — evictor runs without CR | ✅ |
| 2 | Old standalone, CRD exists (Cast auto-upgrade) | Autoscaler `upsertEvictorHelmChart` | `false` (set by autoscaler) | Yes | PostInstall hook — succeeds | Not touched | Helm hook creates/updates, autoscaler patches via `reconcileEvictorConfigCR` | ✅ |
| 3 | Umbrella, Cast auto-upgrade | Autoscaler `patchEvictorResources` | N/A (direct k8s patches) | Yes | N/A | Not touched | Autoscaler patches directly | ✅ |
| 4 | New install via Helm | Customer `helm install` | `true` (default) | No | In ConfigMap, applied by Job | PreInstall Job | PreInstall Job | ✅ |
| 5 | Upgrade via Helm | Customer `helm upgrade` | `true` (default) | Yes | In ConfigMap, applied by Job | PreUpgrade Job | PreUpgrade Job | ✅ |
| 6 | New install via ArgoCD | ArgoCD sync | `true` (default) | No | In ConfigMap, applied by Job | PreSync Job | PreSync Job | ✅ |
| 7 | Upgrade via ArgoCD | ArgoCD sync | `true` (default) | Yes | In ConfigMap, applied by Job | PreSync Job | PreSync Job | ✅ |
| 8 | ArgoCD + `crdUpgrade.enabled=false`, CRD exists | ArgoCD sync | `false` (user set) | Yes | PostSync hook — succeeds | Managed externally | PostSync hook | ✅ |
| 9 | ArgoCD + `crdUpgrade.enabled=false`, no CRD | ArgoCD sync | `false` (user set) | No | PostSync hook — fails gracefully | N/A | N/A — evictor runs without CR | ✅ |
| 10 | Helm install + `crdUpgrade.enabled=false`, no CRD | Customer `helm install` | `false` (user set) | No | PostInstall hook — fails gracefully, regular resources applied | N/A | N/A — evictor runs without CR | ✅ |
| 11 | Helm install + `crdUpgrade.enabled=false`, CRD exists | Customer `helm install` | `false` (user set) | Yes | PostInstall hook — succeeds | Managed externally | PostInstall hook | ✅ |
| 12 | Helm upgrade + `crdUpgrade.enabled=false`, CRD exists | Customer `helm upgrade` | `false` (user set) | Yes | PostUpgrade hook — succeeds | Not touched | PostUpgrade hook | ✅ |
| 13 | Helm upgrade + `crdUpgrade.enabled=false`, no CRD | Customer `helm upgrade` | `false` (user set) | No | PostUpgrade hook — fails gracefully, regular resources upgraded | N/A | N/A — evictor runs without CR | ✅ |

## Compatibility with autoscaler code

Verified against `services/autoscaler/internal/services/autoscaler/evictor.go`:
- `upsertEvictorHelmChart` sets `crdUpgrade.enabled=false` — scenario 1/2 above
- `patchEvictorResources` patches deployment+configmap directly — scenario 3
- `verifyDeploymentNotExternallyManaged` rejects ArgoCD-managed deployments — no conflict with this fix (zero ArgoCD annotations)
- MR !48825's `reconcileEvictorConfigCR` patches the CR via k8s API — compatible (CR exists from Helm hook or Job)

## Verified

Tested on GKE cluster `primoz-07-21`:

- ✅ Standalone Helm install + upgrade (CRD created, CR applied, `dryRun` updated false→true)
- ✅ Umbrella Helm install + upgrade (CRD created, CR applied, `dryRun` updated false→true)
- ✅ Umbrella ArgoCD install (Sync Status=Synced, CRD created by PreSync Job, CR applied, deployment progressing)
- ✅ chart-testing `ct lint` + `ct install` passing
- ✅ No ArgoCD-specific annotations in rendered output