### PR TITLE
fix(ci): pin chart-testing-action to post-v2.8.0 SHA, standardize action versions

### DIFF
--- a/.github/workflows/bump-cluster-agent-image.yml
+++ b/.github/workflows/bump-cluster-agent-image.yml
@@ -72,11 +72,11 @@ jobs:
 
       - name: Install yq
         if: steps.check.outputs.skip != 'true'
-        uses: mikefarah/yq@v4.44.3
+        uses: mikefarah/yq@v4.52.4
 
       - name: Checkout helm-charts to read appVersion
         if: steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Check out the exact release commit, not main, so appVersion
           # matches what was actually released.

--- a/.github/workflows/e2e-umbrella.yaml
+++ b/.github/workflows/e2e-umbrella.yaml
@@ -39,7 +39,7 @@ jobs:
           version: v3.17.0
 
       - name: Install kind
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@v1.14.0
         with:
           install_only: true
 

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -24,7 +24,7 @@ jobs:
           python-version: '3.12'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@d6db0ca01d3598ea552ccf97edb5de6fe6b54ce0 # main, post-v2.8.0 (cosign-installer v4.1.1)
 
       - name: Scan repo with kube-linter
         uses: stackrox/kube-linter-action@v1.0.7

--- a/.github/workflows/release-umbrella-rc.yml
+++ b/.github/workflows/release-umbrella-rc.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install yq
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
-        uses: mikefarah/yq@v4.44.3
+        uses: mikefarah/yq@v4.52.4
 
       - name: Install Helm
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
@@ -118,7 +118,7 @@ jobs:
 
       - name: Checkout helm-charts at release tag
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag_name }}
           # fetch-depth: 0 — drift check needs full tag history to diff
@@ -128,7 +128,7 @@ jobs:
 
       - name: Checkout helm-charts at HEAD (for scripts)
         if: steps.parse.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
           version: v3.17.0
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@d6db0ca01d3598ea552ccf97edb5de6fe6b54ce0 # main, post-v2.8.0 (cosign-installer v4.1.1; v2.8.0 bundles cosign-installer v4.0.0 whose pinned public-key digest no longer validates cosign v3.0.2)
 
       # Only the main charts dir needs umbrella deps; child-chart jobs can skip this.
       - name: Update umbrella subchart dependencies

--- a/.github/workflows/update-umbrella-on-child-release.yaml
+++ b/.github/workflows/update-umbrella-on-child-release.yaml
@@ -79,7 +79,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install yq
-        uses: mikefarah/yq@v4.44.3
+        uses: mikefarah/yq@v4.52.4
 
       - name: Update umbrella subchart dependencies and bump version
         id: update

--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -38,7 +38,7 @@ jobs:
           python-version: '3.12'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@d6db0ca01d3598ea552ccf97edb5de6fe6b54ce0 # main, post-v2.8.0 (cosign-installer v4.1.1)
 
       - name: Validate PR
         run: scripts/validate-pr.sh


### PR DESCRIPTION
## Problem

The `release (charts/castai-pod-pinner/child-charts)` job has been failing with exit code 35:

```
ERROR: Unable to validate cosign version: 'v3.0.2'
ERROR: Fetched public key does not match expected digest, exiting
##[error]Process completed with exit code 35.
```

## Root cause

`helm/chart-testing-action@v2.8.0` internally pins `sigstore/cosign-installer@faadad0` (= cosign-installer **v4.0.0`), which can no longer validate cosign v3.0.2 — its baked-in public-key digest no longer matches. cosign-installer fixed this in **v4.1.0+**, and chart-testing-action's `main` branch already pins `cosign-installer@v4.1.1` (`cad07c2`), but no new tagged release has been cut since v2.8.0.

The `pod-pinner` job failed first only because it reached the cosign step fastest (no umbrella-deps step); the other two matrix jobs were cancelled.

## Fix

**1. Pin chart-testing-action to post-v2.8.0 main SHA** (`d6db0ca`) in all 3 workflows that use it:
- `release.yaml`
- `lint-test.yaml`
- `validate-pr.yaml`

This pulls in cosign-installer v4.1.1, which ships cosign v3.0.5 and resolves the digest validation failure.

**2. Standardize action versions** across all workflows to the latest versions already in use in the repo:
- `actions/checkout`: `v4` → `v6`
- `mikefarah/yq`: `v4.44.3` → `v4.52.4`
- `helm/kind-action`: `v1.12.0` → `v1.14.0`

## Files changed

| File | Change |
|---|---|
| `release.yaml` | chart-testing-action SHA pin |
| `lint-test.yaml` | chart-testing-action SHA pin |
| `validate-pr.yaml` | chart-testing-action SHA pin |
| `bump-cluster-agent-image.yml` | yq v4.52.4, checkout v6 |
| `release-umbrella-rc.yml` | yq v4.52.4, checkout v6 (×2) |
| `update-umbrella-on-child-release.yaml` | yq v4.52.4 |
| `e2e-umbrella.yaml` | kind-action v1.14.0 |

## Known follow-up (not in this PR)

The `release.yaml` matrix still references two deleted chart directories: `charts/castai-pod-pinner/child-charts` (removed in #1387) and `charts/castai-cluster-controller/child-charts` (removed in #1467). These are dead matrix entries that should be cleaned up separately.