### PR TITLE
[egressd] add annotations values for the collector DaemonSet and exporter Deployment

### DIFF
--- a/charts/egressd/Chart.yaml
+++ b/charts/egressd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: egressd
 description: Kubernetes aware network traffic monitoring
 type: application
-version: 0.1.43
+version: 0.1.44
 appVersion: "v0.14.2"

--- a/charts/egressd/templates/collector/daemonSet.yaml
+++ b/charts/egressd/templates/collector/daemonSet.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "egressd.labels" . | nindent 4 }}
+  {{- with .Values.collector.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/egressd/templates/exporter/deployment.yaml
+++ b/charts/egressd/templates/exporter/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "egressd.exporter.labels" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
+  {{- with .Values.exporter.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/egressd/values.yaml
+++ b/charts/egressd/values.yaml
@@ -46,6 +46,10 @@ collector:
   ## The name of the PriorityClass for collector pods
   # priorityClassName: "system-node-critical"
 
+  ## Annotations to be added to the collector DaemonSet object itself
+  ##
+  annotations: {}
+
   ## Annotations to be added to collector pod
   ##
   podAnnotations: {}
@@ -158,6 +162,10 @@ exporter:
 
   ## The name of the PriorityClass for exporter pods
   # priorityClassName: "system-cluster-critical"
+
+  ## Annotations to be added to the exporter Deployment object itself
+  ##
+  annotations: {}
 
   ## Annotations to be added to exporter pod
   ##


### PR DESCRIPTION
## What

The chart exposes `collector.podAnnotations` and `exporter.podAnnotations`, which
render at `spec.template.metadata` and annotate the **pods**. Neither workload
object's own metadata can be annotated — the collector DaemonSet and the exporter
Deployment take only `name`, `namespace` and `labels`.

Object annotations are how IaC tooling and GitOps controllers attach behaviour to
a resource — reconciliation hints, sync options, wait/skip directives. In our
case a Pulumi deployment needs `pulumi.com/skipAwait` on the collector DaemonSet
and currently has to post-process the rendered manifest to get it.

## How

Adds `collector.annotations` and `exporter.annotations`, guarded with
`{{- with }}` and defaulting to `{}`. Both `podAnnotations` values are untouched
and keep annotating the pods.

Chart `version` 0.1.43 → 0.1.44, following the precedent of #621. Your release
tooling also writes this file, so happy to adjust to whatever it expects.


## Rendered behaviour

| values | result |
|---|---|
| both keys unset (default) | **byte-identical** to the unmodified chart — 356 lines, 10 documents |
| both keys set | exactly 4 lines — the two workload objects' `metadata.annotations` |

```
$ diff before.yaml after.yaml     # keys unset
$ diff after.yaml set.yaml
162a163,164
>   annotations:
>     pulumi.com/skipAwait: "true"
276a279,280
>   annotations:
>     pulumi.com/skipAwait: "true"
```

`helm lint` passes.
