### PR TITLE
[castai-evictor] CRD upgrade job pod labels configuration.

### DIFF
--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.131
+version: 0.35.132
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -35,7 +35,7 @@ Cluster utilization defragmentation tool
 | crdUpgrade.image.digest | string | `""` | Image digest for pinning (e.g. sha256:abc...). When set, appended to the image reference. |
 | crdUpgrade.imagePullSecrets | list | `[]` | Image pull secrets for the CRD upgrade Job. Use when crdUpgrade.image.repository points to a private registry that requires authentication. Independent of the evictor imagePullSecrets. |
 | crdUpgrade.podAnnotations | object | `{}` | Additional annotations applied to the CRD upgrade Job pod. |
-| crdUpgrade.podLabels | object | `{}` | Additional labels applied to the CRD upgrade Job pod. These are merged with the global podLabels. Use to match network policies that grant the Job pod access to the Kubernetes API. |
+| crdUpgrade.podLabels | object | `{}` | Additional labels applied to the CRD upgrade Job pod. |
 | crdUpgrade.resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the CRD upgrade Job container. |
 | customConfig | object | `{}` |  |
 | cycleInterval | string | `"1m"` | Specifies the interval between eviction cycles. This property can be used to lower or raise the frequency of the evictor's find-and-drain operations. |

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -31,9 +31,11 @@ Cluster utilization defragmentation tool
 | containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| crdUpgrade | object | `{"enabled":true,"image":{"digest":"","pullPolicy":"IfNotPresent","repository":"rancher/kubectl","tag":"v1.35.6"},"imagePullSecrets":[],"resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | CRD upgrade configuration. Enables automatic CRD upgrade during helm install/upgrade operations via a pre-install/pre-upgrade hook Job. |
+| crdUpgrade | object | `{"enabled":true,"image":{"digest":"","pullPolicy":"IfNotPresent","repository":"rancher/kubectl","tag":"v1.35.6"},"imagePullSecrets":[],"podAnnotations":{},"podLabels":{},"resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | CRD upgrade configuration. Enables automatic CRD upgrade during helm install/upgrade operations via a pre-install/pre-upgrade hook Job. |
 | crdUpgrade.image.digest | string | `""` | Image digest for pinning (e.g. sha256:abc...). When set, appended to the image reference. |
 | crdUpgrade.imagePullSecrets | list | `[]` | Image pull secrets for the CRD upgrade Job. Use when crdUpgrade.image.repository points to a private registry that requires authentication. Independent of the evictor imagePullSecrets. |
+| crdUpgrade.podAnnotations | object | `{}` | Additional annotations applied to the CRD upgrade Job pod. |
+| crdUpgrade.podLabels | object | `{}` | Additional labels applied to the CRD upgrade Job pod. These are merged with the global podLabels. Use to match network policies that grant the Job pod access to the Kubernetes API. |
 | crdUpgrade.resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the CRD upgrade Job container. |
 | customConfig | object | `{}` |  |
 | cycleInterval | string | `"1m"` | Specifies the interval between eviction cycles. This property can be used to lower or raise the frequency of the evictor's find-and-drain operations. |

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -99,7 +99,14 @@ spec:
     metadata:
       name: {{ include "evictor.fullname" . }}-crd-upgrade
       labels:
-        {{- include "evictor.labels" . | nindent 8 }}
+        {{- include "evictor.selectorLabels" . | nindent 8 }}
+        {{- with .Values.crdUpgrade.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.crdUpgrade.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "evictor.fullname" . }}-crd-upgrade

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -88,7 +88,8 @@ metadata:
   name: {{ include "evictor.fullname" . }}-crd-upgrade-{{ .Release.Revision }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "evictor.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "evictor.fullname" . }}-crd-upgrade
+    app.kubernetes.io/instance: {{ include "evictor.fullname" . }}-crd-upgrade
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
@@ -100,7 +101,8 @@ spec:
     metadata:
       name: {{ include "evictor.fullname" . }}-crd-upgrade
       labels:
-        {{- include "evictor.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "evictor.fullname" . }}-crd-upgrade
+        app.kubernetes.io/instance: {{ include "evictor.fullname" . }}-crd-upgrade
         {{- with .Values.crdUpgrade.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -93,6 +93,7 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- include "evictor.annotations" . | nindent 4 }}
 spec:
   backoffLimit: 3
   template:

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -329,8 +329,6 @@ crdUpgrade:
   # points to a private registry that requires authentication. Independent of the evictor imagePullSecrets.
   imagePullSecrets: []
   # crdUpgrade.podLabels -- Additional labels applied to the CRD upgrade Job pod.
-  # These are merged with the global podLabels. Use to match network policies
-  # that grant the Job pod access to the Kubernetes API.
   podLabels: {}
   # crdUpgrade.podAnnotations -- Additional annotations applied to the CRD upgrade Job pod.
   podAnnotations: {}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -328,6 +328,12 @@ crdUpgrade:
   # crdUpgrade.imagePullSecrets -- Image pull secrets for the CRD upgrade Job. Use when crdUpgrade.image.repository
   # points to a private registry that requires authentication. Independent of the evictor imagePullSecrets.
   imagePullSecrets: []
+  # crdUpgrade.podLabels -- Additional labels applied to the CRD upgrade Job pod.
+  # These are merged with the global podLabels. Use to match network policies
+  # that grant the Job pod access to the Kubernetes API.
+  podLabels: {}
+  # crdUpgrade.podAnnotations -- Additional annotations applied to the CRD upgrade Job pod.
+  podAnnotations: {}
   # crdUpgrade.resources -- Resource requests/limits for the CRD upgrade Job container.
   resources:
     requests:


### PR DESCRIPTION
Manage pod labels and annotations for the crd upgrade job separately.