### PR TITLE
[castai-db-proxy] Fix selector overlap between proxy and pooler pods

### DIFF
--- a/charts/castai-db-proxy/Chart.yaml
+++ b/charts/castai-db-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: castai-db-proxy
 description: CAST AI database proxy cache deployment.
 type: application
-version: 0.14.0
+version: 0.14.1

--- a/charts/castai-db-proxy/README.md
+++ b/charts/castai-db-proxy/README.md
@@ -1,6 +1,6 @@
 # castai-db-proxy
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 CAST AI database proxy cache deployment.
 
@@ -8,7 +8,7 @@ CAST AI database proxy cache deployment.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"provisioner.cast.ai/managed-by","operator":"In","values":["cast.ai"]}]},"weight":100}],"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"NotIn","values":["windows"]},{"key":"kubernetes.io/arch","operator":"In","values":["amd64","arm64"]}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["APP_NAME"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Pod affinity rules. |
+| affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"provisioner.cast.ai/managed-by","operator":"In","values":["cast.ai"]}]},"weight":100}],"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"NotIn","values":["windows"]},{"key":"kubernetes.io/arch","operator":"In","values":["amd64","arm64"]}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["APP_NAME"]},{"key":"app.kubernetes.io/component","operator":"In","values":["proxy"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Pod affinity rules. |
 | apiKey | string | `""` | Token to be used for authorizing access to the CAST AI API. |
 | apiKeySecretRef | string | `""` | Name of secret with Token to be used for authorizing access to the API. apiKey and apiKeySecretRef are mutually exclusive. The referenced secret must provide the token in .data["API_KEY"]. |
 | apiURL | string | `"api-grpc.cast.ai"` | URL to the CAST AI gRPC API server. |

--- a/charts/castai-db-proxy/templates/_helpers.tpl
+++ b/charts/castai-db-proxy/templates/_helpers.tpl
@@ -56,6 +56,11 @@ Selector labels
 app.kubernetes.io/name: {{ include "castai-db-proxy.name" . }}
 {{- end }}
 
+{{- define "castai-db-proxy.proxySelectorLabels" -}}
+app.kubernetes.io/name: {{ include "castai-db-proxy.name" . }}
+app.kubernetes.io/component: proxy
+{{- end }}
+
 {{- define "castai-db-proxy.poolingSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "castai-db-proxy.name" . }}
 app.kubernetes.io/component: pooling

--- a/charts/castai-db-proxy/templates/_versions.tpl
+++ b/charts/castai-db-proxy/templates/_versions.tpl
@@ -1,3 +1,3 @@
-{{- define "castai-db-proxy.defaultProxyVersion" -}}v0.14.0{{- end -}}
+{{- define "castai-db-proxy.defaultProxyVersion" -}}v0.14.1{{- end -}}
 {{- define "castai-db-proxy.defaultPoolingConfigManagerVersion" -}}v0.3.0{{- end -}}
 {{- define "castai-db-proxy.defaultPgdogVersion" -}}v0.1.51{{- end -}}

--- a/charts/castai-db-proxy/templates/deployment.yaml
+++ b/charts/castai-db-proxy/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "castai-db-proxy.selectorLabels" . | nindent 8 }}
+        {{- include "castai-db-proxy.proxySelectorLabels" . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/castai-db-proxy/templates/headless-service.yaml
+++ b/charts/castai-db-proxy/templates/headless-service.yaml
@@ -14,4 +14,4 @@ spec:
       targetPort: cluster
       protocol: TCP
   selector:
-    {{- include "castai-db-proxy.selectorLabels" . | nindent 4 }}
+    {{- include "castai-db-proxy.proxySelectorLabels" . | nindent 4 }}

--- a/charts/castai-db-proxy/templates/pdb.yaml
+++ b/charts/castai-db-proxy/templates/pdb.yaml
@@ -10,4 +10,4 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      {{- include "castai-db-proxy.selectorLabels" . | nindent 6 }}
+      {{- include "castai-db-proxy.proxySelectorLabels" . | nindent 6 }}

--- a/charts/castai-db-proxy/templates/service.yaml
+++ b/charts/castai-db-proxy/templates/service.yaml
@@ -24,4 +24,4 @@ spec:
       targetPort: metrics
       protocol: TCP
   selector:
-    {{- include "castai-db-proxy.selectorLabels" . | nindent 4 }}
+    {{- include "castai-db-proxy.proxySelectorLabels" . | nindent 4 }}

--- a/charts/castai-db-proxy/values.yaml
+++ b/charts/castai-db-proxy/values.yaml
@@ -114,6 +114,10 @@ affinity:
               operator: In
               values:
                 - APP_NAME
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+                - proxy
         topologyKey: kubernetes.io/hostname
 
   nodeAffinity:


### PR DESCRIPTION
### Summary
This PR fixes the `castai-db-proxy` chart so that the headless service (used for cluster peer discovery), client-facing service, PDB, and pod anti-affinity specs match only proxy pods — not pooler pods. Previously, all selectors matched only `app.kubernetes.io/name`, which was shared by both proxy and pooler pods. This caused `roxy-cluster` to resolve pooler pod IPs via DNS and continuously attempt TCP connects to port 9050 (which poolers don't expose), producing a reconnect storm and causing RPC channel saturation and throughput collapse under load (`no available capacity`) 

### Key Changes
- Added `proxySelectorLabels` helper (`name` + `component: proxy`) as the counterpart to the existing `poolingSelectorLabels`.
- Kept `selectorLabels` (just `name`) unchanged for the Deployment `spec.selector` — this field is immutable, so narrowing it would break `helm upgrade` on existing releases.
- Narrowed pod anti-affinity to match `component: proxy` so it only prevents proxy-to-proxy co-location, not proxy-to-pooler (which could cause scheduling failures on smaller clusters).
- Bumped chart version to `0.14.1`.

### Compatibility
The Deployment selector is left untouched, so existing releases can upgrade in-place. The rolling update adds `component: proxy` to new Pods, and Services immediately narrow to only those Pods.