### PR TITLE
[gpu-metrics-exporter] Support setting tolerations to migration job

### DIFF
--- a/charts/gpu-metrics-exporter/Chart.yaml
+++ b/charts/gpu-metrics-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gpu-metrics-exporter
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.29
-appVersion: "0.1.29"
+version: 0.1.30
+appVersion: "0.1.30"

--- a/charts/gpu-metrics-exporter/templates/move-api-key-to-secret.yaml
+++ b/charts/gpu-metrics-exporter/templates/move-api-key-to-secret.yaml
@@ -11,6 +11,10 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "gpu-metrics-exporter.serviceAccountName" . }}
+      {{- with .Values.migrate.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: migrate
           image: "{{.Values.migrate.image.repository}}:{{.Values.migrate.image.tag}}"

--- a/charts/gpu-metrics-exporter/values.yaml
+++ b/charts/gpu-metrics-exporter/values.yaml
@@ -95,7 +95,14 @@ migrate:
     repository: alpine/k8s
     pullPolicy: IfNotPresent
     tag: 1.31.0
-    
+  tolerations:
+    - effect: "NoExecute"
+      operator: "Exists"
+    - effect: "NoSchedule"
+      operator: "Exists"
+    - effect: "PreferNoSchedule"
+      operator: "Exists"
+
 # updateStrategy -- Controls `daemonset.spec.updateStrategy` field.
 # updateStrategy:
 #   type: RollingUpdate


### PR DESCRIPTION
- Adds the ability to set tolerations for the migration job
- For clusters which have tolerations required to run in any node pool, the migration job can never run.