### PR TITLE
[castai-evictor] Split CRD/CR apply into initcontainers.

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -17,7 +17,7 @@ jobs:
           version: v3.17.0
 
       - name: Install helm-unittest
-        run: helm plugin install https://github.com/quintush/helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,6 +16,9 @@ jobs:
         with:
           version: v3.17.0
 
+      - name: Install helm-unittest
+        run: helm plugin install https://github.com/quintush/helm-unittest
+
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
       - name: Set up Python
@@ -44,6 +47,18 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --debug --config ct.yaml
+
+      - name: Run helm unittest
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          charts=$(ct list-changed --config ct.yaml)
+          while IFS= read -r c; do
+            [ -z "$c" ] && continue
+            if [ -d "$c/tests" ]; then
+              helm dependency build "$c"
+              helm unittest "$c"
+            fi
+          done <<< "$charts"
 
       - name: Check for merge conflict markers
         uses: olivernybroe/action-conflict-finder@v4.1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 *.tgz
 .kimchi
+__snapshot__/
+*.bak

--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.133
+version: 0.35.134
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.132
+version: 0.35.133
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/Chart.yaml
+++ b/charts/castai-evictor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.35.131
+version: 0.35.132
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -31,12 +31,14 @@ Cluster utilization defragmentation tool
 | containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| crdUpgrade | object | `{"enabled":true,"image":{"digest":"","pullPolicy":"IfNotPresent","repository":"rancher/kubectl","tag":"v1.35.6"},"imagePullSecrets":[],"podAnnotations":{},"podLabels":{},"resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | CRD upgrade configuration. Enables automatic CRD upgrade during helm install/upgrade operations via a pre-install/pre-upgrade hook Job. |
+| crdUpgrade | object | `{"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000},"enabled":true,"image":{"digest":"","pullPolicy":"IfNotPresent","repository":"rancher/kubectl","tag":"v1.35.6"},"imagePullSecrets":[],"podAnnotations":{},"podLabels":{},"resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"securityContext":{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}}` | CRD upgrade configuration. Enables automatic CRD upgrade during helm install/upgrade operations via a pre-install/pre-upgrade hook Job. |
+| crdUpgrade.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | Container security context (applied to all init + main containers). seccompProfile inherited from pod-level. |
 | crdUpgrade.image.digest | string | `""` | Image digest for pinning (e.g. sha256:abc...). When set, appended to the image reference. |
 | crdUpgrade.imagePullSecrets | list | `[]` | Image pull secrets for the CRD upgrade Job. Use when crdUpgrade.image.repository points to a private registry that requires authentication. Independent of the evictor imagePullSecrets. |
 | crdUpgrade.podAnnotations | object | `{}` | Additional annotations applied to the CRD upgrade Job pod. |
 | crdUpgrade.podLabels | object | `{}` | Additional labels applied to the CRD upgrade Job pod. |
-| crdUpgrade.resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the CRD upgrade Job container. |
+| crdUpgrade.resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources for all containers (init + main) in the Job. |
+| crdUpgrade.securityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod security context. On OpenShift with useRestrictedProfile, UID fields are stripped automatically. |
 | customConfig | object | `{}` |  |
 | cycleInterval | string | `"1m"` | Specifies the interval between eviction cycles. This property can be used to lower or raise the frequency of the evictor's find-and-drain operations. |
 | dnsPolicy | string | `""` | DNS Policy Override - Needed when using some custom CNI's. |

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -35,7 +35,7 @@ Cluster utilization defragmentation tool
 | crdUpgrade.image.digest | string | `""` | Image digest for pinning (e.g. sha256:abc...). When set, appended to the image reference. |
 | crdUpgrade.imagePullSecrets | list | `[]` | Image pull secrets for the CRD upgrade Job. Use when crdUpgrade.image.repository points to a private registry that requires authentication. Independent of the evictor imagePullSecrets. |
 | crdUpgrade.podAnnotations | object | `{}` | Additional annotations applied to the CRD upgrade Job pod. |
-| crdUpgrade.podLabels | object | `{}` | Additional labels applied to the CRD upgrade Job pod. These are merged with the global podLabels. Use to match network policies that grant the Job pod access to the Kubernetes API. |
+| crdUpgrade.podLabels | object | `{}` | Additional labels applied to the CRD upgrade Job pod. |
 | crdUpgrade.resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the CRD upgrade Job container. |
 | customConfig | object | `{}` |  |
 | cycleInterval | string | `"1m"` | Specifies the interval between eviction cycles. This property can be used to lower or raise the frequency of the evictor's find-and-drain operations. |

--- a/charts/castai-evictor/README.md
+++ b/charts/castai-evictor/README.md
@@ -31,9 +31,11 @@ Cluster utilization defragmentation tool
 | containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| crdUpgrade | object | `{"enabled":true,"image":{"digest":"","pullPolicy":"IfNotPresent","repository":"rancher/kubectl","tag":"v1.35.6"},"imagePullSecrets":[],"resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | CRD upgrade configuration. Enables automatic CRD upgrade during helm install/upgrade operations via a pre-install/pre-upgrade hook Job. |
+| crdUpgrade | object | `{"enabled":true,"image":{"digest":"","pullPolicy":"IfNotPresent","repository":"rancher/kubectl","tag":"v1.35.6"},"imagePullSecrets":[],"podAnnotations":{},"podLabels":{},"resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | CRD upgrade configuration. Enables automatic CRD upgrade during helm install/upgrade operations via a pre-install/pre-upgrade hook Job. |
 | crdUpgrade.image.digest | string | `""` | Image digest for pinning (e.g. sha256:abc...). When set, appended to the image reference. |
 | crdUpgrade.imagePullSecrets | list | `[]` | Image pull secrets for the CRD upgrade Job. Use when crdUpgrade.image.repository points to a private registry that requires authentication. Independent of the evictor imagePullSecrets. |
+| crdUpgrade.podAnnotations | object | `{}` | Additional annotations applied to the CRD upgrade Job pod. |
+| crdUpgrade.podLabels | object | `{}` | Additional labels applied to the CRD upgrade Job pod. These are merged with the global podLabels. Use to match network policies that grant the Job pod access to the Kubernetes API. |
 | crdUpgrade.resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the CRD upgrade Job container. |
 | customConfig | object | `{}` |  |
 | cycleInterval | string | `"1m"` | Specifies the interval between eviction cycles. This property can be used to lower or raise the frequency of the evictor's find-and-drain operations. |

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -99,7 +99,14 @@ spec:
     metadata:
       name: {{ include "evictor.fullname" . }}-crd-upgrade
       labels:
-        {{- include "evictor.labels" . | nindent 8 }}
+        {{- include "evictor.selectorLabels" . | nindent 8 }}
+        {{- with .Values.crdUpgrade.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.crdUpgrade.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "evictor.fullname" . }}-crd-upgrade

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -88,7 +88,8 @@ metadata:
   name: {{ include "evictor.fullname" . }}-crd-upgrade-{{ .Release.Revision }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "evictor.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "evictor.fullname" . }}-crd-upgrade
+    app.kubernetes.io/instance: {{ include "evictor.fullname" . }}-crd-upgrade
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
@@ -100,7 +101,8 @@ spec:
     metadata:
       name: {{ include "evictor.fullname" . }}-crd-upgrade
       labels:
-        {{- include "evictor.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "evictor.fullname" . }}-crd-upgrade
+        app.kubernetes.io/instance: {{ include "evictor.fullname" . }}-crd-upgrade
         {{- with .Values.crdUpgrade.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -93,6 +93,7 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- include "evictor.annotations" . | nindent 4 }}
 spec:
   backoffLimit: 3
   template:

--- a/charts/castai-evictor/templates/crd-upgrade-job.yaml
+++ b/charts/castai-evictor/templates/crd-upgrade-job.yaml
@@ -113,13 +113,20 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "evictor.fullname" . }}-crd-upgrade
+      {{- if .Values.crdUpgrade.securityContext }}
+      {{- $isOpenShift := .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+      {{- $useRestrictedProfile := and $isOpenShift (.Values.openshift.scc.useRestrictedProfile | default false) }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        {{- if $useRestrictedProfile }}
+        runAsNonRoot: {{ .Values.crdUpgrade.securityContext.runAsNonRoot | default true }}
+        {{- with .Values.crdUpgrade.securityContext.seccompProfile }}
         seccompProfile:
-          type: RuntimeDefault
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- else }}
+        {{- toYaml .Values.crdUpgrade.securityContext | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.crdUpgrade.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -136,8 +143,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      containers:
-      - name: crd-upgrade
+      initContainers:
+      - name: apply-crd
         image: {{ .Values.crdUpgrade.image.repository }}:{{ .Values.crdUpgrade.image.tag }}{{ with .Values.crdUpgrade.image.digest }}@{{ . }}{{ end }}
         imagePullPolicy: {{ .Values.crdUpgrade.image.pullPolicy }}
         command:
@@ -147,7 +154,7 @@ spec:
         - --server-side
         - --force-conflicts
         - -f
-        - /crds/
+        - /crds/crds.yaml
         volumeMounts:
         - name: crds
           mountPath: /crds
@@ -156,16 +163,52 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.crdUpgrade.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          runAsUser: 1000
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      - name: wait-crd
+        image: {{ .Values.crdUpgrade.image.repository }}:{{ .Values.crdUpgrade.image.tag }}{{ with .Values.crdUpgrade.image.digest }}@{{ . }}{{ end }}
+        imagePullPolicy: {{ .Values.crdUpgrade.image.pullPolicy }}
+        command:
+        - /bin/kubectl
+        args:
+        - wait
+        - --for=condition=Established
+        - crd/evictorconfigs.autoscaling.cast.ai
+        - --timeout=60s
+        {{- with .Values.crdUpgrade.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.crdUpgrade.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      containers:
+      - name: apply-cr
+        image: {{ .Values.crdUpgrade.image.repository }}:{{ .Values.crdUpgrade.image.tag }}{{ with .Values.crdUpgrade.image.digest }}@{{ . }}{{ end }}
+        imagePullPolicy: {{ .Values.crdUpgrade.image.pullPolicy }}
+        command:
+        - /bin/kubectl
+        args:
+        - apply
+        - --server-side
+        - --force-conflicts
+        - -f
+        - /crds/evictorconfig.yaml
+        volumeMounts:
+        - name: crds
+          mountPath: /crds
+          readOnly: true
+        {{- with .Values.crdUpgrade.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.crdUpgrade.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: crds
         configMap:

--- a/charts/castai-evictor/templates/openshift-scc.yaml
+++ b/charts/castai-evictor/templates/openshift-scc.yaml
@@ -14,10 +14,13 @@ metadata:
   name: {{ include "evictor.sccName" . }}
   labels:
     {{- include "evictor.labels" . | nindent 4 }}
-# Explicitly scope this SCC to only the CAST AI service account.
+# Explicitly scope this SCC to only the CAST AI service accounts.
 # This prevents the SCC from being inadvertently applied to other workloads.
 users:
   - system:serviceaccount:{{ .Release.Namespace }}:{{ include "evictor.serviceAccountName" . }}
+{{- if .Values.crdUpgrade.enabled }}
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "evictor.fullname" . }}-crd-upgrade
+{{- end }}
 groups: []
 allowHostDirVolumePlugin: false
 allowHostIPC: false

--- a/charts/castai-evictor/tests/crd-upgrade-job_test.yaml
+++ b/charts/castai-evictor/tests/crd-upgrade-job_test.yaml
@@ -1,0 +1,154 @@
+suite: CRD upgrade Job rendering
+templates:
+  - crd-upgrade-job.yaml
+  - evictorconfig.yaml
+capabilities:
+  apiVersions:
+    - autoscaling.cast.ai/v1alpha1/EvictorConfig
+
+tests:
+  # ── Rendering gate ──────────────────────────────────────────────────────────
+
+  - it: does not render when crdUpgrade is disabled
+    set:
+      crdUpgrade:
+        enabled: false
+    template: crd-upgrade-job.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ── Pod security context (default) ──────────────────────────────────────────
+
+  - it: renders full pod security context by default
+    set:
+      crdUpgrade:
+        enabled: true
+    template: crd-upgrade-job.yaml
+    documentIndex: 4
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  # ── Pod security context (OpenShift restricted profile) ─────────────────────
+
+  - it: strips UID fields on OpenShift with restricted profile
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+        - autoscaling.cast.ai/v1alpha1/EvictorConfig
+    set:
+      crdUpgrade:
+        enabled: true
+      openshift:
+        scc:
+          useRestrictedProfile: true
+    template: crd-upgrade-job.yaml
+    documentIndex: 4
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - notExists:
+          path: spec.template.spec.securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.securityContext.runAsGroup
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+
+  - it: keeps UID fields on OpenShift without restricted profile
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1
+        - autoscaling.cast.ai/v1alpha1/EvictorConfig
+    set:
+      crdUpgrade:
+        enabled: true
+    template: crd-upgrade-job.yaml
+    documentIndex: 4
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
+  # ── Container security context ─────────────────────────────────────────────
+
+  - it: applies container security context without seccompProfile (inherited from pod)
+    set:
+      crdUpgrade:
+        enabled: true
+    template: crd-upgrade-job.yaml
+    documentIndex: 4
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext.seccompProfile
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile
+
+  # ── Overridable security context ────────────────────────────────────────────
+
+  - it: reflects overridden crdUpgrade.securityContext values
+    set:
+      crdUpgrade:
+        enabled: true
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          fsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
+        containerSecurityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 2000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+    template: crd-upgrade-job.yaml
+    documentIndex: 4
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 2000

--- a/charts/castai-evictor/tests/evictorconfig_test.yaml
+++ b/charts/castai-evictor/tests/evictorconfig_test.yaml
@@ -8,48 +8,37 @@ capabilities:
 tests:
   # ── Rendering paths ─────────────────────────────────────────────────────────
 
-  - it: does not render when crdUpgrade is disabled and CRD does not exist
+  - it: does not render standalone CR when crdUpgrade is enabled (default)
+    set:
+      crdUpgrade:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders as post-install hook when crdUpgrade is disabled
     capabilities:
       apiVersions:
     set:
       crdUpgrade:
         enabled: false
     asserts:
-      - hasDocuments:
-          count: 0
-
-  - it: renders as regular resource when CRD exists (no hook annotations)
-    asserts:
-      - isNull:
-          path: metadata.annotations
-
-  - it: renders as post-install hook when crdUpgrade enabled and CRD does not exist
-    capabilities:
-      apiVersions:
-    set:
-      crdUpgrade:
-        enabled: true
-    asserts:
       - equal:
           path: metadata.annotations["helm.sh/hook"]
           value: post-install,post-upgrade
       - equal:
           path: metadata.annotations["helm.sh/hook-weight"]
-          value: "10"
+          value: "0"
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation
-      - exists:
-          path: metadata.annotations["meta.helm.sh/release-name"]
-      - exists:
-          path: metadata.annotations["meta.helm.sh/release-namespace"]
 
   - it: hook path renders same spec as regular path
     capabilities:
       apiVersions:
     set:
       crdUpgrade:
-        enabled: true
+        enabled: false
     asserts:
       - equal:
           path: apiVersion
@@ -73,6 +62,9 @@ tests:
   # ── Metadata ────────────────────────────────────────────────────────────────
 
   - it: has correct apiVersion and kind
+    set:
+      crdUpgrade:
+        enabled: false
     asserts:
       - equal:
           path: apiVersion
@@ -82,6 +74,9 @@ tests:
           value: EvictorConfig
 
   - it: name is always evictor-config (singleton)
+    set:
+      crdUpgrade:
+        enabled: false
     asserts:
       - equal:
           path: metadata.name
@@ -90,6 +85,9 @@ tests:
   # ── managementMode ───────────────────────────────────────────────────────────
 
   - it: managementMode is castai when managedByCASTAI is true (default)
+    set:
+      crdUpgrade:
+        enabled: false
     asserts:
       - equal:
           path: spec.managementMode
@@ -97,6 +95,8 @@ tests:
 
   - it: managementMode is self-managed when managedByCASTAI is false
     set:
+      crdUpgrade:
+        enabled: false
       managedByCASTAI: false
     asserts:
       - equal:
@@ -106,6 +106,9 @@ tests:
   # ── enabled ──────────────────────────────────────────────────────────────────
 
   - it: enabled is true by default
+    set:
+      crdUpgrade:
+        enabled: false
     asserts:
       - equal:
           path: spec.enabled
@@ -114,6 +117,9 @@ tests:
   # ── config: basic fields ─────────────────────────────────────────────────────
 
   - it: renders default config values
+    set:
+      crdUpgrade:
+        enabled: false
     asserts:
       - equal:
           path: spec.config.dryRun
@@ -178,6 +184,8 @@ tests:
 
   - it: reflects overridden config values
     set:
+      crdUpgrade:
+        enabled: false
       dryRun: true
       aggressiveMode: true
       scopedMode: true
@@ -215,6 +223,8 @@ tests:
 
   - it: reflects overridden CR-pending config values
     set:
+      crdUpgrade:
+        enabled: false
       evictorEnabled: false
       drainTimeout: 15m
       drainRollbackTimeout: 5m
@@ -273,6 +283,9 @@ tests:
   # ── forceDisable: inverted from *.enabled ────────────────────────────────────
 
   - it: forceDisable fields are false when all legacy enabled flags are true (default)
+    set:
+      crdUpgrade:
+        enabled: false
     asserts:
       - equal:
           path: spec.config.forceDisableLiveMigration
@@ -285,6 +298,9 @@ tests:
           value: false
 
   - it: forceDisableKarpenterMode is true by default
+    set:
+      crdUpgrade:
+        enabled: false
     asserts:
       - equal:
           path: spec.config.forceDisableKarpenterMode
@@ -292,6 +308,8 @@ tests:
 
   - it: forceDisable is true when enabled is set to false
     set:
+      crdUpgrade:
+        enabled: false
       liveMigration:
         enabled: false
       woop:
@@ -314,12 +332,17 @@ tests:
           value: false
 
   - it: omits evictionRules when customConfig is empty map (default)
+    set:
+      crdUpgrade:
+        enabled: false
     asserts:
       - notExists:
-          path: spec.evictionRules
+          path: spec.config.evictionRules
 
   - it: omits evictionRules when customConfig is a legacy string
     set:
+      crdUpgrade:
+        enabled: false
       customConfig: |
         evictionConfig:
           - nodeSelector:
@@ -331,10 +354,12 @@ tests:
                 enabled: true
     asserts:
       - notExists:
-          path: spec.evictionRules
+          path: spec.config.evictionRules
 
   - it: renders evictionRules from structured slice with flattened settings
     set:
+      crdUpgrade:
+        enabled: false
       customConfig:
         - nodeSelector:
             labelSelector:
@@ -345,17 +370,19 @@ tests:
               enabled: true
     asserts:
       - lengthEqual:
-          path: spec.evictionRules
+          path: spec.config.evictionRules
           count: 1
       - matchRegex:
-          path: spec.evictionRules[0].nodeSelector.labelSelector.matchLabels.app
+          path: spec.config.evictionRules[0].nodeSelector.labelSelector.matchLabels.app
           pattern: "^test$"
       - equal:
-          path: spec.evictionRules[0].settings.removalDisabled
+          path: spec.config.evictionRules[0].settings.removalDisabled
           value: true
 
   - it: renders evictionRules from map with evictionRules key with flattened settings
     set:
+      crdUpgrade:
+        enabled: false
       customConfig:
         evictionRules:
           - nodeSelector:
@@ -367,11 +394,11 @@ tests:
                 enabled: true
     asserts:
       - lengthEqual:
-          path: spec.evictionRules
+          path: spec.config.evictionRules
           count: 1
       - matchRegex:
-          path: spec.evictionRules[0].nodeSelector.labelSelector.matchLabels.app
+          path: spec.config.evictionRules[0].nodeSelector.labelSelector.matchLabels.app
           pattern: "^test$"
       - equal:
-          path: spec.evictionRules[0].settings.removalDisabled
+          path: spec.config.evictionRules[0].settings.removalDisabled
           value: true

--- a/charts/castai-evictor/tests/openshift-scc_test.yaml
+++ b/charts/castai-evictor/tests/openshift-scc_test.yaml
@@ -1,0 +1,193 @@
+suite: OpenShift SCC rendering
+templates:
+  - openshift-scc.yaml
+capabilities:
+  apiVersions:
+    - security.openshift.io/v1
+
+tests:
+  # ── Rendering gates ─────────────────────────────────────────────────────────
+
+  - it: does not render when not on OpenShift
+    capabilities:
+      apiVersions:
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders 3 documents
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: document 0 is the SCC
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: kind
+          value: SecurityContextConstraints
+
+  - it: document 1 is the ClusterRole
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: kind
+          value: ClusterRole
+
+  - it: document 2 is the ClusterRoleBinding
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: kind
+          value: ClusterRoleBinding
+
+  # ── SCC users ───────────────────────────────────────────────────────────────
+
+  - it: includes only the evictor SA when crdUpgrade is disabled
+    set:
+      crdUpgrade:
+        enabled: false
+    documentIndex: 0
+    asserts:
+      - lengthEqual:
+          path: users
+          count: 1
+      - equal:
+          path: users[0]
+          value: system:serviceaccount:NAMESPACE:castai-evictor
+
+  - it: includes both evictor and crd-upgrade SAs when crdUpgrade is enabled
+    set:
+      crdUpgrade:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - lengthEqual:
+          path: users
+          count: 2
+      - equal:
+          path: users[0]
+          value: system:serviceaccount:NAMESPACE:castai-evictor
+      - equal:
+          path: users[1]
+          value: system:serviceaccount:NAMESPACE:castai-evictor-crd-upgrade
+
+  # ── Default profile (useRestrictedProfile=false) ────────────────────────────
+
+  - it: uses MustRunAs for runAsUser by default
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: runAsUser.type
+          value: MustRunAs
+      - equal:
+          path: runAsUser.uid
+          value: 1004
+
+  - it: uses MustRunAs for fsGroup by default
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: fsGroup.type
+          value: MustRunAs
+      - equal:
+          path: fsGroup.ranges[0].min
+          value: 1004
+      - equal:
+          path: fsGroup.ranges[0].max
+          value: 1004
+
+  - it: enforces readOnlyRootFilesystem by default
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: readOnlyRootFilesystem
+          value: true
+
+  - it: lists runtime/default as the allowed seccomp profile
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: seccompProfiles
+          value:
+            - runtime/default
+
+  # ── Restricted profile (useRestrictedProfile=true) ──────────────────────────
+
+  - it: uses MustRunAsRange for runAsUser when restricted profile is enabled
+    set:
+      openshift:
+        scc:
+          useRestrictedProfile: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: runAsUser.type
+          value: MustRunAsRange
+      - notExists:
+          path: runAsUser.uid
+
+  - it: uses RunAsAny for fsGroup when restricted profile is enabled
+    set:
+      openshift:
+        scc:
+          useRestrictedProfile: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: fsGroup.type
+          value: RunAsAny
+      - notExists:
+          path: fsGroup.ranges
+
+  - it: uses RunAsAny for supplementalGroups when restricted profile is enabled
+    set:
+      openshift:
+        scc:
+          useRestrictedProfile: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: supplementalGroups.type
+          value: RunAsAny
+
+  - it: omits readOnlyRootFilesystem when restricted profile is enabled
+    set:
+      openshift:
+        scc:
+          useRestrictedProfile: true
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: readOnlyRootFilesystem
+
+  # ── ClusterRole / ClusterRoleBinding ───────────────────────────────────────
+
+  - it: ClusterRole grants use of the SCC resource
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: rules[0].apiGroups[0]
+          value: security.openshift.io
+      - equal:
+          path: rules[0].resources[0]
+          value: securitycontextconstraints
+      - equal:
+          path: rules[0].verbs[0]
+          value: use
+      - equal:
+          path: rules[0].resourceNames[0]
+          value: castai-evictor-scc
+
+  - it: ClusterRoleBinding references the evictor SA
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: castai-evictor
+      - equal:
+          path: roleRef.name
+          value: castai-evictor-scc-user

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -332,7 +332,24 @@ crdUpgrade:
   podLabels: {}
   # crdUpgrade.podAnnotations -- Additional annotations applied to the CRD upgrade Job pod.
   podAnnotations: {}
-  # crdUpgrade.resources -- Resource requests/limits for the CRD upgrade Job container.
+  # crdUpgrade.securityContext -- Pod security context. On OpenShift with useRestrictedProfile, UID fields are stripped automatically.
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  # crdUpgrade.containerSecurityContext -- Container security context (applied to all init + main containers). seccompProfile inherited from pod-level.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+  # crdUpgrade.resources -- Resources for all containers (init + main) in the Job.
   resources:
     requests:
       cpu: 100m

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -329,8 +329,6 @@ crdUpgrade:
   # points to a private registry that requires authentication. Independent of the evictor imagePullSecrets.
   imagePullSecrets: []
   # crdUpgrade.podLabels -- Additional labels applied to the CRD upgrade Job pod.
-  # These are merged with the global podLabels. Use to match network policies
-  # that grant the Job pod access to the Kubernetes API.
   podLabels: {}
   # crdUpgrade.podAnnotations -- Additional annotations applied to the CRD upgrade Job pod.
   podAnnotations: {}

--- a/charts/castai-evictor/values.yaml
+++ b/charts/castai-evictor/values.yaml
@@ -328,6 +328,12 @@ crdUpgrade:
   # crdUpgrade.imagePullSecrets -- Image pull secrets for the CRD upgrade Job. Use when crdUpgrade.image.repository
   # points to a private registry that requires authentication. Independent of the evictor imagePullSecrets.
   imagePullSecrets: []
+  # crdUpgrade.podLabels -- Additional labels applied to the CRD upgrade Job pod.
+  # These are merged with the global podLabels. Use to match network policies
+  # that grant the Job pod access to the Kubernetes API.
+  podLabels: {}
+  # crdUpgrade.podAnnotations -- Additional annotations applied to the CRD upgrade Job pod.
+  podAnnotations: {}
   # crdUpgrade.resources -- Resource requests/limits for the CRD upgrade Job container.
   resources:
     requests:


### PR DESCRIPTION
1. Split the CRD and CR creation into initcontainers (single job while ensuring the proper sequence).
2. Add security context for crdUpgrade and OpenshiftSCC handling based on the Evictor deployment.